### PR TITLE
Use even numbers for resultWidth & resultHeight

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/VideoEditorActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/VideoEditorActivity.java
@@ -1115,8 +1115,8 @@ public class VideoEditorActivity extends BaseFragment implements NotificationCen
 
             if (resultWidth > 640 || resultHeight > 640) {
                 float scale = resultWidth > resultHeight ? 640.0f / resultWidth : 640.0f / resultHeight;
-                resultWidth *= scale;
-                resultHeight *= scale;
+                resultWidth = Math.round(resultWidth * scale / 2) * 2;
+                resultHeight = Math.round(resultHeight * scale / 2) * 2;
                 if (bitrate != 0) {
                     bitrate *= Math.max(0.5f, scale);
                     videoFramesSize = (long) (bitrate / 8 * videoDuration);


### PR DESCRIPTION
Had an issue (reproduced in your App) when transcoding from a 620x714 video input to a scaled down 555x640 output. The encoder was throwing during configuration. After some research this is apparently caused by odd output sizes (in the sample 555). Just by rounding to nearest even number this issue gets fixed.

I added the rounding code to the VideoEditorActivity.java since is where those values are being computed and the rounding happens, but this could be done/checked later on during transcoding in MediaController.