### PR TITLE
.nomedia file in cache

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/FileLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/FileLoader.java
@@ -81,6 +81,9 @@ public class FileLoader {
         try {
             if (!dir.isDirectory()) {
                 dir.mkdirs();
+            if (type == MEDIA_DIR_CACHE){
+            new File(dir, ".nomedia").createNewFile();
+            }
             }
         } catch (Exception e) {
             //don't promt


### PR DESCRIPTION
On some phones (e.g. HTC M8) gallery apps (e.g. HTC Gallery) show the Telegram cache folder as an album. 
Even though this is not the fault of the telegram app I believe for the UX it would be better if the app created a .nomedia file, so the (not so perfect) gallery apps skip scanning the cache folder.

Thanks to @asdofindia for the code.