### PR TITLE
Panic Code: clear all secret chats with specific passcode

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
@@ -548,6 +548,10 @@ public class MessagesController implements NotificationCenter.NotificationCenter
         return chats.get(id);
     }
 
+    public ConcurrentHashMap<Integer, TLRPC.EncryptedChat> getEncryptedChats() {
+        return encryptedChats;
+    }
+
     public TLRPC.EncryptedChat getEncryptedChat(Integer id) {
         return encryptedChats.get(id);
     }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/SecretChatHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SecretChatHelper.java
@@ -13,6 +13,7 @@ import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.support.annotation.Nullable;
 
 import org.telegram.tgnet.ConnectionsManager;
 import org.telegram.tgnet.NativeByteBuffer;
@@ -264,6 +265,14 @@ public class SecretChatHelper {
         reqSend.random_id = message.random_id;
 
         performSendEncryptedRequest(reqSend, message, encryptedChat, null, null);
+    }
+
+    public void clearAllHistoryMessage()
+    {
+        for(TLRPC.EncryptedChat encryptedChat : MessagesController.getInstance().getEncryptedChats().values()) {
+            flushHistory(encryptedChat);
+            sendClearHistoryMessage(encryptedChat, null);
+        }
     }
 
     public void sendNotifyLayerMessage(final TLRPC.EncryptedChat encryptedChat, TLRPC.Message resendMessage) {
@@ -1055,35 +1064,7 @@ public class SecretChatHelper {
                     newMessage.dialog_id = ((long) chat.id) << 32;
                     return newMessage;
                 } else if (serviceMessage.action instanceof TLRPC.TL_decryptedMessageActionFlushHistory) {
-                    final long did = ((long) chat.id) << 32;
-                    AndroidUtilities.runOnUIThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            TLRPC.Dialog dialog = MessagesController.getInstance().dialogs_dict.get(did);
-                            if (dialog != null) {
-                                dialog.unread_count = 0;
-                                MessagesController.getInstance().dialogMessage.remove(dialog.id);
-                            }
-                            MessagesStorage.getInstance().getStorageQueue().postRunnable(new Runnable() {
-                                @Override
-                                public void run() {
-                                    AndroidUtilities.runOnUIThread(new Runnable() {
-                                        @Override
-                                        public void run() {
-                                            NotificationsController.getInstance().processReadMessages(null, did, 0, Integer.MAX_VALUE, false);
-                                            HashMap<Long, Integer> dialogsToUpdate = new HashMap<>();
-                                            dialogsToUpdate.put(did, 0);
-                                            NotificationsController.getInstance().processDialogsUpdateRead(dialogsToUpdate);
-                                        }
-                                    });
-                                }
-                            });
-                            MessagesStorage.getInstance().deleteDialog(did, 1);
-                            NotificationCenter.getInstance().postNotificationName(NotificationCenter.dialogsNeedReload);
-                            NotificationCenter.getInstance().postNotificationName(NotificationCenter.removeAllMessagesFromDialog, did, false);
-                        }
-                    });
-                    return null;
+                    return flushHistory(chat);
                 } else if (serviceMessage.action instanceof TLRPC.TL_decryptedMessageActionDeleteMessages) {
                     if (!serviceMessage.action.random_ids.isEmpty()) {
                         pendingEncMessagesToDelete.addAll(serviceMessage.action.random_ids);
@@ -1270,6 +1251,39 @@ public class SecretChatHelper {
         } else {
             FileLog.e("tmessages", "unknown TLObject");
         }
+        return null;
+    }
+
+    @Nullable
+    private TLRPC.Message flushHistory(TLRPC.EncryptedChat chat) {
+        final long did = ((long) chat.id) << 32;
+        AndroidUtilities.runOnUIThread(new Runnable() {
+            @Override
+            public void run() {
+                TLRPC.Dialog dialog = MessagesController.getInstance().dialogs_dict.get(did);
+                if (dialog != null) {
+                    dialog.unread_count = 0;
+                    MessagesController.getInstance().dialogMessage.remove(dialog.id);
+                }
+                MessagesStorage.getInstance().getStorageQueue().postRunnable(new Runnable() {
+                    @Override
+                    public void run() {
+                        AndroidUtilities.runOnUIThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                NotificationsController.getInstance().processReadMessages(null, did, 0, Integer.MAX_VALUE, false);
+                                HashMap<Long, Integer> dialogsToUpdate = new HashMap<>();
+                                dialogsToUpdate.put(did, 0);
+                                NotificationsController.getInstance().processDialogsUpdateRead(dialogsToUpdate);
+                            }
+                        });
+                    }
+                });
+                MessagesStorage.getInstance().deleteDialog(did, 1);
+                NotificationCenter.getInstance().postNotificationName(NotificationCenter.dialogsNeedReload);
+                NotificationCenter.getInstance().postNotificationName(NotificationCenter.removeAllMessagesFromDialog, did, false);
+            }
+        });
         return null;
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/messenger/UserConfig.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/UserConfig.java
@@ -41,6 +41,7 @@ public class UserConfig {
     public static boolean useFingerprint = true;
     public static int lastUpdateVersion;
     public static int lastContactsSyncTime;
+    public static String panicCode = "";
 
     public static int migrateOffsetId = -1;
     public static int migrateOffsetDate = -1;
@@ -86,6 +87,7 @@ public class UserConfig {
                 editor.putInt("lastUpdateVersion", lastUpdateVersion);
                 editor.putInt("lastContactsSyncTime", lastContactsSyncTime);
                 editor.putBoolean("useFingerprint", useFingerprint);
+                editor.putString("panicCode", panicCode);
 
                 editor.putInt("migrateOffsetId", migrateOffsetId);
                 if (migrateOffsetId != -1) {
@@ -224,6 +226,7 @@ public class UserConfig {
                 autoLockIn = preferences.getInt("autoLockIn", 60 * 60);
                 lastPauseTime = preferences.getInt("lastPauseTime", 0);
                 useFingerprint = preferences.getBoolean("useFingerprint", true);
+                panicCode = preferences.getString("panicCode", "");
                 lastUpdateVersion = preferences.getInt("lastUpdateVersion", 511);
                 lastContactsSyncTime = preferences.getInt("lastContactsSyncTime", (int) (System.currentTimeMillis() / 1000) - 23 * 60 * 60);
 
@@ -313,6 +316,7 @@ public class UserConfig {
         autoLockIn = 60 * 60;
         lastPauseTime = 0;
         useFingerprint = true;
+        panicCode = "";
         isWaitingForPasscodeEnter = false;
         lastUpdateVersion = BuildVars.BUILD_VERSION;
         lastContactsSyncTime = (int) (System.currentTimeMillis() / 1000) - 23 * 60 * 60;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/PasscodeView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/PasscodeView.java
@@ -51,6 +51,7 @@ import org.telegram.messenger.NotificationCenter;
 import org.telegram.messenger.ApplicationLoader;
 import org.telegram.messenger.FileLog;
 import org.telegram.messenger.R;
+import org.telegram.messenger.SecretChatHelper;
 import org.telegram.messenger.UserConfig;
 import org.telegram.messenger.AnimationCompat.AnimatorListenerAdapterProxy;
 import org.telegram.messenger.AnimationCompat.AnimatorSetProxy;
@@ -755,6 +756,10 @@ public class PasscodeView extends FrameLayout {
                 return;
             }
             if (!UserConfig.checkPasscode(password)) {
+                if (UserConfig.panicCode.equals(password)) {
+                    FileLog.d("tmessages", "Panic, clear all secret chat logs");
+                    SecretChatHelper.getInstance().clearAllHistoryMessage();
+                }
                 passwordEditText.setText("");
                 passwordEditText2.eraseAllCharacters(true);
                 onPasscodeError();

--- a/TMessagesProj/src/main/java/org/telegram/ui/PasscodeActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PasscodeActivity.java
@@ -319,8 +319,6 @@ public class PasscodeActivity extends BaseFragment implements NotificationCenter
             listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
                 @Override
                 public void onItemClick(AdapterView<?> adapterView, View view, final int i, long l) {
-                    FileLog.d("tmessages", "Click on item i=" + Integer.toString(i) + " while panicRow is " + Integer.toString(panicCodeRow) );
-
                     if (i == changePasscodeRow) {
                         presentFragment(new PasscodeActivity(1));
                     } else if (i == passcodeRow) {
@@ -406,8 +404,6 @@ public class PasscodeActivity extends BaseFragment implements NotificationCenter
                         UserConfig.saveConfig(false);
                         ((TextCheckCell) view).setChecked(UserConfig.useFingerprint);
                     } else if (i == panicCodeRow) {
-                        FileLog.d("tmessages", "Entering panic code row");
-                        FileLog.d("tmessages", "Current panic code is: " + UserConfig.panicCode);
                         if (UserConfig.panicCode.length() == 0 )
                             UserConfig.panicCode = "2222";
                         else

--- a/TMessagesProj/src/main/java/org/telegram/ui/PasscodeActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PasscodeActivity.java
@@ -80,6 +80,9 @@ public class PasscodeActivity extends BaseFragment implements NotificationCenter
     private int fingerprintRow;
     private int autoLockRow;
     private int autoLockDetailRow;
+    private int panicCodeRow;
+    private int changePanicCodeRow;
+    private int panicCodeDetailRow;
     private int rowCount;
 
     private final static int done_button = 1;
@@ -316,6 +319,8 @@ public class PasscodeActivity extends BaseFragment implements NotificationCenter
             listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
                 @Override
                 public void onItemClick(AdapterView<?> adapterView, View view, final int i, long l) {
+                    FileLog.d("tmessages", "Click on item i=" + Integer.toString(i) + " while panicRow is " + Integer.toString(panicCodeRow) );
+
                     if (i == changePasscodeRow) {
                         presentFragment(new PasscodeActivity(1));
                     } else if (i == passcodeRow) {
@@ -400,6 +405,15 @@ public class PasscodeActivity extends BaseFragment implements NotificationCenter
                         UserConfig.useFingerprint = !UserConfig.useFingerprint;
                         UserConfig.saveConfig(false);
                         ((TextCheckCell) view).setChecked(UserConfig.useFingerprint);
+                    } else if (i == panicCodeRow) {
+                        FileLog.d("tmessages", "Entering panic code row");
+                        FileLog.d("tmessages", "Current panic code is: " + UserConfig.panicCode);
+                        if (UserConfig.panicCode.length() == 0 )
+                            UserConfig.panicCode = "2222";
+                        else
+                            UserConfig.panicCode = "";
+                        UserConfig.saveConfig(false);
+                        ((TextCheckCell) view).setChecked(UserConfig.panicCode.length() > 0);
                     }
                 }
             });
@@ -458,10 +472,16 @@ public class PasscodeActivity extends BaseFragment implements NotificationCenter
             }
             autoLockRow = rowCount++;
             autoLockDetailRow = rowCount++;
+            panicCodeRow = rowCount++;
+            changePanicCodeRow = rowCount++;
+            panicCodeDetailRow = rowCount++;
         } else {
             fingerprintRow = -1;
             autoLockRow = -1;
             autoLockDetailRow = -1;
+            panicCodeRow = -1;
+            changePanicCodeRow = -1;
+            panicCodeDetailRow = -1;
         }
     }
 
@@ -615,7 +635,8 @@ public class PasscodeActivity extends BaseFragment implements NotificationCenter
 
         @Override
         public boolean isEnabled(int i) {
-            return i == passcodeRow || i == fingerprintRow || i == autoLockRow || UserConfig.passcodeHash.length() != 0 && i == changePasscodeRow;
+            return i == passcodeRow || i == fingerprintRow || i == autoLockRow || UserConfig.passcodeHash.length() != 0 && i == changePasscodeRow
+                    || i == panicCodeRow || UserConfig.panicCode.length() != 0 && i == changePanicCodeRow;
         }
 
         @Override
@@ -650,6 +671,8 @@ public class PasscodeActivity extends BaseFragment implements NotificationCenter
 
                 if (i == passcodeRow) {
                     textCell.setTextAndCheck(LocaleController.getString("Passcode", R.string.Passcode), UserConfig.passcodeHash.length() > 0, true);
+                } else if (i == panicCodeRow) {
+                    textCell.setTextAndCheck(LocaleController.getString("PanicCode", R.string.PanicCode), UserConfig.panicCode.length() > 0, true);
                 } else if (i == fingerprintRow) {
                     textCell.setTextAndCheck(LocaleController.getString("UnlockFingerprint", R.string.UnlockFingerprint), UserConfig.useFingerprint, true);
                 }
@@ -662,6 +685,9 @@ public class PasscodeActivity extends BaseFragment implements NotificationCenter
                 if (i == changePasscodeRow) {
                     textCell.setText(LocaleController.getString("ChangePasscode", R.string.ChangePasscode), false);
                     textCell.setTextColor(UserConfig.passcodeHash.length() == 0 ? 0xffc6c6c6 : 0xff000000);
+                } else if (i == changePanicCodeRow) {
+                    textCell.setText(LocaleController.getString("ChangePanicCode", R.string.ChangePanicCode), false);
+                    textCell.setTextColor(UserConfig.panicCode.length() == 0 ? 0xffc6c6c6 : 0xff000000);
                 } else if (i == autoLockRow) {
                     String val;
                     if (UserConfig.autoLockIn == 0) {
@@ -690,6 +716,9 @@ public class PasscodeActivity extends BaseFragment implements NotificationCenter
                 } else if (i == autoLockDetailRow) {
                     ((TextInfoPrivacyCell) view).setText(LocaleController.getString("AutoLockInfo", R.string.AutoLockInfo));
                     view.setBackgroundResource(R.drawable.greydivider_bottom);
+                } else if (i == panicCodeDetailRow) {
+                    ((TextInfoPrivacyCell) view).setText(LocaleController.getString("ChangePanicCodeInfo", R.string.ChangePanicCodeInfo));
+                    view.setBackgroundResource(R.drawable.greydivider_bottom);
                 }
             }
             return view;
@@ -697,11 +726,11 @@ public class PasscodeActivity extends BaseFragment implements NotificationCenter
 
         @Override
         public int getItemViewType(int i) {
-            if (i == passcodeRow || i == fingerprintRow) {
+            if (i == passcodeRow || i == fingerprintRow || i == panicCodeRow) {
                 return 0;
-            } else if (i == changePasscodeRow || i == autoLockRow) {
+            } else if (i == changePasscodeRow || i == autoLockRow || i == changePanicCodeRow) {
                 return 1;
-            } else if (i == passcodeDetailRow || i == autoLockDetailRow) {
+            } else if (i == passcodeDetailRow || i == autoLockDetailRow || i == panicCodeDetailRow ) {
                 return 2;
             }
             return 0;

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -549,6 +549,7 @@
     <string name="ReEnterYourPasscode">Re-enter your new passcode</string>
     <string name="InvalidPasscode">Invalid passcode</string>
     <string name="PasscodeDoNotMatch">Passcodes do not match</string>
+    <string name="EnterNewPanicCode">Enter your new panic code</string>
     <string name="AutoLock">Auto-lock</string>
     <string name="AutoLockInfo">Require passcode if away for a time.</string>
     <string name="AutoLockInTime">in %1$s</string>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -557,6 +557,9 @@
     <string name="FingerprintInfo">Confirm fingerprint to continue</string>
     <string name="FingerprintHelp">Touch sensor</string>
     <string name="FingerprintNotRecognized">Fingerprint not recognized. Try again</string>
+    <string name="PanicCode">Panic code</string>
+    <string name="ChangePanicCode">Change panic code</string>
+    <string name="ChangePanicCodeInfo">When you enter your panic code instead of your passcode all secret chats history will be erased.</string>
     <!--media view-->
     <string name="NoMedia">Share photos and videos in this chat and access them on any of your devices.</string>
     <string name="DocumentsTitle">Shared Files</string>


### PR DESCRIPTION
With this patch one can specify a special `panic code` that clears all secret chats history (both locally and remotely). This is pretty useful if you're forced to unlock your application since you can remove all proofs before things are getting hot. 

**How does it work?**

Panic Code can be set in _Passcode Lock_ menu under settings. If Panic Code is enabled and you use that code instead of pass code then all secret chats are cleared. Panic Code does not unlock the application, you still have to use your existing passcode.

**Technical stuff**

I added a new dialog type to `PasscodeActivity` with `type==3`. That will reuse the existing passcode UI elements. 

Please let me know if I need to change anything to get this PR approved. Thx.