### PR TITLE
Telegram on android M crashes everytime the Emoji popup is shown

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -1269,20 +1269,19 @@ public class ChatActivityEnterView extends FrameLayoutFixed implements Notificat
 
         if (emojiPopup != null && emojiPopup.isShowing()) {
             int newHeight = isWidthGreater ? keyboardHeightLand : keyboardHeight;
-            final WindowManager.LayoutParams layoutParams = (WindowManager.LayoutParams) emojiPopup.getContentView().getLayoutParams();
+            final ViewGroup.LayoutParams layoutParams = emojiPopup.getContentView().getLayoutParams();
             FileLog.e("tmessages", "update emoji height to = " + newHeight);
             if (layoutParams.width != AndroidUtilities.displaySize.x || layoutParams.height != newHeight) {
                 layoutParams.width = AndroidUtilities.displaySize.x;
                 layoutParams.height = newHeight;
-                WindowManager wm = (WindowManager) ApplicationLoader.applicationContext.getSystemService(Activity.WINDOW_SERVICE);
-                if (wm != null) {
-                    wm.updateViewLayout(emojiPopup.getContentView(), layoutParams);
-                    if (!keyboardVisible) {
-                        if (sizeNotifierLayout != null) {
-                            sizeNotifierLayout.setPadding(0, 0, 0, layoutParams.height);
-                            sizeNotifierLayout.requestLayout();
-                            onWindowSizeChanged(sizeNotifierLayout.getHeight() - sizeNotifierLayout.getPaddingBottom());
-                        }
+
+                emojiPopup.getContentView().setLayoutParams(layoutParams);
+                emojiPopup.getContentView().requestLayout();
+                if (!keyboardVisible) {
+                    if (sizeNotifierLayout != null) {
+                        sizeNotifierLayout.setPadding(0, 0, 0, layoutParams.height);
+                        sizeNotifierLayout.requestLayout();
+                        onWindowSizeChanged(sizeNotifierLayout.getHeight() - sizeNotifierLayout.getPaddingBottom());
                     }
                 }
             }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/PasscodeView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/PasscodeView.java
@@ -995,7 +995,7 @@ public class PasscodeView extends FrameLayout {
 
         if (UserConfig.passcodeType == 1 && (AndroidUtilities.isTablet() || getContext().getResources().getConfiguration().orientation != Configuration.ORIENTATION_LANDSCAPE)) {
             int t = 0;
-            if (passwordFrameLayout.getTag() != 0) {
+            if (passwordFrameLayout.getTag() instanceof Integer) {
                 t = (Integer) passwordFrameLayout.getTag();
             }
             LayoutParams layoutParams = (LayoutParams) passwordFrameLayout.getLayoutParams();


### PR DESCRIPTION
As the PopupWindow.getContentView().getLayoutParams() in Android M doesn't return a WindowManager.LayoutParams instance anymore, but a FrameLayout.LayoutParams, the cast would induce a foce close.

Therefore I rewrote the code in order to avoid casting the params (therefore being compatible with older versions of android).

It would be great if you'd accept my pull request. Then I could use the official Telegram App again. I'm sure that multiple users have this problem.
