### PR TITLE
Fixed issue #125 - push notifications do not always work

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ApplicationLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ApplicationLoader.java
@@ -20,6 +20,7 @@ import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Handler;
 import android.view.ViewConfiguration;
 
@@ -247,7 +248,13 @@ public class ApplicationLoader extends Application {
                 }
                 return false;
             }
-        }.execute(null, null, null);
+        };
+        if(Build.VERSION.SDK_INT < 11) {
+            task.execute(null, null, null);
+        }
+        else{
+            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, null, null, null);
+        }
     }
 
     private void sendRegistrationIdToBackend(final boolean isNew) {


### PR DESCRIPTION
Problem is that the code which sends the request to the GCM is inside an AsyncTask and since Froyo tasks are run serially, so if another task starts before it and doesn't finish it doesn't run.
The fix is to use the new API of executeOnExecutor which runs the task in parallel to other tasks.
