### PR TITLE
To recognize wav and aac files being sent from other apps as audio instead of file attachment

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
@@ -2063,7 +2063,7 @@ public class SendMessagesHelper implements NotificationCenter.NotificationCenter
         if (idx != -1) {
             ext = path.substring(idx + 1);
         }
-        if (ext.toLowerCase().equals("mp3") || ext.toLowerCase().equals("m4a")) {
+        if (ext.toLowerCase().equals("mp3") || ext.toLowerCase().equals("m4a") || ext.toLowerCase().equals("wav") || ext.toLowerCase().equals("aac")) {
             AudioInfo audioInfo = AudioInfo.getAudioInfo(f);
             if (audioInfo != null && audioInfo.getDuration() != 0) {
                 if (isEncrypted) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/audioinfo/AudioInfo.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/audioinfo/AudioInfo.java
@@ -145,7 +145,7 @@ public abstract class AudioInfo {
             if (header[4] == 'f' && header[5] == 't' && header[6] == 'y' && header[7] == 'p') {
                 return new M4AInfo(input);
             } else {
-                return new MP3Info(input, file.length());
+                return new MP3Info(input, file);
             }
         } catch (Exception e) {
             return null;


### PR DESCRIPTION
When other apps sends a wav or aac audio clips using intent, because its duration cannot be determined it is being attached as file attachment. With this change they can be played using internal media player without issue.