### PR TITLE
Fixed Audio Recording

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -56,6 +56,8 @@ public class MediaController implements NotificationCenter.NotificationCenterDel
     private long recordStartTime;
     private long recordDialogId;
 
+    private int audioBitDepth = 4;
+
     private final Integer sync = 1;
 
     private int lastTag = 0;
@@ -379,9 +381,10 @@ public class MediaController implements NotificationCenter.NotificationCenterDel
         } else {
             audioRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);
         }
-        audioRecorder.setAudioSamplingRate(24000);
+        audioRecorder.setAudioSamplingRate(16000);
         audioRecorder.setAudioChannels(1);
-        audioRecorder.setAudioEncodingBitRate(16000);
+        // formula : Bit rate = (sampling rate) × (bit depth) × (number of channels)
+        audioRecorder.setAudioEncodingBitRate(16000*audioBitDepth*1);
 
         try {
             audioRecorder.prepare();


### PR DESCRIPTION
Your Audio recording code is not working ( on Samsung Galaxy S3 ).
The problem is the Sampling rate 24,000 is no official rate.
I replaced it with 16,000 Hz ( see on http://en.wikipedia.org/wiki/Sampling_rate )
=> That is the usual VoIP quality.

Also your Encoding Bitrate is wrong (or at least not usual )
The formula for the Bitrate is 
`Bit rate = (sampling rate) × (bit depth) × (number of channels)`

The normal bit depth on Android is 8 but I used 4 because it keeps the files much smaller and the quality difference isn't that much ( still noticable )

If it's still too big the Sampling rate can be decreased to 11,025 Hz or 8,000 Hz but the Bit Depth musn't be reduced below 4.
I personally recommend using 8 because it's Android standard I used 4 in my code to keep the size low.

Size table for 30sec of audio ( uncompressed ):

| Sampling rate | Bit depth | Bit rate | size |
| --- | --- | --- | --- |
| 8,000 | 8 | 64,000 | 234 kb |
| 8,000 | 4 | 32,000 | 117 kb |
| 11,025 | 8 | 88,200 | 322 kb |
| 11,025 | 4 | 44,100 | 161 kb |
| 16,000 | 8 | 128,000 | 468 kb |
| 16,000 | 4 | 64,000 | 234 kb |

With the code on your repo it would be : 
24,000 \* 0.666 \* 1 = 16000
And a bit depth of 0.666 which is  not usual ( see http://en.wikipedia.org/wiki/Audio_bit_depth ) and results in bad sound quality 

Using my changes it is working on my mobile.
