### PR TITLE
Enable SQLite secure_delete pragma.

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
@@ -69,6 +69,7 @@ public class MessagesStorage {
         }
         try {
             database = new SQLiteDatabase(cacheFile.getPath());
+            database.execute("PRAGMA secure_delete = ON");
             if (createTable) {
                 database.executeFast("CREATE TABLE users(uid INTEGER PRIMARY KEY, name TEXT, status INTEGER, data BLOB)").stepThis().dispose();
                 database.executeFast("CREATE TABLE messages(mid INTEGER PRIMARY KEY, uid INTEGER, read_state INTEGER, send_state INTEGER, date INTEGER, data BLOB, out INTEGER, ttl INTEGER)").stepThis().dispose();


### PR DESCRIPTION
By default, when a row is deleted, its contents are preserved until its space is requested for a new insertion. This makes possible to extract the contents from deleted messages, even the ones encrypted and self-destroyed.

When SQLite has its secure_delete pragma activated and a row is deleted, it overwrites its contents with zeros, making harder to recover the text.

Thanks to Abel Gomez from INCIDE for noticing this (http://atrapadosporlosbits.blogspot.com.es/2014/02/destruccion-de-mensajes-en-telegram.html).
