### PR TITLE
Fix clearItemsMethod at ActionBarMenu 

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBarMenu.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBarMenu.java
@@ -112,8 +112,8 @@ public class ActionBarMenu extends LinearLayout {
     }
 
     public void clearItems() {
-        for (int a = 0; a < getChildCount(); a++) {
-            View view = getChildAt(a);
+        while(getChildCount() > 0) {
+            View view = getChildAt(0);
             removeView(view);
         }
     }


### PR DESCRIPTION
Old `clearItems` method at `ActionBarMenu` doesn't clear view correctly.
Each iteration remove one `View` from parent `View`, that is a `getChildCount` method take incorrect value.
Some example:
getChildCount = 4;

Some example:
a = 0, a<**4**, removeView (getChildCount = getChildCount-1)
a = 1, a<**3**, removeView
a = 2, a<**2**,, removeView
exit cycle.

*_The last menu item isn't removed_*