### PR TITLE
Add a feature: When the keyboard or "popup" is showing, then click on the chat list, people can hide the input keyboard or "popup"

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -4645,6 +4645,16 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
     }
 
     public void createMenu(View v, boolean single) {
+        if (chatActivityEnterView.isPopupShowing()) {
+            chatActivityEnterView.hidePopup(true);
+            return;
+        }
+
+        if (chatActivityEnterView.isKeyBoardShowing()) {
+            chatActivityEnterView.hideKeyboard();
+            return;
+        }
+
         if (actionBar.isActionModeShowed()) {
             return;
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -1367,12 +1367,16 @@ public class ChatActivityEnterView extends FrameLayoutFixed implements Notificat
         }
     }
 
-    public void openKeyboard() {
-        AndroidUtilities.showKeyboard(messageEditText);
+    public void hideKeyboard() {
+        AndroidUtilities.hideKeyboard(messageEditText);
     }
 
     public boolean isPopupShowing() {
         return emojiView != null && emojiView.getVisibility() == VISIBLE || botKeyboardView != null && botKeyboardView.getVisibility() == VISIBLE;
+    }
+
+    public boolean isKeyBoardShowing() {
+        return keyboardVisible;
     }
 
     @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -1367,6 +1367,10 @@ public class ChatActivityEnterView extends FrameLayoutFixed implements Notificat
         }
     }
 
+    public void openKeyboard() {
+        AndroidUtilities.showKeyboard(messageEditText);
+    }
+
     public void hideKeyboard() {
         AndroidUtilities.hideKeyboard(messageEditText);
     }


### PR DESCRIPTION
Add a feature: When the keyboard or "popup" is showing, then click on the chat list, people can hide the input keyboard or "popup";

Preview GIF: 
![demo](https://cloud.githubusercontent.com/assets/5214214/9906578/66e68108-5cbd-11e5-9e2d-41fcff142d38.gif)

It is easier to use, more intuitive.

I sincerely hope that it can be adopted, thank you very much!
