### PR TITLE
Workaround for numbers without country code (locall calling code)

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/PhoneFormat/PhoneFormat.java
+++ b/TMessagesProj/src/main/java/org/telegram/PhoneFormat/PhoneFormat.java
@@ -24,8 +24,6 @@
 
 package org.telegram.PhoneFormat;
 
-import android.util.Log;
-
 import org.telegram.ui.ApplicationLoader;
 
 import java.io.ByteArrayOutputStream;

--- a/TMessagesProj/src/main/java/org/telegram/messenger/ContactsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ContactsController.java
@@ -18,7 +18,6 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.provider.BaseColumns;
 import android.provider.ContactsContract;
-import android.util.Log;
 import android.util.SparseArray;
 
 import org.telegram.PhoneFormat.PhoneFormat;


### PR DESCRIPTION
This is a proposal for a solution (workaround) for issue #126.
It replaces the local calling code (0) with the default country calling code.
