### PR TITLE
Support running debug and release versions (and foss) simultaneously

### DIFF
--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -45,6 +45,7 @@ android {
             debuggable true
             jniDebuggable true
             signingConfig signingConfigs.debug
+            applicationIdSuffix ".debug"
         }
 
         release {
@@ -57,6 +58,7 @@ android {
             debuggable false
             jniDebuggable false
             signingConfig signingConfigs.release
+            applicationIdSuffix ".foss"
         }
     }
 


### PR DESCRIPTION
Adding applicationIdSuffix to build types helps separate packages. Source: [tools.android.com](http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Build-Types)

I've tested that this indeed works with debug and foss versions simultaneously installed and logged in and sending messages.

`adb install` fails though (says already exists). So had to manually install by pushing the file to sdcard.

This will be quite useful for people who want to run both the stable version and the bleeding version simultaneously without resorting to rename directories or download from other developers.
