### PR TITLE
For privacy reasons, we should give priority to internal storage cache

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
@@ -479,6 +479,14 @@ public class AndroidUtilities {
         } catch (Exception e) {
             FileLog.e(e);
         }
+        try {
+            File file = ApplicationLoader.applicationContext.getCacheDir();
+            if (file != null) {
+                return file;
+            }
+        } catch (Exception e) {
+            FileLog.e(e);
+        }
         if (state == null || state.startsWith(Environment.MEDIA_MOUNTED)) {
             try {
                 File file = ApplicationLoader.applicationContext.getExternalCacheDir();
@@ -488,14 +496,6 @@ public class AndroidUtilities {
             } catch (Exception e) {
                 FileLog.e(e);
             }
-        }
-        try {
-            File file = ApplicationLoader.applicationContext.getCacheDir();
-            if (file != null) {
-                return file;
-            }
-        } catch (Exception e) {
-            FileLog.e(e);
         }
         return new File("");
     }


### PR DESCRIPTION
Cache directory contains all thumbnails and image (also from secret chat). So we should check first if a private internal storage is available, and, if not, fallback to external.
We should save them in internal storage instead of publicly accessible external storage cache.