### PR TITLE
Fix non-bmp first character split issue

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AvatarDrawable.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AvatarDrawable.java
@@ -167,6 +167,12 @@ public class AvatarDrawable extends Drawable {
         color = value;
     }
 
+    // http://stackoverflow.com/a/21398030/1414809
+    // substring useful for non-bmp character
+    static String substring(String str, int idx, int len) {
+        return str.substring(idx, str.offsetByCodePoints(idx, len));
+    }
+
     public void setInfo(int id, String firstName, String lastName, boolean isBroadcast) {
         if (isProfile) {
             color = arrColorsProfiles[getColorIndex(id)];
@@ -183,7 +189,7 @@ public class AvatarDrawable extends Drawable {
 
         stringBuilder.setLength(0);
         if (firstName != null && firstName.length() > 0) {
-            stringBuilder.append(firstName.substring(0, 1));
+            stringBuilder.append(substring(firstName, 0, 1));
         }
         if (lastName != null && lastName.length() > 0) {
             String lastch = null;
@@ -191,7 +197,7 @@ public class AvatarDrawable extends Drawable {
                 if (lastch != null && lastName.charAt(a) == ' ') {
                     break;
                 }
-                lastch = lastName.substring(a, a + 1);
+                lastch = substring(lastName, a, 1);
             }
             if (Build.VERSION.SDK_INT >= 16) {
                 stringBuilder.append("\u200C");
@@ -204,7 +210,7 @@ public class AvatarDrawable extends Drawable {
                         if (Build.VERSION.SDK_INT >= 16) {
                             stringBuilder.append("\u200C");
                         }
-                        stringBuilder.append(firstName.substring(a + 1, a + 2));
+                        stringBuilder.append(substring(firstName, a + 1, 1));
                         break;
                     }
                 }


### PR DESCRIPTION
If you set your last name to a name started with an emoji (as a non-bmp character) you will get invalid character shape. This _UNTESTED_ patch tries to resolve it by incorporating offsetByCodePoints for splitting first character instead. Someone should check if this fix the issue before the merge of course, I just speculatively patched it with a tablet as my lack of access to a suitable for development machine so pardon me before hand if it has any issue, I guess this at least leads to an actual fix in case itself couldn't.

Steps to repro the issue this patch tries to fix:
1. Set your last name or first to an Emoji (or any non-bmp characters, say a historical character)
2. Open the drawer of the app and look at your text avatar, if you didn't set an avatar yet of course
Actual:
You see something like an unrecognized character as first character splittion failed.
Expected (with the patch):
You don't see anything weird
