### PR TITLE
 Fix ThumbGenerate Task

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
@@ -547,7 +547,7 @@ public class ImageLoader {
                         removeTask();
                         return;
                     }
-                    originalBitmap = ImageLoader.loadBitmap(path, null, size, size, false);
+                    originalBitmap = ImageLoader.loadBitmap(originalPath.toString(), null, size, size, false);
                 }
                 if (originalBitmap == null) {
                     removeTask();


### PR DESCRIPTION
Path is case-sensitive

```
01-13 18:14:20.633 12002 12033 E BitmapFactory: Unable to decode stream: java.io.FileNotFoundException: /mnt/media_rw/125b-160c/telegram/telegram documents/1_5093868532026834962.png (No such file or directory)

kenzo:/ $ (ls "/mnt/media_rw/125b-160c/telegram/telegram documents/1_5093868532026834962.png" && echo Found) || echo Not Found
/mnt/media_rw/125b-160c/telegram/telegram documents/1_5093868532026834962.png
Not Found

kenzo:/ $ (ls "/mnt/media_rw/125B-160C/Telegram/Telegram Documents/1_5093868532026834962.png" && echo Found) || echo Not Found
/mnt/media_rw/125B-160C/Telegram/Telegram Documents/1_5093868532026834962.png
Found
```