### PR TITLE
issue #1179 - change notifications so the oldest messages are on top;

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/NotificationsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/NotificationsController.java
@@ -467,7 +467,7 @@ public class NotificationsController {
                             notifyOverride = 1;
                         }
                     }
-                    boolean canAddValue = !(notifyOverride == 2 || (!preferences.getBoolean("EnableAll", true) || ((int)dialog_id < 0) && !preferences.getBoolean("EnableGroup", true)) && notifyOverride == 0);
+                    boolean canAddValue = !(notifyOverride == 2 || (!preferences.getBoolean("EnableAll", true) || ((int) dialog_id < 0) && !preferences.getBoolean("EnableGroup", true)) && notifyOverride == 0);
 
                     Integer currentCount = pushDialogs.get(dialog_id);
                     Integer newCount = entry.getValue();
@@ -1326,26 +1326,40 @@ public class NotificationsController {
                 mBuilder.setContentText(detailText);
                 NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle();
                 inboxStyle.setBigContentTitle(name);
-                int count = Math.min(10, pushMessages.size());
-                for (int i = 0; i < count; i++) {
-                    String message = getStringForMessage(pushMessages.get(i), false);
-                    if (message == null) {
-                        continue;
-                    }
-                    if (i == 0) {
-                        lastMessage = message;
-                    }
-                    if (pushDialogs.size() == 1) {
-                        if (replace) {
-                            if (chat != null) {
-                                message = message.replace(" @ " + name, "");
-                            } else {
-                                message = message.replace(name + ": ", "").replace(name + " ", "");
+                int limit = 7;
+                int count = Math.min(limit, pushMessages.size());
+
+                boolean newOnTop = preferences.getBoolean("messageOrder", true);
+                
+                    for (int i = 0; i < count; i++) {
+                        int tmp = i;
+                        if (!newOnTop) {
+                            tmp = limit - 1  - i;
+                        }
+
+                        String message = getStringForMessage(pushMessages.get(tmp), false);
+                        if (message == null) {
+                            continue;
+                        }
+                        if (tmp == 0) {
+                            lastMessage = message;
+                        }
+                        if (pushDialogs.size() == 1) {
+                            if (replace) {
+                                if (chat != null) {
+                                    message = message.replace(" @ " + name, "");
+                                } else {
+                                    message = message.replace(name + ": ", "").replace(name + " ", "");
+                                }
                             }
                         }
+                        inboxStyle.addLine(message);
                     }
-                    inboxStyle.addLine(message);
+
+                if (pushMessages.size() > limit) {
+                    detailText += " +";
                 }
+
                 inboxStyle.setSummaryText(detailText);
                 mBuilder.setStyle(inboxStyle);
             }

--- a/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
@@ -88,6 +88,7 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
     private int otherSectionRow2;
     private int otherSectionRow;
     private int badgeNumberRow;
+    private int messageOrderRow;
     private int androidAutoAlertRow;
     private int repeatRow;
     private int resetSectionRow2;
@@ -141,6 +142,7 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
         otherSectionRow2 = rowCount++;
         otherSectionRow = rowCount++;
         badgeNumberRow = rowCount++;
+        messageOrderRow = rowCount++;
         androidAutoAlertRow = -1;
         repeatRow = rowCount++;
         resetSectionRow2 = rowCount++;
@@ -332,6 +334,12 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
                     editor.putBoolean("badgeNumber", !enabled);
                     editor.commit();
                     NotificationsController.getInstance().setBadgeEnabled(!enabled);
+                } else if (i == messageOrderRow) {
+                    SharedPreferences preferences = ApplicationLoader.applicationContext.getSharedPreferences("Notifications", Activity.MODE_PRIVATE);
+                    SharedPreferences.Editor editor = preferences.edit();
+                    enabled = preferences.getBoolean("messageOrder", true);
+                    editor.putBoolean("messageOrder", !enabled);
+                    editor.commit();
                 } else if (i == notificationsServiceRow) {
                     final SharedPreferences preferences = ApplicationLoader.applicationContext.getSharedPreferences("Notifications", Activity.MODE_PRIVATE);
                     enabled = preferences.getBoolean("pushService", true);
@@ -716,6 +724,8 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
                     checkCell.setTextAndCheck(LocaleController.getString("NotificationsService", R.string.NotificationsService), preferences.getBoolean("pushService", true), false);
                 } else if (i == badgeNumberRow) {
                     checkCell.setTextAndCheck(LocaleController.getString("BadgeNumber", R.string.BadgeNumber), preferences.getBoolean("badgeNumber", true), true);
+                } else if (i == messageOrderRow) {
+                    checkCell.setTextAndCheck(LocaleController.getString("MessageOrder", R.string.MessageOrder), preferences.getBoolean("messageOrder", true), true);
                 } else if (i == inchatSoundRow) {
                     checkCell.setTextAndCheck(LocaleController.getString("InChatSound", R.string.InChatSound), preferences.getBoolean("EnableInChatSound", true), true);
                 }
@@ -838,7 +848,8 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
             } else if (i == messageAlertRow || i == messagePreviewRow || i == groupAlertRow ||
                     i == groupPreviewRow || i == inappSoundRow || i == inappVibrateRow ||
                     i == inappPreviewRow || i == contactJoinedRow ||
-                    i == notificationsServiceRow || i == badgeNumberRow || i == inappPriorityRow ||
+                    i == notificationsServiceRow || i == badgeNumberRow || i == messageOrderRow ||
+                    i == inappPriorityRow ||
                     i == inchatSoundRow || i == androidAutoAlertRow) {
                 return 1;
             } else if (i == messageLedRow || i == groupLedRow) {

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -460,6 +460,7 @@
     <string name="OnlyWhenScreenOff">Only when screen \"off\"</string>
     <string name="AlwaysShowPopup">Always show popup</string>
     <string name="BadgeNumber">Badge Counter</string>
+    <string name="MessageOrder">New notifications on top</string>
     <string name="Short">Short</string>
     <string name="Long">Long</string>
     <string name="SystemDefault">System default</string>


### PR DESCRIPTION
(I haven't done anything for android before so this is my first attempt at this)

issue #1179 - change notifications so the oldest messages are on top; it's also possible to configure preferred way of display and small "+" in the summary to indicate that there are more messages than being displayed.
