### PR TITLE
Location sharing enhancements

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
@@ -3614,6 +3614,29 @@ public class SendMessagesHelper implements NotificationCenter.NotificationCenter
         });
     }
 
+    public static void prepareSendingLocation(final Location location, final long dialog_id) {
+        MessagesStorage.getInstance().getStorageQueue().postRunnable(new Runnable() {
+            @Override
+            public void run() {
+                Utilities.stageQueue.postRunnable(new Runnable() {
+                    @Override
+                    public void run() {
+                        AndroidUtilities.runOnUIThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                TLRPC.TL_messageMediaGeo mediaGeo = new TLRPC.TL_messageMediaGeo();
+                                mediaGeo.geo = new TLRPC.TL_geoPoint();
+                                mediaGeo.geo.lat = location.getLatitude();
+                                mediaGeo.geo._long = location.getLongitude();
+                                SendMessagesHelper.getInstance().sendMessage(mediaGeo, dialog_id, null, null, null);
+                            }
+                        });
+                    }
+                });
+            }
+        });
+    }
+
     public static void prepareSendingPhotos(ArrayList<String> paths, ArrayList<Uri> uris, final long dialog_id, final MessageObject reply_to_msg, final ArrayList<String> captions, final ArrayList<ArrayList<TLRPC.InputDocument>> masks, final InputContentInfoCompat inputContent, final boolean forceDocument, final ArrayList<Integer> ttls) {
         if (paths == null && uris == null || paths != null && paths.isEmpty() || uris != null && uris.isEmpty()) {
             return;

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -9936,6 +9936,18 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                             }
                         } else if (message.type == 4) {
                             if (!AndroidUtilities.isGoogleMapsInstalled(ChatActivity.this)) {
+                                double lat = message.messageOwner.media.geo.lat;
+                                double lon = message.messageOwner.media.geo._long;
+                                Intent intent = new Intent(android.content.Intent.ACTION_VIEW,
+                                        Uri.parse("geo:" + lat + "," + lon + "?z=15&q=" + lat + "," + lon ));
+                                if(intent.resolveActivity(getParentActivity().getPackageManager()) != null) {
+                                    try{
+                                        getParentActivity().startActivity(intent);
+                                    }
+                                    catch (Exception e){
+                                        FileLog.e("tmessages", e);
+                                    }
+                                }
                                 return;
                             }
                             LocationActivity fragment = new LocationActivity();

--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -20,6 +20,7 @@ import android.database.Cursor;
 import android.graphics.Point;
 import android.graphics.Shader;
 import android.graphics.drawable.BitmapDrawable;
+import android.location.Location;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -91,11 +92,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class LaunchActivity extends Activity implements ActionBarLayout.ActionBarLayoutDelegate, NotificationCenter.NotificationCenterDelegate, DialogsActivity.DialogsActivityDelegate {
 
     private boolean finished;
     private String videoPath;
+    final private Pattern r = Pattern.compile("geo: ?(-?\\d+\\.\\d+),(-?\\d+\\.\\d+)(,|\\?z=)(-?\\d+)");
+    private Location sendingLocation;
     private String sendingText;
     private ArrayList<Uri> photoPathsArray;
     private ArrayList<String> documentsPathsArray;
@@ -808,8 +813,13 @@ public class LaunchActivity extends Activity implements ActionBarLayout.ActionBa
                                 }
                             }
                             String subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
-
-                            if (text != null && text.length() != 0) {
+                            Matcher m = r.matcher(text);
+                            if(m.find()) {
+                                sendingLocation = new Location("");
+                                sendingLocation.setLatitude(Double.parseDouble(m.group(1)));
+                                sendingLocation.setLongitude(Double.parseDouble(m.group(2)));
+                            }
+                            else if (text != null && text.length() != 0) {
                                 if ((text.startsWith("http://") || text.startsWith("https://")) && subject != null && subject.length() != 0) {
                                     text = subject + "\n" + text;
                                 }
@@ -861,7 +871,7 @@ public class LaunchActivity extends Activity implements ActionBarLayout.ActionBa
                                         }
                                     }
                                 }
-                            } else if (sendingText == null) {
+                            } else if (sendingText == null && sendingLocation == null) {
                                 error = true;
                             }
                         }
@@ -1208,7 +1218,7 @@ public class LaunchActivity extends Activity implements ActionBarLayout.ActionBa
                 }
                 actionBarLayout.presentFragment(new AudioPlayerActivity(), false, true, true);
                 pushOpened = true;
-            } else if (videoPath != null || photoPathsArray != null || sendingText != null || documentsPathsArray != null || contactsToSend != null || documentsUrisArray != null) {
+            } else if (videoPath != null || photoPathsArray != null || sendingText != null || sendingLocation != null || documentsPathsArray != null || contactsToSend != null || documentsUrisArray != null) {
                 if (!AndroidUtilities.isTablet()) {
                     NotificationCenter.getInstance().postNotificationName(NotificationCenter.closeChats);
                 }
@@ -1765,7 +1775,9 @@ public class LaunchActivity extends Activity implements ActionBarLayout.ActionBa
                 if (sendingText != null) {
                     SendMessagesHelper.prepareSendingText(sendingText, dialog_id);
                 }
-
+                if (sendingLocation != null) {
+                    SendMessagesHelper.prepareSendingLocation(sendingLocation, dialog_id);
+                }
                 if (documentsPathsArray != null || documentsUrisArray != null) {
                     SendMessagesHelper.prepareSendingDocuments(documentsPathsArray, documentsOriginalPathsArray, documentsUrisArray, documentsMimeType, dialog_id, null, null);
                 }
@@ -1779,6 +1791,7 @@ public class LaunchActivity extends Activity implements ActionBarLayout.ActionBa
             photoPathsArray = null;
             videoPath = null;
             sendingText = null;
+            sendingLocation = null;
             documentsPathsArray = null;
             documentsOriginalPathsArray = null;
             contactsToSend = null;


### PR DESCRIPTION
This PR adds two independent, small enhancements:
-  Add sending location objects via geo: message. 
  This patch add the ability for Telegram to parse locations form messages containing a `geo:<lat>,<lon>,<zoom>` string.
  This is used by various map applications including the popular OSMAnd and Orux maps. This patch enables the user to share the position of a POI or destination with Telegram and have it send as a location.
-  Add support for opening locations without gmaps.
  When google maps is not found on the device, try to open a location message with a `geo:` intent so it can be interpreted by any other maps application.
