### PR TITLE
Fix Emoji Recents Behavior

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiView.java
@@ -76,7 +76,7 @@ public class EmojiView extends LinearLayout {
             }
         }
         if (!was) {
-            localArrayList.add(0, paramLong);
+            localArrayList.add((currentRecent.length > 1) ? currentRecent.length - 1 : 0, paramLong);
         }
         Emoji.data[0] = new long[Math.min(localArrayList.size(), 50)];
         for (int q = 0; q < Emoji.data[0].length; q++) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiView.java
@@ -162,16 +162,12 @@ public class EmojiView extends LinearLayout {
     }
 
     private void saveRecents() {
-        ArrayList<Long> localArrayList = new ArrayList<>();
-        long[] arrayOfLong = Emoji.data[0];
-        int i = arrayOfLong.length;
-        for (int j = 0; ; j++) {
-            if (j >= i) {
-                getContext().getSharedPreferences("emoji", 0).edit().putString("recents", TextUtils.join(",", localArrayList)).commit();
-                return;
-            }
-            localArrayList.add(arrayOfLong[j]);
+        ArrayList<Long> tmp = new ArrayList<>();
+        for (int i = 0; i < Emoji.data[0].length; ++i) {
+            tmp.add(Emoji.data[0][i]);
         }
+        getContext().getSharedPreferences("emoji", 0).edit().putString("recents", TextUtils.join(",", tmp)).commit();
+
     }
 
     public void loadRecents() {


### PR DESCRIPTION
Currently, selected emojis are always added to the beginning of the recents list. This shifts the whole layout, making it hard for the user to memorize it.
Selected emojis should be added at the end of that list instead. They are only moved to the beginning if the user selects them again via the regular emoji grid. Also, we make sure to add them in the second last slot, so they replace the last emoji if we already have the max number of emojis in there.
This makes the recents layout more consistent and easier to remember for the user.