### PR TITLE
Fix wrong empty view on gif searching view

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiView.java
@@ -4449,7 +4449,7 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
                                 resultsMap.put(result.id, result);
                                 addedCount++;
                             }
-                            searchEndReached = oldCount == results.size();
+                            searchEndReached = TextUtils.isEmpty(res.next_offset);
                             if (addedCount != 0) {
                                 if (oldCount != 0) {
                                     notifyItemChanged(oldCount);


### PR DESCRIPTION
Fix showing empty view for gifs searching result when there is one item

Before
![1_1](https://user-images.githubusercontent.com/991533/59672582-54a93800-91f2-11e9-8700-8ec7614061da.gif)
After
![1_2](https://user-images.githubusercontent.com/991533/59672593-596dec00-91f2-11e9-8bdf-29162cac9836.gif)


