### PR TITLE
Fixed a memory leak

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/camera/CameraController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/camera/CameraController.java
@@ -473,7 +473,10 @@ public class CameraController implements MediaRecorder.OnInfoListener {
             AndroidUtilities.runOnUIThread(new Runnable() {
                 @Override
                 public void run() {
-                    onVideoTakeCallback.onFinishVideoRecording(bitmap);
+                    if(onVideoTakeCallback != null) {
+                        onVideoTakeCallback.onFinishVideoRecording(bitmap);
+                        onVideoTakeCallback = null;
+                    }
                 }
             });
         }
@@ -497,7 +500,10 @@ public class CameraController implements MediaRecorder.OnInfoListener {
                 AndroidUtilities.runOnUIThread(new Runnable() {
                     @Override
                     public void run() {
-                        onVideoTakeCallback.onFinishVideoRecording(bitmap);
+                        if(onVideoTakeCallback != null) {
+                            onVideoTakeCallback.onFinishVideoRecording(bitmap);
+                            onVideoTakeCallback = null;
+                        }
                     }
                 });
             }


### PR DESCRIPTION
Usually `onVideoTakeCallback` is anonymous class in Fragment which causes memory leak when Fragment is no longer active. Setting onVideoTakeCallback to null when its no longer required fixes this issue.
