### PR TITLE
Fixed issue related with committing previously aborted key during re-keying

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/android/SecretChatHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/android/SecretChatHelper.java
@@ -1176,6 +1176,7 @@ public class SecretChatHelper {
                             chat.future_key_fingerprint = fingerprint;
 
                             MessagesStorage.getInstance().updateEncryptedChat(chat);
+                            sendCommitKeyMessage(chat, null);
                         } else {
                             chat.future_auth_key = new byte[256];
                             chat.future_key_fingerprint = 0;
@@ -1183,8 +1184,6 @@ public class SecretChatHelper {
                             MessagesStorage.getInstance().updateEncryptedChat(chat);
                             sendAbortKeyMessage(chat, null, serviceMessage.action.exchange_id);
                         }
-
-                        sendCommitKeyMessage(chat, null);
                     } else {
                         chat.future_auth_key = new byte[256];
                         chat.future_key_fingerprint = 0;


### PR DESCRIPTION
This doesn't have any security implications (albeit it potentially could, thanks to [this line](https://github.com/DrKLO/Telegram/blob/8c50d4d03bdda3839978e55ae1f0a2ca5492b0f6/TMessagesProj/src/main/java/org/telegram/android/SecretChatHelper.java#L840)), but it will consistently break the secret chat in the case of not matching fingerprints during re-keying.
