### PR TITLE
Fix message notification priority

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/NotificationsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/NotificationsController.java
@@ -247,7 +247,7 @@ public class NotificationsController {
                             choosenSoundPath = preferences.getString("GlobalSoundPath", defaultPath);
                         }
                         needVibrate = preferences.getInt("vibrate_messages", 0);
-                        priority = preferences.getInt("priority_group", 1);
+                        priority = preferences.getInt("priority_messages", 1);
                         ledColor = preferences.getInt("MessagesLed", 0xff0000ff);
 
                         if (needVibrate == 4) {
@@ -1630,7 +1630,7 @@ public class NotificationsController {
                         choosenSoundPath = preferences.getString("GlobalSoundPath", defaultPath);
                     }
                     needVibrate = preferences.getInt("vibrate_messages", 0);
-                    priority = preferences.getInt("priority_group", 1);
+                    priority = preferences.getInt("priority_messages", 1);
                     ledColor = preferences.getInt("MessagesLed", 0xff0000ff);
                 }
                 if (custom) {


### PR DESCRIPTION
Use priority_messages instead of priority_group for message notifications

Expected behavior:

The "Priority" setting under "Settings > Notifications and Sounds > Message notifications" should control the priority for individual chat notifications, including whether a message will show a peek notification.

Observed behavior:

The Priority setting for Message Notifications does not do anything, while the Priority settting for Group notifications affects notifications for both individual chats and groups.