### PR TITLE
fix incorrect status bar height

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
@@ -24,6 +24,7 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetFileDescriptor;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.database.ContentObserver;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -498,6 +499,14 @@ public class AndroidUtilities {
             }
         } catch (Exception e) {
             FileLog.e(e);
+        }
+    }
+
+    public static void initStatusBarHeight(Resources resources) {
+        if(AndroidUtilities.statusBarHeight > 0) return;
+        int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            AndroidUtilities.statusBarHeight = resources.getDimensionPixelSize(resourceId);
         }
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/ExternalActionActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ExternalActionActivity.java
@@ -89,10 +89,8 @@ public class ExternalActionActivity extends Activity implements ActionBarLayout.
             SharedConfig.lastPauseTime = ConnectionsManager.getInstance(UserConfig.selectedAccount).getCurrentTime();
         }
 
-        int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
-        if (resourceId > 0) {
-            AndroidUtilities.statusBarHeight = getResources().getDimensionPixelSize(resourceId);
-        }
+        AndroidUtilities.initStatusBarHeight(getResources());
+
         Theme.createDialogsResources(this);
         Theme.createChatResources(this, false);
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -239,10 +239,7 @@ public class LaunchActivity extends Activity implements ActionBarLayout.ActionBa
             SharedConfig.lastPauseTime = ConnectionsManager.getInstance(currentAccount).getCurrentTime();
         }
 
-        int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
-        if (resourceId > 0) {
-            AndroidUtilities.statusBarHeight = getResources().getDimensionPixelSize(resourceId);
-        }
+        AndroidUtilities.initStatusBarHeight(getResources());
 
         actionBarLayout = new ActionBarLayout(this);
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/PopupNotificationActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PopupNotificationActivity.java
@@ -159,10 +159,7 @@ public class PopupNotificationActivity extends Activity implements NotificationC
         super.onCreate(savedInstanceState);
         Theme.createChatResources(this, false);
 
-        int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
-        if (resourceId > 0) {
-            AndroidUtilities.statusBarHeight = getResources().getDimensionPixelSize(resourceId);
-        }
+        AndroidUtilities.initStatusBarHeight(getResources());
         for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
             NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.appDidLogout);
             NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.updateInterfaces);


### PR DESCRIPTION
Status bar height from layout insets return true value, but activity creation can override this value.
added overriding AndroidUtilities.statusBarHeight from resources only when AndroidUtilities.statusBarHeigh == 0

 