### PR TITLE
Corrected a typo in the "<insert people> are typing" string.

### DIFF
--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -844,7 +844,7 @@
     <string name="Members_many">%1$d members</string>
     <string name="Members_other">%1$d members</string>
     <string name="AndMoreTyping_zero">and %1$d more people are typing</string>
-    <string name="AndMoreTyping_one">and %1$d more people are typing</string>
+    <string name="AndMoreTyping_one">and %1$d more person are typing</string>
     <string name="AndMoreTyping_two">and %1$d more people are typing</string>
     <string name="AndMoreTyping_few">and %1$d more people are typing</string>
     <string name="AndMoreTyping_many">and %1$d more people are typing</string>


### PR DESCRIPTION
It used to read "Mark, Sarah, and 1 other people are typing". In the case of 1 other person, it should read "Mark, Sarah, and 1 other person are typing".