### PR TITLE
Bugfix: Added correct match check of phone numbers.

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/CancelAccountDeletionActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/CancelAccountDeletionActivity.java
@@ -28,6 +28,7 @@ import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
+import android.telephony.PhoneNumberUtils;
 import android.telephony.SmsManager;
 import android.telephony.TelephonyManager;
 import android.text.Editable;
@@ -409,7 +410,7 @@ public class CancelAccountDeletionActivity extends BaseFragment {
                 try {
                     @SuppressLint("HardwareIds") String number = tm.getLine1Number();
                     if (!TextUtils.isEmpty(number)) {
-                        req.settings.current_number = phone.contains(number) || number.contains(phone);
+                        req.settings.current_number = PhoneNumberUtils.compare(phone, number);
                         if (!req.settings.current_number) {
                             req.settings.allow_flashcall = false;
                         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChangePhoneActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChangePhoneActivity.java
@@ -30,6 +30,7 @@ import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
+import android.telephony.PhoneNumberUtils;
 import android.telephony.SmsManager;
 import android.telephony.TelephonyManager;
 import android.text.Editable;
@@ -775,7 +776,7 @@ public class ChangePhoneActivity extends BaseFragment {
                 try {
                     @SuppressLint("HardwareIds") String number = tm.getLine1Number();
                     if (!TextUtils.isEmpty(number)) {
-                        req.settings.current_number = phone.contains(number) || number.contains(phone);
+                        req.settings.current_number = PhoneNumberUtils.compare(phone, number);
                         if (!req.settings.current_number) {
                             req.settings.allow_flashcall = false;
                         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
@@ -32,6 +32,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Vibrator;
+import android.telephony.PhoneNumberUtils;
 import android.telephony.SmsManager;
 import android.telephony.TelephonyManager;
 import android.text.Editable;
@@ -1198,7 +1199,7 @@ public class LoginActivity extends BaseFragment {
                         continue;
                     }
                     String userPhone = userConfig.getCurrentUser().phone;
-                    if (userPhone.contains(phone) || phone.contains(userPhone)) {
+                    if (PhoneNumberUtils.compare(phone, userPhone)) {
                         final int num = a;
                         AlertDialog.Builder builder = new AlertDialog.Builder(getParentActivity());
                         builder.setTitle(LocaleController.getString("AppName", R.string.AppName));
@@ -1244,7 +1245,7 @@ public class LoginActivity extends BaseFragment {
                 try {
                     String number = tm.getLine1Number();
                     if (!TextUtils.isEmpty(number)) {
-                        req.settings.current_number = phone.contains(number) || number.contains(phone);
+                        req.settings.current_number = PhoneNumberUtils.compare(phone, number);
                         if (!req.settings.current_number) {
                             req.settings.allow_flashcall = false;
                         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/PassportActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PassportActivity.java
@@ -28,6 +28,7 @@ import android.os.Bundle;
 import android.os.Vibrator;
 import android.provider.MediaStore;
 import android.support.v4.content.FileProvider;
+import android.telephony.PhoneNumberUtils;
 import android.telephony.SmsManager;
 import android.telephony.TelephonyManager;
 import android.text.Editable;
@@ -6309,7 +6310,7 @@ public class PassportActivity extends BaseFragment implements NotificationCenter
                 @SuppressLint("HardwareIds")
                 String number = tm.getLine1Number();
                 if (!TextUtils.isEmpty(number)) {
-                    req.settings.current_number = phone.contains(number) || number.contains(phone);
+                    req.settings.current_number = PhoneNumberUtils.compare(phone, number);
                     if (!req.settings.current_number) {
                         req.settings.allow_flashcall = false;
                     }


### PR DESCRIPTION
Currently it is impossible to login second account with another phone number which is the same phone number you already used but with extra digit at the end.
For example user can have the following accounts:
- +0 1234567890 (10 digits)
- +0 12345678901 (11 digits)

In another clients (e.g. Telegram Swift) user will be able to login both accounts in the same time.

The code of Pull Request for checking phone numbers uses the built-in [Android function](https://developer.android.com/reference/android/telephony/PhoneNumberUtils.html#compare(java.lang.String,%20java.lang.String)), which was added to the API level 1.
