### PR TITLE
Fixed the second header appearance in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Telegram](https://telegram.org) is a messaging app with a focus on speed and security. It’s superfast, simple and free.
 This repo contains the official source code for [Telegram App for Android](https://play.google.com/store/apps/details?id=org.telegram.messenger).
 
-##Creating your Telegram Application
+## Creating your Telegram Application
 
 We welcome all developers to use our API and source code to create applications on our platform.
 There are several things we require from **all developers** for the moment.


### PR DESCRIPTION
Fixed the "Creating your Telegram Application" header.
Some browsers would show ## before the "Creating your Telegram Application".
This should now be fixed