### PR TITLE
Redundant special case

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AvatarDrawable.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AvatarDrawable.java
@@ -85,9 +85,6 @@ public class AvatarDrawable extends Drawable {
     }
 
     public static int getColorIndex(int id) {
-        if (id >= 0 && id < 7) {
-            return id;
-        }
         return Math.abs(id % Theme.keys_avatar_background.length);
     }
 


### PR DESCRIPTION
If the length of colours is 7, the IDs from 0 to 6 will return 0 to 6 respectively without the need for a special case.