### PR TITLE
Fix blink screen on start app

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/PermissionsUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/PermissionsUtilities.java
@@ -1,0 +1,44 @@
+/*
+ * This is the source code of Telegram for Android v. 3.x.x.
+ * It is licensed under GNU GPL v. 2 or later.
+ * You should have received a copy of the license in this archive (see LICENSE).
+ *
+ * Copyright Nikolai Kudashov, 2013-2016.
+ */
+
+package org.telegram.messenger;
+
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.support.v4.content.ContextCompat;
+
+public abstract class PermissionsUtilities
+{
+    /**
+     * Simple check is permission are granted
+     */
+    public static boolean isGranted(Context context, String permission) {
+        return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    /**
+     * Returns true only if permission are not granted and user dont press "Never Ask Again" button previously
+     */
+    public static boolean isNeedToRequest(Activity activity, String permission) {
+        return !isGranted(activity, permission) && !isNeverAskAgainPressed(activity, permission);
+    }
+
+    /**
+     * Returns true if user pressed "Never Ask Again" button or
+     * if a device policy prohibits the app from having that permission
+     */
+    public static boolean isNeverAskAgainPressed(Activity activity, String permission) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return !activity.shouldShowRequestPermissionRationale(permission);
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Fix blink screen on start app if one of the permissions was rejected and "Never ask again" button was pressed.

**Problem:**
If one of the permissions (READ_CONTACTS or WRITE_EXTERNAL_STORAGE) was rejected by the user and user pressed the button "Never ask again", then after that, screen start to blink after start application.

**Сause:**
It happens because one of the functions **shouldShowRequestPermissionRationale** in **onResume** methode in **ui/DialogsActivity.java** returns **false** and else statement call **askForPermissons()** function where all permissions put in one List and immediately requesting. Android trying to request blocked permission (blocked by the user with "never ask again" button), and this cause screen blink.

```
if (activity.checkSelfPermission(Manifest.permission.READ_CONTACTS) != PackageManager.PERMISSION_GRANTED || activity.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
    if (activity.shouldShowRequestPermissionRationale(Manifest.permission.READ_CONTACTS)) {
         //showDialog
     } else if (activity.shouldShowRequestPermissionRationale(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
         //showDialog
     } else {
         askForPermissons();
     }
}
```

**Solution:**
Request permissions only if this permission not granted **and** not "Never ask again" button pressed.

I wrote small helper class with static functions. Sorry, i dont know in which one of the packages I can placed it.
This class created for using your requests with other you permissions.
Thanks for your work.