### PR TITLE
Support Split Window on LG devices

### DIFF
--- a/TMessagesProj/src/main/AndroidManifest.xml
+++ b/TMessagesProj/src/main/AndroidManifest.xml
@@ -210,6 +210,7 @@
 
         <meta-data android:name="com.google.android.gms.car.application" android:resource="@xml/automotive_app_desc" />
 
+        <meta-data android:name="com.lge.support.SPLIT_WINDOW" android:value="true"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
In order to support Split Window on LG devices we just need to edit AndroidManifest.xml