### PR TITLE
Fix NL typo in NewConversationShortcut

### DIFF
--- a/TMessagesProj/src/main/res/values-nl/strings.xml
+++ b/TMessagesProj/src/main/res/values-nl/strings.xml
@@ -110,7 +110,7 @@ Betalingen gaan direct naar de ontwikkelaar van %1$s. Telegram kan geen garantie
     <string name="PaymentEmailToProvider">E-mail wordt doorgegeven aan %1$s als factuurinformatie.</string>
     <string name="PaymentPhoneEmailToProvider">Telefoonnummer en E-mail worden doorgegeven aan %1$s als factuurinformatie.</string>
     <!--chats view-->
-    <string name="NewConversationShortcut">NIeuwe chat</string>
+    <string name="NewConversationShortcut">Nieuwe chat</string>
     <string name="Settings">Instellingen</string>
     <string name="Contacts">Contacten</string>
     <string name="NewGroup">Nieuwe groep</string>


### PR DESCRIPTION
When you longpress the Telegram icon on the startscreen it shows the text "NIeuwe groep" in Dutch. The second letter "I" is also uppercased. The good translations should be "Nieuwe groep".