### PR TITLE
Change method name 'cancel' to 'stopNotification'

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/MrzCameraActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/MrzCameraActivity.java
@@ -169,7 +169,7 @@ public class MrzCameraActivity extends BaseFragment implements Camera.PreviewCal
         backgroundHandlerThread.quitSafely();
     }
 
-    public void cancel() {
+    public void stopNotification() {
         NotificationCenter.getInstance(currentAccount).postNotificationName(NotificationCenter.recordStopped, 0);
     }
 


### PR DESCRIPTION
This class is used to represent MrzCameraActivity.  This method named 'cancel' is to stop notification. Thus, the method name 'stopNotification' is more intuitive than 'cancel'.