### PR TITLE
Correct avatar_nameInMessage for violet and pink

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
@@ -1224,11 +1224,11 @@ public class Theme {
         defaultColors.put(key_avatar_subtitleInProfilePink, 0xffd7eafa);
         defaultColors.put(key_avatar_nameInMessageRed, 0xffca5650);
         defaultColors.put(key_avatar_nameInMessageOrange, 0xffd87b29);
-        defaultColors.put(key_avatar_nameInMessageViolet, 0xff4e92cc);
+        defaultColors.put(key_avatar_nameInMessageViolet, 0xff877ee2);
         defaultColors.put(key_avatar_nameInMessageGreen, 0xff50b232);
         defaultColors.put(key_avatar_nameInMessageCyan, 0xff42b1a8);
         defaultColors.put(key_avatar_nameInMessageBlue, 0xff4e92cc);
-        defaultColors.put(key_avatar_nameInMessagePink, 0xff4e92cc);
+        defaultColors.put(key_avatar_nameInMessagePink, 0xffe56e92);
         defaultColors.put(key_avatar_actionBarSelectorRed, 0xffbc4b41);
         defaultColors.put(key_avatar_actionBarSelectorOrange, 0xffe67429);
         defaultColors.put(key_avatar_actionBarSelectorViolet, 0xff735fbe);


### PR DESCRIPTION
Previously these colors were set to blue (same as `avatar_nameInMessage_blue`) in all default themes which is frustrating.

The chosen colors were calculated as (round(0.95 * r), round(0.95 * g), round(0.95 * b)) for corresponding `avatar_background` and tested using Telegram built-in theme editor with all three default themes and seem to look fine.