### PR TITLE
Fix linkify email in messages and caption

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -2857,7 +2857,7 @@ public class MessageObject {
             if (useManualParse) {
                 if (containsUrls(caption)) {
                     try {
-                        Linkify.addLinks((Spannable) caption, Linkify.WEB_URLS | Linkify.PHONE_NUMBERS);
+                        Linkify.addLinks((Spannable) caption, Linkify.WEB_URLS | Linkify.PHONE_NUMBERS | Linkify.EMAIL_ADDRESSES);
                     } catch (Exception e) {
                         FileLog.e(e);
                     }
@@ -3006,7 +3006,7 @@ public class MessageObject {
         if (messageText instanceof Spannable && containsUrls(messageText)) {
             if (messageText.length() < 1000) {
                 try {
-                    Linkify.addLinks((Spannable) messageText, Linkify.WEB_URLS | Linkify.PHONE_NUMBERS);
+                    Linkify.addLinks((Spannable) messageText, Linkify.WEB_URLS | Linkify.PHONE_NUMBERS | Linkify.EMAIL_ADDRESSES);
                 } catch (Exception e) {
                     FileLog.e(e);
                 }


### PR DESCRIPTION
Fix linkify email after sending a message or image with caption.

Before
![gif_mail_before2](https://user-images.githubusercontent.com/3606758/59718435-de70f980-9222-11e9-885b-c75f2c623a90.gif)
After
![gif_mail_after](https://user-images.githubusercontent.com/3606758/59718523-082a2080-9223-11e9-98b6-6b1c0c980e79.gif)




