### PR TITLE
Remove message item tap menu.

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -220,7 +220,6 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                 processRowSelect(view);
                 return;
             }
-            createMenu(view, true);
         }
     };
 


### PR DESCRIPTION
It's far, far too easy to accidentally to tap a message and then tap in just the right position to tap Delete.

And then the message is gone forever.

Since all the options in the popup menu are also present in the selection actionbar menu, no functionality is lost by removing it.

![screenshot_2014-12-11-02-13-28](https://cloud.githubusercontent.com/assets/235432/5381459/65c2248e-80dc-11e4-9a87-366dfc22f6ce.png)
![screenshot_2014-12-11-02-13-39](https://cloud.githubusercontent.com/assets/235432/5381504/efefef9c-80dc-11e4-89c2-fdf36e866a0e.png)
