### PR TITLE
Add plural rules for Aragonese and Asturian languages

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/android/LocaleController.java
+++ b/TMessagesProj/src/main/java/org/telegram/android/LocaleController.java
@@ -135,7 +135,7 @@ public class LocaleController {
         addRules(new String[]{"bem", "brx", "da", "de", "el", "en", "eo", "es", "et", "fi", "fo", "gl", "he", "iw", "it", "nb",
                 "nl", "nn", "no", "sv", "af", "bg", "bn", "ca", "eu", "fur", "fy", "gu", "ha", "is", "ku",
                 "lb", "ml", "mr", "nah", "ne", "om", "or", "pa", "pap", "ps", "so", "sq", "sw", "ta", "te",
-                "tk", "ur", "zu", "mn", "gsw", "chr", "rm", "pt"}, new PluralRules_One());
+                "tk", "ur", "zu", "mn", "gsw", "chr", "rm", "pt", "an", "ast"}, new PluralRules_One());
         addRules(new String[]{"cs", "sk"}, new PluralRules_Czech());
         addRules(new String[]{"ff", "fr", "kab"}, new PluralRules_French());
         addRules(new String[]{"hr", "ru", "sr", "uk", "be", "bs", "sh"}, new PluralRules_Balkan());


### PR DESCRIPTION
Telegram doesn't find the plural forms for Aragonese and Asturian, so it shows "LOC:ERR" messages when plural strings are used, so defining this rules for both languages makes it to show the correct strings.