### PR TITLE
Fixed traslation for "Shared Media"

### DIFF
--- a/TMessagesProj/src/main/res/values-ar/strings.xml
+++ b/TMessagesProj/src/main/res/values-ar/strings.xml
@@ -175,7 +175,7 @@
     <string name="GroupName">اسم المجموعة</string>
     <string name="MembersCount">%1$d/%2$d عضو</string>
     <!--group info view-->
-    <string name="SharedMedia">عدد الوسائط المشتركة</string>
+    <string name="SharedMedia">الوسائط المشتركة</string>
     <string name="SETTINGS">الإعدادات</string>
     <string name="AddMember">إضافة مشترك</string>
     <string name="DeleteAndExit">مغادرة المجموعة وحذفها</string>


### PR DESCRIPTION
The word "عدد" means number. Which doesn't match the english translation and also doesn't fit when displaying as action bar title.