### PR TITLE
Brazilian translations with proper locale code.

### DIFF
--- a/TMessagesProj/src/main/res/values-pt-rBR/strings.xml
+++ b/TMessagesProj/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,353 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- -->
+
+<resources>
+    <string name="AppName">Telegram</string>
+
+    <!--signin view-->
+    <string name="YourPhone">Seu telefone</string>
+    <string name="StartText">Por favor confirme o código de seu país\ne digite o seu número.</string>
+    <string name="ChooseCountry">Escolha um país</string>
+    <string name="WrongCountry">Código de país errado</string>
+
+    <!--code enter view-->
+    <string name="YourCode">Seu código</string>
+    <string name="SentSmsCode">Enviamos um SMS com um código de ativação para seu telefone</string>
+    <string name="CallText">Ligaremos para você em</string>
+    <string name="Calling">Ligando para você...</string>
+    <string name="Code">Código</string>
+    <string name="WrongNumber">Número errado?</string>
+
+    <!--signup view-->
+    <string name="YourName">Seu nome</string>
+    <string name="RegisterText">Registre seu nome e sobrenome</string>
+    <!--<string name="RegisterText">Registre seu nome e foto de perfil</string>-->
+    <string name="FirstName">Nome (obrigatório)</string>
+    <string name="LastName">Sobrenome (opcional)</string>
+    <string name="CancelRegistration">Cancelar registro</string>
+
+    <!--chats view-->
+    <string name="Chats">Conversas</string>
+    <string name="Search">Buscar</string>
+    <string name="NewMessages">Novas mensagens</string>
+    <string name="Settings">Configurações</string>
+    <string name="Contacts">Contatos</string>
+    <string name="NewGroup">Novo grupo</string>
+    <string name="Yesterday">ontem</string>
+    <string name="NoResult">Sem resultados</string>
+    <string name="NoChats">Ainda não há conversas...</string>
+    <string name="NoChatsHelp">Para começar a conversar, pressione o\nbotão Escrever no canto superior direito\nou vá à seção de Contatos.</string>
+    <string name="WaitingForNetwork">Esperando pela rede...</string>
+    <string name="Connecting">Conectando...</string>
+    <string name="Updating">Atualizando...</string>
+    <string name="NewSecretChat">Nova conversa secreta</string>
+    <string name="AwaitingEncryption">Esperando %s ficar disponível...</string>
+    <string name="EncryptionRejected">Conversa secreta cancelada</string>
+    <string name="EncryptionProcessing">Trocando chaves de criptografia...</string>
+    <string name="EncryptedChatStartedOutgoing">%s se juntou à sua conversa secreta.</string>
+    <string name="EncryptedChatStartedIncoming">Você se juntou à conversa secreta.</string>
+    <string name="ClearHistory">Limpar histórico</string>
+    <string name="DeleteChat">Excluir e sair</string>
+    <string name="HiddenName">Nome oculto</string>
+    <string name="SelectChat">Selecione a conversa</string>
+
+    <!--documents view-->
+    <string name="SelectFile">Selecionar arquivo</string>
+    <string name="FreeOfTotal">%1$s disponível de %2$s</string>
+    <string name="UnknownError">Erro desconhecido</string>
+    <string name="AccessError">Erro de acesso</string>
+    <string name="NoFiles">Sem arquivos ainda...</string>
+    <string name="FileUploadLimit">O tamanho do arquivo não pode ser maior do que %1$s</string>
+    <string name="NotMounted">O armazenamento não está montado</string>
+    <string name="UsbActive">Transferência USB ativa</string>
+    <string name="InternalStorage">Armazenamento interno</string>
+    <string name="ExternalStorage">Armazenamento externo</string>
+    <string name="SystemRoot">Raiz do sistema</string>
+    <string name="SdCard">Cartão SD</string>
+
+    <!--chat view-->
+    <string name="Invisible">invisível</string>
+    <string name="Typing">digitando...</string>
+    <string name="Attach">Anexar</string>
+    <string name="IsTyping">está digitando...</string>
+    <string name="AreTyping">estão digitando...</string>
+    <string name="AndMoreTyping">e mais %d pessoa(s)</string>
+    <string name="GotAQuestion">Tem dúvidas sobre\no Telegram?</string>
+    <string name="ChatTakePhoto">Tirar uma foto</string>
+    <string name="ChatGallery">Galeria</string>
+    <string name="ChatLocation">Localização</string>
+    <string name="ChatVideo">Vídeo</string>
+    <string name="ChatDocument">Documento</string>
+    <string name="NoMessages">Sem mensagens aqui...</string>
+    <string name="ViewPhoto">Visualizar foto</string>
+    <string name="ViewLocation">Ver localização</string>
+    <string name="ViewVideo">Reproduzir vídeo</string>
+    <string name="ForwardedMessage">Mensagem encaminhada</string>
+    <string name="From">De</string>
+    <string name="NoRecent">Nada recente</string>
+    <string name="Members">membros</string>
+    <string name="Message">Mensagem</string>
+    <string name="TypeMessage">Digitar uma mensagem</string>
+    <string name="DOWNLOAD">Baixar</string>
+    <string name="Selected">Selecionados:</string>
+    <string name="ShareMyContactInfo">COMPARTILHAR MINHAS INFORMAÇÕES DE CONTATO</string>
+    <string name="AddToContacts">ADICIONAR AOS CONTATOS</string>
+    <string name="EncryptedPlaceholderTitleIncoming">%s convidou você para se juntar a uma conversa secreta.</string>
+    <string name="EncryptedPlaceholderTitleOutgoing">Você convidou %s para se juntar a uma conversa secreta.</string>
+    <string name="EncryptedDescriptionTitle">Conversas secretas:</string>
+    <string name="EncryptedDescription1">Use criptografia fim-a-fim</string>
+    <string name="EncryptedDescription2">Não deixe rastros nos nossos servidores</string>
+    <string name="EncryptedDescription3">Tenha um temporizador para autodestruição</string>
+    <string name="EncryptedDescription4">Não permita encaminhamento de mensagens</string>
+    <string name="OneNewMessage">%1$d nova mensagem</string>
+    <string name="FewNewMessages">%1$d novas mensagens</string>
+    <string name="YouWereKicked">Você foi expulso deste grupo</string>
+    <string name="YouLeft">Você deixou este grupo</string>
+    <string name="DeleteThisGroup">Excluir este grupo</string>
+
+    <!--notification-->
+    <string name="EncryptedChatRequested">Conversa secreta requisitada</string>
+    <string name="EncryptedChatAccepted">Conversa secreta iniciada</string>
+    <string name="MessageLifetimeChanged">%1$s configurou a autodestruição para daqui a %2$s</string>
+    <string name="MessageLifetimeChangedOutgoing">Você configurou a autodestruição para daqui a %1$s</string>
+    <string name="MessageLifetimeRemoved">%1$s desabilitou a autodestruição</string>
+    <string name="MessageLifetimeYouRemoved">Você desabilitou a autodestruição</string>
+    <string name="MessageLifetime2s">2 segundos</string>
+    <string name="MessageLifetime5s">5 segundos</string>
+    <string name="MessageLifetime1m">1 minuto</string>
+    <string name="MessageLifetime1h">1 hora</string>
+    <string name="MessageLifetime1d">1 dia</string>
+    <string name="MessageLifetime1w">1 semana</string>
+    <string name="YouHaveNewMessage">Você tem uma mensagem nova</string>
+    <string name="NotificationMessageText">%1$s: %2$s</string>
+    <string name="NotificationMessageNoText">%1$s te enviou uma mensagem</string>
+    <string name="NotificationMessagePhoto">%1$s te enviou uma foto</string>
+    <string name="NotificationMessageVideo">%1$s te enviou um vídeo</string>
+    <string name="NotificationMessageContact">%1$s compartilhou um contato com você</string>
+    <string name="NotificationMessageMap">%1$s te enviou um mapa</string>
+    <string name="NotificationMessageDocument">%1$s te enviou um documento</string>
+    <string name="NotificationMessageAudio">%1$s te enviou um áudio</string>
+    <string name="NotificationMessageGroupText">%1$s @ %2$s: %3$s</string>
+    <string name="NotificationMessageGroupNoText">%1$s enviou uma mensagem para o grupo %2$s</string>
+    <string name="NotificationMessageGroupPhoto">%1$s enviou uma foto para o grupo %2$s</string>
+    <string name="NotificationMessageGroupVideo">%1$s enviou um vídeo para o grupo %2$s</string>
+    <string name="NotificationMessageGroupContact">%1$s compartilhou um contato no grupo %2$s</string>
+    <string name="NotificationMessageGroupMap">%1$s enviou um mapa para o grupo %2$s</string>
+    <string name="NotificationMessageGroupDocument">%1$s enviou um documento para o grupo %2$s</string>
+    <string name="NotificationMessageGroupAudio">%1$s enviou um áudio para o grupo %2$s</string>
+    <string name="NotificationInvitedToGroup">%1$s convidou você para o grupo %2$s</string>
+    <string name="NotificationEditedGroupName">%1$s editou o nome do grupo %2$s</string>
+    <string name="NotificationEditedGroupPhoto">%1$s editou a foto do grupo %2$s</string>
+    <string name="NotificationGroupAddMember">%1$s convidou %3$s para o grupo %2$s</string>
+    <string name="NotificationGroupKickMember">%1$s expulsou %3$s do grupo %2$s</string>
+    <string name="NotificationGroupKickYou">%1$s expulsou você do grupo %2$s</string>
+    <string name="NotificationGroupLeftMember">%1$s saiu do grupo %2$s</string>
+    <string name="NotificationContactJoined">%1$s se juntou ao Telegram!</string>
+    <string name="NotificationUnrecognizedDevice">Novo acesso de dispositivo desconhecido %1$s, localização: %2$s</string>
+    <string name="NotificationContactNewPhoto">%1$s atualizou a foto de perfil</string>
+
+    <!--contacts view-->
+    <string name="SelectContact">Selecionar contato</string>
+    <string name="NoContacts">Não há contatos</string>
+    <string name="InviteText">Oi, vamos mudar para o Telegram? http://telegram.org/dl2</string>
+    <string name="TodayAt">hoje à(s)</string>
+    <string name="YesterdayAt">ontem à(s)</string>
+    <string name="OtherAt">à(s)</string>
+    <string name="Online">disponível</string>
+    <string name="Offline">indisponível</string>
+    <string name="LastSeen">último acesso</string>
+    <string name="LastSeenDate">último acesso</string>
+    <string name="InviteFriends">Convidar amigos</string>
+
+    <!--group create view-->
+    <string name="SendMessageTo">Enviar mensagem a...</string>
+    <string name="EnterGroupNamePlaceholder">Digite o nome do grupo</string>
+    <string name="MEMBER">MEMBRO</string>
+    <string name="GroupName">Nome do grupo</string>
+    <string name="MEMBERS">MEMBROS</string>
+    <string name="AllContacts">TODOS OS CONTATOS</string>
+
+    <!--group info view-->
+    <string name="EnterGroupNameTitle">DIGITE O NOME DO GRUPO</string>
+    <string name="SharedMedia">Mídia compartilhada</string>
+    <string name="GroupInfo">Informações do Grupo</string>
+    <string name="SHAREDMEDIA">MÍDIA COMPARTILHADA</string>
+    <string name="SETTINGS">CONFIGURAÇÕES</string>
+    <string name="AddMember">Adicionar membro</string>
+    <string name="DeleteAndExit">Excluir e deixar o grupo</string>
+    <string name="Notifications">Notificações</string>
+    <string name="KickFromGroup">Expulsar do grupo</string>
+
+    <!--contact info view-->
+    <string name="ShareContact">Compartilhar</string>
+    <string name="AddContact">Adicionar</string>
+    <string name="BlockContact">Bloquear</string>
+    <string name="EditContact">Editar</string>
+    <string name="DeleteContact">Excluir</string>
+    <string name="PhoneHome">RESIDENCIAL</string>
+    <string name="PhoneMobile">CELULAR</string>
+    <string name="PhoneWork">TRABALHO</string>
+    <string name="PhoneOther">OUTRO</string>
+    <string name="PhoneMain">PRINCIPAL</string>
+    <string name="ContactInfo">Informações do contato</string>
+    <string name="PHONE">TELEFONE</string>
+    <string name="StartEncryptedChat">Começar conversa secreta</string>
+    <string name="CreateEncryptedChatError">Houve um erro.</string>
+    <string name="CreateEncryptedChatOutdatedError">Não foi possível criar uma conversa secreta com %1$s.\n\n%2$s está usando uma versão antiga do Telegram e precisa atualizar antes.</string>
+    <string name="SecretTitle">Conversa secreta</string>
+    <string name="EncryptionKey">Chave de criptografia</string>
+    <string name="MessageLifetime">Tempo para autodestruição</string>
+    <string name="ShortMessageLifetimeForever">Desligado</string>
+    <string name="ShortMessageLifetime2s">2 segundos</string>
+    <string name="ShortMessageLifetime5s">5 segundos</string>
+    <string name="ShortMessageLifetime1m">1 minuto</string>
+    <string name="ShortMessageLifetime1h">1 hora</string>
+    <string name="ShortMessageLifetime1d">1 dia</string>
+    <string name="ShortMessageLifetime1w">1 semana</string>
+    <string name="EncryptionKeyDescription">Esta imagem é uma visualização da chave de criptografia para a sua conversa secreta com <![CDATA[<b>]]>%1$s<![CDATA[</b>]]>.<![CDATA[<br><br>]]>Se esta imagem aparece da mesma maneira no telefone de <![CDATA[<b>]]>%2$s<![CDATA[</b>]]>, a sua conversa está 200%% segura.<![CDATA[<br><br>]]>Saiba mais em telegram.org</string>
+
+    <!--settings view-->
+    <string name="ResetNotificationsText">Restaurar configurações de notificação</string>
+    <string name="TextSize">Tamanho do texto</string>
+    <string name="AskAQuestion">Fazer uma pergunta</string>
+    <string name="EnableAnimations">Animações</string>
+    <string name="Unblock">Desbloquear</string>
+    <string name="UnblockText">Mantenha pressionado um usuário para desbloqueá-lo.</string>
+    <string name="NoBlocked">Nenhum usuário bloqueado</string>
+    <string name="YourPhoneNumber">SEU NÚMERO</string>
+    <string name="MessageNotifications">NOTIFICAÇÕES DE MENSAGEM</string>
+    <string name="Alert">Alerta</string>
+    <string name="MessagePreview">Prévia de mensagem</string>
+    <string name="GroupNotifications">NOTIFICAÇÕES DE GRUPO</string>
+    <string name="Sound">Som</string>
+    <string name="InAppNotifications">NOTIFICAÇÕES NO APLICATIVO</string>
+    <string name="InAppSounds">Sons do aplicativo</string>
+    <string name="InAppVibrate">Vibração do aplicativo</string>
+    <string name="Vibrate">Vibrar</string>
+    <string name="InAppPreview">Prévia no aplicativo</string>
+    <string name="Reset">RESTAURAR</string>
+    <string name="ResetAllNotifications">Restaurar configurações de notificação</string>
+    <string name="UndoAllCustom">Desfaz todas as configurações personalizadas de notificação para todos os contatos e grupos</string>
+    <string name="NotificationsAndSounds">Notificações e sons</string>
+    <string name="BlockedUsers">Usuários bloqueados</string>
+    <string name="SaveIncomingPhotos">Salvar fotos recebidas</string>
+    <string name="LogOut">Sair</string>
+    <string name="YourFirstNameAndLastName">SEU NOME E SOBRENOME</string>
+    <string name="NoSound">Sem som</string>
+    <string name="Default">Padrão</string>
+    <string name="Support">SUPORTE</string>
+    <string name="ChatBackground">Imagem de fundo da Conversa</string>
+    <string name="MessagesSettings">MENSAGENS</string>
+    <string name="SendByEnter">Enviar com Enter</string>
+    <string name="TerminateAllSessions">Sair de todas as sessões</string>
+    <string name="AutomaticPhotoDownload">BAIXAR FOTOS AUTOMATICAMENTE</string>
+    <string name="AutomaticPhotoDownloadGroups">Grupos</string>
+    <string name="AutomaticPhotoDownloadPrivateChats">Conversas privadas</string>
+    <string name="Events">EVENTOS</string>
+    <string name="ContactJoined">Um contato se juntou ao Telegram</string>
+
+    <!--media view-->
+    <string name="NoMedia">Nenhuma mídia compartilhada</string>
+    <string name="CancelDownload">Cancelar transferência</string>
+
+    <!--map view-->
+    <string name="MyLocation">Minha localização</string>
+    <string name="Map">Mapa</string>
+    <string name="Satellite">Satélite</string>
+    <string name="Hybrid">Híbrido</string>
+    <string name="MetersAway">m de distância</string>
+    <string name="KMetersAway">km de distância</string>
+    <string name="SendLocation">Enviar localização</string>
+    <string name="ShareLocation">Compartilhar localização</string>
+
+    <!--photo gallery view-->
+    <string name="ShowAllMedia">Exibir todas as mídias</string>
+    <string name="SaveToGallery">Salvar na Galeria</string>
+    <string name="Of">de</string>
+    <string name="Gallery">Galeria</string>
+
+    <!--button titles-->
+    <string name="Next">Próximo</string>
+    <string name="Back">Voltar</string>
+    <string name="Done">Concluído</string>
+    <string name="Open">Abrir</string>
+    <string name="Cancel">Cancelar</string>
+    <string name="Add">Adicionar</string>
+    <string name="Edit">Editar</string>
+    <string name="Send">Enviar</string>
+    <string name="Call">Chamar</string>
+    <string name="Copy">Copiar</string>
+    <string name="Delete">Excluir</string>
+    <string name="Forward">Encaminhar</string>
+    <string name="Retry">Tentar novamente</string>
+    <string name="FromCamera">Da câmera</string>
+    <string name="FromGalley">Da galeria</string>
+    <string name="DeletePhoto">Excluir foto</string>
+    <string name="OpenPhoto">Abrir foto</string>
+    <string name="Set">Definir</string>
+    <string name="OK">OK</string>
+
+    <!--messages-->
+    <string name="ActionKickUser">un1 expulsou un2</string>
+    <string name="ActionLeftUser">un1 deixou o grupo</string>
+    <string name="ActionAddUser">un1 adicionou un2</string>
+    <string name="ActionRemovedPhoto">un1 removeu a foto do grupo</string>
+    <string name="ActionChangedPhoto">un1 mudou a foto do grupo</string>
+    <string name="ActionChangedTitle">un1 mudou o nome do grupo para un2</string>
+    <string name="ActionCreateGroup">un1 criou o grupo</string>
+    <string name="ActionYouKickUser">Você expulsou un2</string>
+    <string name="ActionYouLeftUser">Você deixou o grupo</string>
+    <string name="ActionYouAddUser">Você adicionou un2</string>
+    <string name="ActionYouRemovedPhoto">Você removeu a foto do grupo</string>
+    <string name="ActionYouChangedPhoto">Você mudou a foto do grupo</string>
+    <string name="ActionYouChangedTitle">Você mudou o nome do grupo para un2</string>
+    <string name="ActionYouCreateGroup">Você criou o grupo</string>
+    <string name="ActionKickUserYou">un1 te expulsou</string>
+    <string name="ActionAddUserYou">un1 te adicionou</string>
+    <string name="UnsuppotedMedia">Esta mensagem não é suportada na sua versão do Telegram.</string>
+    <string name="AttachPhoto">Foto</string>
+    <string name="AttachVideo">Vídeo</string>
+    <string name="AttachLocation">Localização</string>
+    <string name="AttachContact">Contato</string>
+    <string name="AttachDocument">Documento</string>
+    <string name="AttachAudio">Áudio</string>
+    <string name="FromYou">Você</string>
+
+    <!--Alert messages-->
+    <string name="InvalidPhoneNumber">Telefone inválido</string>
+    <string name="CodeExpired">O código expirou, por favor entre novamente</string>
+    <string name="FloodWait">Você excedeu o número de tentativas. Por favor, tente mais tarde</string>
+    <string name="InvalidCode">Código inválido</string>
+    <string name="InvalidFirstName">Nome inválido</string>
+    <string name="InvalidLastName">Sobrenome inválido</string>
+    <string name="Loading">Carregando...</string>
+    <string name="NoPlayerInstalled">Você não tem um reprodutor de vídeo, por favor instale um para continuar</string>
+    <string name="NoHandleAppInstalled">Você não possui aplicativos que possam abrir o tipo de arquivo \'%1$s\', por favor instale um para continuar</string>
+    <string name="InviteUser">Este usuário ainda não possui o Telegram, deseja convidá-lo?</string>
+    <string name="AreYouSure">Tem certeza?</string>
+    <string name="AddContactQ">Adicionar contato?</string>
+    <string name="AddToTheGroup">Adicionar %1$s ao grupo?</string>
+    <string name="ForwardMessagesTo">Encaminhar mensagens a %1$s?</string>
+    <string name="DeleteChatQuestion">Excluir esta conversa?</string>
+
+    <!--Intro view-->
+    <string name="Page1Title">Telegram</string>
+    <string name="Page2Title">Rápido</string>
+    <string name="Page3Title">Gratuito</string>
+    <string name="Page4Title">Seguro</string>
+    <string name="Page5Title">Poderoso</string>
+    <string name="Page6Title">Nas nuvens</string>
+    <string name="Page7Title">Privado</string>
+    <string name="Page1Message">Bem-vindo à era da troca rápida e segura de mensagens</string>
+    <string name="Page2Message"><![CDATA[<b>Telegram</b>]]> entrega mensagens mais rápido do que<![CDATA[<br/>]]>qualquer outro aplicativo</string>
+    <string name="Page3Message"><![CDATA[<b>Telegram</b>]]> é de graça para sempre. Sem propagandas.<![CDATA[<br/>]]>Sem taxas de inscrição</string>
+    <string name="Page4Message"><![CDATA[<b>Telegram</b>]]> mantém suas mensagens seguras<![CDATA[<br/>]]>de ataques de crackers</string>
+    <string name="Page5Message"><![CDATA[<b>Telegram</b>]]> não tem limites de tamanho para<![CDATA[<br/>]]>seus arquivos e conversas</string>
+    <string name="Page6Message"><![CDATA[<b>Telegram</b>]]> deixa você acessar suas mensagens<![CDATA[<br/>]]>de vários dispositivos</string>
+    <string name="Page7Message">As mensagens do <![CDATA[<b>Telegram</b>]]> são fortemente criptografadas<![CDATA[<br/>]]>e podem se autodestruir</string>
+    <string name="StartMessaging">Comece a mandar mensagens</string>
+
+    <!--Don't change this! Not for localization!-->
+    <string name="CacheTag">CACHE_TAG</string>
+</resources>


### PR DESCRIPTION
Brazilian translations with proper locale code (PT-BR), to allow merging with portuguese (PT-PT) translation. This translation contains almost no anglicisms, being closer to proper portuguese.
