### PR TITLE
Always open chat before sending text message shared from other app

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -2953,6 +2953,10 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
         return chatActivityEnterView.processSendingText(text);
     }
 
+    public void setReplyText(String text) {
+        chatActivityEnterView.setFieldText(text);
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public void didReceivedNotification(int id, final Object... args) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -948,7 +948,7 @@ public class LaunchActivity extends Activity implements ActionBarLayout.ActionBa
                 actionBarLayout.presentFragment(fragment, true);
 
                 if (sendingText != null) {
-                    fragment.processSendingText(sendingText);
+                    fragment.setReplyText(sendingText);
                 }
                 if (photoPathsArray != null) {
                     SendMessagesHelper.prepareSendingPhotos(null, photoPathsArray, dialog_id, null);


### PR DESCRIPTION
* This allows to edit the reply text and/or show the link preview

Change-Id: I2f445e554d72da029e49d65623aa7b87a543ab05