### PR TITLE
Fix for GIF search when using Arabic interface

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoPickerActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoPickerActivity.java
@@ -654,7 +654,7 @@ public class PhotoPickerActivity extends BaseFragment implements NotificationCen
         }
         try {
             searching = true;
-            String url = String.format("https://api.giphy.com/v1/gifs/search?q=%s&offset=%d&limit=%d&api_key=141Wa2KDAfNfxu", URLEncoder.encode(query, "UTF-8"), offset, count);
+            String url = String.format(Locale.US, "https://api.giphy.com/v1/gifs/search?q=%s&offset=%d&limit=%d&api_key=141Wa2KDAfNfxu", URLEncoder.encode(query, "UTF-8"), offset, count);
             JsonObjectRequest jsonObjReq = new JsonObjectRequest(Request.Method.GET, url, null,
                     new Response.Listener<JSONObject>() {
                         @Override


### PR DESCRIPTION
Without "Locale.US" the String.format will change the numbers 0 & 53 to the device local language representation. For example, if the Telegram language is set to Arabic the formatted URL will have the offset and count in Hindu-Arabic numerals representation like the picture below

![tel_gif_before](https://cloud.githubusercontent.com/assets/432460/6064217/860db544-ad2a-11e4-91d1-c894ee958ea1.png)

The fix will insure the numbers stays as is

* Without the fix the search result is always empty!