### PR TITLE
Notification when group name or photo is changed

### DIFF
--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -137,8 +137,8 @@
     <string name="NotificationMessageGroupDocument">%1$s sent a document to the group %2$s</string>
     <string name="NotificationMessageGroupAudio">%1$s sent an audio to the group %2$s</string>
     <string name="NotificationInvitedToGroup">%1$s invited you to the group %2$s</string>
-    <string name="NotificationEditedGroupName">%1$s edited the group\'s %2$s name</string>
-    <string name="NotificationEditedGroupPhoto">%1$s edited the group\'s %2$s photo</string>
+    <string name="NotificationEditedGroupName">%1$s edited the \"%2$s\" group\'s name</string>
+    <string name="NotificationEditedGroupPhoto">%1$s edited the \"%2$s\" group\'s photo</string>
     <string name="NotificationGroupAddMember">%1$s invited %3$s to the group %2$s</string>
     <string name="NotificationGroupKickMember">%1$s kicked %3$s from the group %2$s</string>
     <string name="NotificationGroupKickYou">%1$s kicked you from the group %2$s</string>


### PR DESCRIPTION
Updated to make for more clear reading. Currently, this formats to:
"Andy has edited the group's Hiking Club name"

Which is a bit odd.

This change proposes to make this:
"Andy has edited the "Hiking Club" group's name"
