### PR TITLE
Set vibrate to empty vibrate, if disabled in Telegram settings.

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
@@ -4517,6 +4517,8 @@ public class MessagesController implements NotificationCenter.NotificationCenter
 
             if (needVibrate) {
                 mBuilder.setVibrate(new long[]{0, 100, 0, 100});
+            } else {
+                mBuilder.setVibrate(new long[]{0});
             }
             if (choosenSoundPath != null && !choosenSoundPath.equals("NoSound")) {
                 if (choosenSoundPath.equals(defaultPath)) {


### PR DESCRIPTION
Overrides default notification vibration settings (which are disabled in normal mode, and enabled in vibrate mode)

This will makes the behaviour of the app in line with how vibrate works in other messaging apps (Hangouts, etc).

Resolves Issue #366.
