### PR TITLE
Include missing unistd.h header.

### DIFF
--- a/TMessagesProj/jni/tgnet/Config.cpp
+++ b/TMessagesProj/jni/tgnet/Config.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <sys/stat.h>
+#include <unistd.h>
 #include "Config.h"
 #include "ConnectionsManager.h"
 #include "FileLog.h"


### PR DESCRIPTION
On Linux unistd.h is needed for fsync().
The native library does not compile otherwise.