### PR TITLE
Text Avatar for groups and users with no photo

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AvatarDrawable.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AvatarDrawable.java
@@ -176,7 +176,19 @@ public class AvatarDrawable extends Drawable {
                 }
                 lastch = lastName.substring(a, a + 1);
             }
-            text += lastch;
+            text += "\u200C" + lastch;    // Adding a Zero-width non-joiner (U+200C) to prevent letters from joining when using languages such as Arabic.
+        } else { // if there is no last name (like group names) check if first name is two words
+            String lastch = null;
+            int a;
+            for (a = firstName.length() - 1; a >= 0; a--) {
+                if (lastch != null && firstName.charAt(a) == ' ') {
+                    break;
+                }
+                lastch = firstName.substring(a, a + 1);
+            }
+            if (a > 0) {    // Make sure it is not just single word and we are getting the same first letter
+                text += "\u200C" + lastch;
+            }
         }
         if (text.length() > 0) {
             text = text.toUpperCase();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AvatarDrawable.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AvatarDrawable.java
@@ -178,16 +178,18 @@ public class AvatarDrawable extends Drawable {
             }
             text += "\u200C" + lastch;    // Adding a Zero-width non-joiner (U+200C) to prevent letters from joining when using languages such as Arabic.
         } else { // if there is no last name (like group names) check if first name is two words
-            String lastch = null;
-            int a;
-            for (a = firstName.length() - 1; a >= 0; a--) {
-                if (lastch != null && firstName.charAt(a) == ' ') {
-                    break;
+            if (firstName != null && firstName.length() > 0) {
+                String lastch = null;
+                int a;
+                for (a = firstName.length() - 1; a >= 0; a--) {
+                    if (lastch != null && firstName.charAt(a) == ' ') {
+                        break;
+                    }
+                    lastch = firstName.substring(a, a + 1);
                 }
-                lastch = firstName.substring(a, a + 1);
-            }
-            if (a > 0) {    // Make sure it is not just single word and we are getting the same first letter
-                text += "\u200C" + lastch;
+                if (a > 0) {    // Make sure it is not a just single word
+                    text += "\u200C" + lastch;
+                }
             }
         }
         if (text.length() > 0) {


### PR DESCRIPTION
Two changes are proposed here:
1- Group names doesn't have a last name field, so if a group has a name of two words such as "Test Group" then Telegram for Android will only show the first letter T only (while Telegram Web and desktop show TG), so if there is no last name simply check if the first name has a space separating two or more words and use the first letter from the last word.

2- In languages like Arabic, letters that are have no space in between will usually link to each other, but in case of initials they should be separate, so I propose the use of "Zero-width non-joiner" character between the two letters which will make the letters display as stand-alone (non-joined) also it has no effect on other languages like English.

Image after applying the group name fix (groups now have two letters)
![tel_joiner](https://cloud.githubusercontent.com/assets/432460/6009699/219b0904-aafa-11e4-8371-53a1dc53f9ac.png)

Image after applying the Zero-width non-joiner, you see the effect is only on the Arabic letters but the English letters remain the same
![tel_non-joiner](https://cloud.githubusercontent.com/assets/432460/6009704/384adabc-aafa-11e4-95de-2561e21d0cfd.png)

More info about Zero-width non-joiner can be found here:
http://en.wikipedia.org/wiki/Zero-width_non-joiner