### PR TITLE
shows emoji button instead of the return one

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -334,7 +334,7 @@ public class ChatActivityEnterView extends FrameLayoutFixed implements Notificat
         };
         updateFieldHint();
         messageEditText.setImeOptions(EditorInfo.IME_FLAG_NO_EXTRACT_UI);
-        messageEditText.setInputType(messageEditText.getInputType() | EditorInfo.TYPE_TEXT_FLAG_CAP_SENTENCES | EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE);
+        messageEditText.setInputType(messageEditText.getInputType() | EditorInfo.TYPE_TEXT_FLAG_CAP_SENTENCES | EditorInfo.TYPE_TEXT_VARIATION_SHORT_MESSAGE);
         messageEditText.setSingleLine(false);
         messageEditText.setMaxLines(4);
         messageEditText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 18);


### PR DESCRIPTION
Forces the keyboard to show emoji button instead of enter - more handy in a chat application where there is abundance of single-liners with smiley at the end
#1168 - old issue number which is gone now
