### PR TITLE
Fix issue #127

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,9 @@
+[main]
+host = https://www.transifex.com
+
+[telegram.stringsxml-48]
+file_filter = TMessagesProj/src/main/res/values-<lang>/string.xml
+source_file = TMessagesProj/src/main/res/values/strings.xml
+source_lang = en
+type = ANDROID
+

--- a/README.md
+++ b/README.md
@@ -13,3 +13,20 @@ Documentation for MTproto protocol is available here: http://core.telegram.org/m
 ### Usage
 
 Import the root folder into your IDE (tested on Android Studio), then run project.
+
+
+### Translation
+
+Sirs translators, It was becoming impossible to manage all pull requests regarding translations. This was also taking the precious time to fix bugs. A translated program is good, but is better a program with less or no bugs, and more features. We decided then, fully migrate any translation effort to Transifex translation platform. 
+
+The Transifex platform makes it much simpler to manage groups of translations and translations, and has several well useful tools for this purpose. 
+
+We thank everyone for their arduous effort.
+
+See [Telegram] (http://telegram.org) translation project on Transifex platform here: 
+
+https://www.transifex.com/projects/p/telegram 
+
+If your language is not yet available, make the request for inclusion in [Transifex.com platform] (Https://www.transifex.com/projects/p/telegram)
+
+All pull requests on GitHub, regarding translations will not be accepted. 

--- a/TMessagesProj/src/main/res/values-ar/strings.xml
+++ b/TMessagesProj/src/main/res/values-ar/strings.xml
@@ -350,5 +350,5 @@
     <string name="StartMessaging">إبدأ المراسلة</string>
 
     <!--Don't change this! Not for localization!-->
-    <string name="CacheTag">CACHE_TAG</string>
+    <string name="CacheTag" translate="false">CACHE_TAG</string>
 </resources>

--- a/TMessagesProj/src/main/res/values-de/strings.xml
+++ b/TMessagesProj/src/main/res/values-de/strings.xml
@@ -350,5 +350,5 @@
     <string name="StartMessaging">Jetzt beginnen</string>
 
     <!--Don't change this! Not for localization!-->
-    <string name="CacheTag">CACHE_TAG</string>
+    <string name="CacheTag" translate="false">CACHE_TAG</string>
 </resources>

--- a/TMessagesProj/src/main/res/values-es/strings.xml
+++ b/TMessagesProj/src/main/res/values-es/strings.xml
@@ -350,5 +350,5 @@
     <string name="StartMessaging">Empieza a conversar</string>
 
     <!--Don't change this! Not for localization!-->
-    <string name="CacheTag">CACHE_TAG</string>
+    <string name="CacheTag" translate="false">CACHE_TAG</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -350,5 +350,5 @@
     <string name="StartMessaging">Start Messaging</string>
 
     <!--Don't change this! Not for localization!-->
-    <string name="CacheTag">CACHE_TAG</string>
+    <string name="CacheTag" translate="false">CACHE_TAG</string>
 </resources>


### PR DESCRIPTION
Fix issue #127

Resume:
- Make the "CACHE_TAG" string on strings.xml not translatable, see https://github.com/luzfcb/Telegram/commit/96377b23bc6896750905623bbdee5259a7a80ec5
- Create transifex configuration ( .tx/config ) to easy pull and push translations using Transifex client. Please see: 
  http://support.transifex.com/customer/portal/articles/995605-installation 
  http://support.transifex.com/customer/portal/articles/1000855-configuring-the-client - only ".transifexrc" section
  http://support.transifex.com/customer/portal/articles/960804-overview#user-client-08-type
  http://support.transifex.com/customer/portal/articles/996157-getting-translations
  http://support.transifex.com/customer/portal/articles/996211-pushing-new-translations
- Update Readme to informing that all efforts for translation were moved to Transifex

After pulling translations using a Transifex client, for each translation, Transifex client automatically creates a folder containing the translation

The folder name will be defined according to the following syntax: 

```
TMessagesProj/src/main/res/values-<lang-code>/string.xml
```

Related issues:
#21 #29 #50 #53
#55 #63 #65 #67
#79 #81 #87 #96
#100 #107 #108 #110
#112 #119 #122 #129
#131 #141 #143 #149
#153 #154 #157 #160
#165 #169 #171 #176
#179 #184 #197 #201
#202 #203 #207 #214
#215 #216 #233 #240
#242 #250 #251 #253
