### PR TITLE
"Start Messaging" button: accomodate multiline strings

### DIFF
--- a/TMessagesProj/src/main/res/layout/intro_layout.xml
+++ b/TMessagesProj/src/main/res/layout/intro_layout.xml
@@ -36,7 +36,7 @@
             android:id="@+id/intro_view_pager"/>
 
         <TextView android:layout_width="192dp"
-            android:layout_height="44dp"
+            android:layout_height="wrap_content"
             android:layout_marginTop="336dp"
             android:background="@drawable/regbtn_states"
             android:text="@string/StartMessaging"
@@ -45,7 +45,7 @@
             android:textColor="#ffffff"
             android:gravity="center"
             android:id="@+id/start_messaging_button"
-            android:paddingBottom="2dp"/>
+            android:padding="6dp"/>
 
         <LinearLayout
             android:layout_width="wrap_content"


### PR DESCRIPTION
Use variable height and same padding for all sides to accomodate multiline strings. Useful for localization.

Fixes #191
