### PR TITLE
Fix icon on Samsung Galaxy devices

### DIFF
--- a/TMessagesProj/src/main/AndroidManifest.xml
+++ b/TMessagesProj/src/main/AndroidManifest.xml
@@ -344,7 +344,6 @@
 
         <meta-data android:name="com.google.android.gms.vision.DEPENDENCIES" android:value="face" />
 
-        <meta-data android:name="com.samsung.android.icon_container.has_icon_container" android:value="true"/>
         <meta-data android:name="android.max_aspect" android:value="2.5" />
 
     </application>


### PR DESCRIPTION
The line I removed from the manifest makes it possible for the Samsung Galaxy framework to style the icon (adaptive icons, before adaptive icons were even a thing). This will add a colored "squircle" background, allowing Telegram to blend in.

I understand that many do not like the old, Note7 style "bland" icon, but this way the icon stands out too much from the rest of the apps. Also, so far it was Telegram (and clones) only that have employed this tactic, most likely by [this](https://medium.com/@AthorNZ/disabling-touchwiz-icon-frames-c7cb4b626180) "fix recommendation" - a.k.a. how to fuck up your app icon aesthetics on Samsung devices.

Unless the Telegram icon is changed to a Samsung-matching squircle style one, I think the best course of action would be removing this flag from the manifest.