### PR TITLE
Bugfix: correctly render vcard of a selected inline query result

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
@@ -4620,6 +4620,7 @@ public class SendMessagesHelper implements NotificationCenter.NotificationCenter
             user.phone = result.send_message.phone_number;
             user.first_name = result.send_message.first_name;
             user.last_name = result.send_message.last_name;
+            user.restriction_reason = result.send_message.vcard;
             SendMessagesHelper.getInstance(currentAccount).sendMessage(user, dialog_id, reply_to_msg, result.send_message.reply_markup, params);
         }
     }


### PR DESCRIPTION
Currently when selecting a contact as inline query result which contains a vcard the vcard is not rendered at first.
After switching between chats the vcard is rendered correctly though.

**How to reproduce:**
Use a bot which returns contacts as inline results and select a contact - for testing you can use [@InlineVcardBug_bot](https://t.me/InlineVcardBug_bot), source [here](https://github.com/acran/InlineVcardBug_bot):
![1-inline-query](https://user-images.githubusercontent.com/4603809/46049254-b211cc00-c12d-11e8-9031-2fc3ab270211.png)

**What happens:**
 the selected contact is sent into the chat but the contained vcard is not rendered:
![2-broken-rendering](https://user-images.githubusercontent.com/4603809/46049255-b2aa6280-c12d-11e8-97dd-042940e144bb.png)

When leaving the chat and opening it again the vcard is displayed correctly:
![3-correct-rendering](https://user-images.githubusercontent.com/4603809/46049256-b2aa6280-c12d-11e8-8246-6a27dd60930d.png)

**What should happen:** the vcard gets rendered right away.

This pull request fixes this by correctly passing down any contained vcard.