### PR TITLE
CameraView: add suport for 16:10 aspect ratio

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/camera/CameraView.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/camera/CameraView.java
@@ -128,7 +128,7 @@ public class CameraView extends FrameLayout implements TextureView.SurfaceTextur
             return;
         }
         float size4to3 = 4.0f / 3.0f;
-        float size16to9 = 16.0f / 9.0f;
+        float size16to10 = 16.0f / 10.0f;
         float screenSize = (float) Math.max(AndroidUtilities.displaySize.x, AndroidUtilities.displaySize.y) / Math.min(AndroidUtilities.displaySize.x, AndroidUtilities.displaySize.y);
         org.telegram.messenger.camera.Size aspectRatio;
         int wantedWidth;
@@ -142,6 +142,10 @@ public class CameraView extends FrameLayout implements TextureView.SurfaceTextur
                 aspectRatio = new Size(4, 3);
                 wantedWidth = 1280;
                 wantedHeight = 960;
+            } else if (Math.abs(screenSize - size16to10) < 0.1f) {
+                aspectRatio = new Size(16, 10);
+                wantedWidth = 1280;
+                wantedHeight = 800;
             } else {
                 aspectRatio = new Size(16, 9);
                 wantedWidth = 1280;
@@ -157,6 +161,8 @@ public class CameraView extends FrameLayout implements TextureView.SurfaceTextur
         if (pictureSize.getWidth() >= 1280 && pictureSize.getHeight() >= 1280) {
             if (Math.abs(screenSize - size4to3) < 0.1f) {
                 aspectRatio = new Size(3, 4);
+            } else if (Math.abs(screenSize - size16to10) < 0.1f) {
+                aspectRatio = new Size(10, 16);
             } else {
                 aspectRatio = new Size(9, 16);
             }


### PR DESCRIPTION
Fixes preview glithces on device with aspect ratio 16:10 (ex. 1280x800)

For example, my Galaxy Note (N7000), with HD display has resolution 1280x800 (the normal resolution for HD is 1280x720), and aspect ratio 16:10 (the normal is 16:9).

Telegram preview view, has glitch. Looks like colors marix is smaller then real photo. (see pic)
(Photo that i took with Telegram in-camera, is OK, no problem with them, glitches only in preview)

First pic (glitches in preview):
https://imgur.com/8WNO77c

Second pic (photo that it tooks):
https://imgur.com/OykIEoP

I made a patch to fix this bug, but i cant test it.
https://github.com/Saylance/Telegram/commit/5384210471a2e3a3f868c99fb65adda9078242c4

And generaly, its pretty crabby code, becouse now we have many aspect ratio of screens "Infinity" (trends of 2017), and we (have?) to manually hardcore them there?

(Anyway, maybe patch isnt work, i cant build this (without normal PC))
Thanks for help.