### PR TITLE
BUG in notification settings activity

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
@@ -390,7 +390,8 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
                                 editor.putInt("GroupLed", colorPickerView.getColor());
                             }
                             editor.commit();
-                            listView.invalidateViews();
+                            listView.invalidateViews();  /* [BUG] after call this method, when MessagesLed and GroupLed row
+                                                            fit in a same screen both of them display in a same color */
                         }
                     });
                     builder.setNeutralButton(LocaleController.getString("LedDisabled", R.string.LedDisabled), new DialogInterface.OnClickListener() {


### PR DESCRIPTION
[BUG] after call this method, when MessagesLed and GroupLed row fit in a same screen both of them display in a same color.

Because of Issues section is disabled I had to propose that here.