### PR TITLE
Increase limit to linkify phone numbers from 100 to 200

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -782,7 +782,7 @@ public class MessageObject {
 
     public static void addLinks(CharSequence messageText, boolean botCommands) {
         if (messageText instanceof Spannable && containsUrls(messageText)) {
-            if (messageText.length() < 100) {
+            if (messageText.length() < 200) {
                 try {
                     Linkify.addLinks((Spannable) messageText, Linkify.WEB_URLS | Linkify.PHONE_NUMBERS);
                 } catch (Exception e) {


### PR DESCRIPTION
100 symbols is too few to make sending phone cards (not telegram users' cards, but any phone cards).