### PR TITLE
Move dependencies to main gradle.build

### DIFF
--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -5,16 +5,16 @@ repositories {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:23.4.0'
-    compile "com.google.android.gms:play-services-gcm:8.4.0"
-    compile "com.google.android.gms:play-services-maps:8.4.0"
-    compile 'net.hockeyapp.android:HockeySDK:4.0.1'
-    compile 'com.googlecode.mp4parser:isoparser:1.0.6'
+    compile deps.supportV4
+    compile deps.playServicesGcm
+    compile deps.playServicesMaps
+    compile deps.hockeySdk
+    compile deps.isoParser
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.3'
+    compileSdkVersion setup.compileSdkVersion
+    buildToolsVersion setup.buildToolsVersion
 
     useLibrary 'org.apache.http.legacy'
     defaultConfig.applicationId = "org.telegram.messenger"
@@ -112,8 +112,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 23
+        minSdkVersion setup.minSdkVersion
+        targetSdkVersion setup.targetSdkVersion
         versionName "3.10.1"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,22 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+
+    ext.setup = [compileSdkVersion : 23,
+                 buildToolsVersion: '23.0.3',
+                 minSdkVersion: 23,
+                 targetSdkVersion: 23]
+
+    ext.versions = [supportLibrary: "23.4.0",
+                    playServices: "8.4.0"]
+
+    ext.deps = [
+        supportV4       : "com.android.support:support-v4:$versions.supportLibrary",
+        playServicesGcm : "com.google.android.gms:play-services-gcm:$versions.playServices",
+        playServicesMaps: "com.google.android.gms:play-services-maps:$versions.playServices",
+        hockeySdk       : 'net.hockeyapp.android:HockeySDK:4.0.1',
+        isoParser       : 'com.googlecode.mp4parser:isoparser:1.0.6'
+    ]
+
     repositories {
         jcenter()
         mavenCentral()


### PR DESCRIPTION
With that you can add, update and reuse libraries easy and clean inside submodules
