### PR TITLE
Fix statusBar and title overlap

### DIFF
--- a/TMessagesProj/src/main/res/values-v21/styles.xml
+++ b/TMessagesProj/src/main/res/values-v21/styles.xml
@@ -21,6 +21,7 @@
         <item name="android:navigationBarColor">#000000</item>
         <item name="android:textViewStyle">@style/MyTextViewStyle</item>
         <item name="android:forceDarkAllowed">false</item>
+        <item name="android:windowFullscreen">true</item>
     </style>
 
     <style name="Theme.TMessages" parent="@android:style/Theme.Material.Light">


### PR DESCRIPTION
My phone is Xiaomi Mi 8. The status bar on the page will overlap the title every time I restart Telegram, which will affect the experience. I hope this can be resolved.
1. Original code and effect
```xml
<style name="Theme.TMessages.Start" parent="@android:style/Theme.Material">
    <item name="android:actionBarStyle">@style/ActionBar.Transparent.TMessages.Start</item>
    <item name="android:colorBackground">@android:color/white</item>
    <item name="android:windowBackground">@android:color/white</item>
    <item name="android:windowContentOverlay">@null</item>
    <item name="android:colorPrimaryDark">#426482</item>
    <item name="android:colorPrimary">#527da3</item>
    <item name="android:navigationBarColor">#000000</item>
    <item name="android:textViewStyle">@style/MyTextViewStyle</item>
    <item name="android:forceDarkAllowed">false</item>
    <item name="android:windowFullscreen">true</item>
</style>
```
![壳图20200105-150634](https://user-images.githubusercontent.com/38378650/71776476-3871ba80-2fcd-11ea-830f-b28c8613b33c.jpg)

2. The code and effects of this fix. After using this property "android:windowFullscreen", I couldn't find any other way to control the color of the statusBar. Although the statusBar turns black, but I feel easier to accept than the original effect.
```xml
<style name="Theme.TMessages.Start" parent="@android:style/Theme.Material">
    <item name="android:actionBarStyle">@style/ActionBar.Transparent.TMessages.Start</item>
    <item name="android:colorBackground">@android:color/white</item>
    <item name="android:windowBackground">@android:color/white</item>
    <item name="android:windowContentOverlay">@null</item>
    <item name="android:colorPrimaryDark">#426482</item>
    <item name="android:colorPrimary">#527da3</item>
    <item name="android:navigationBarColor">#000000</item>
    <item name="android:textViewStyle">@style/MyTextViewStyle</item>
    <item name="android:forceDarkAllowed">false</item>
    <!--set attr "android:windowFullscreen" is true-->
    <item name="android:windowFullscreen">true</item>
</style>
```
![壳图20200105-150647](https://user-images.githubusercontent.com/38378650/71776546-73c0b900-2fce-11ea-85c4-52061eb680e7.jpg)

3. Code and effects of the first additional solution
```xml
<style name="Theme.TMessages.Start" parent="@android:style/Theme.Material">
    <item name="android:actionBarStyle">@style/ActionBar.Transparent.TMessages.Start</item>
    <item name="android:colorBackground">@android:color/white</item>
    <item name="android:windowBackground">@android:color/white</item>
    <item name="android:windowContentOverlay">@null</item>
    <item name="android:colorPrimaryDark">#426482</item>
    <item name="android:colorPrimary">#527da3</item>
    <item name="android:navigationBarColor">#000000</item>
    <item name="android:textViewStyle">@style/MyTextViewStyle</item>
    <item name="android:forceDarkAllowed">false</item>
    <!--set attr "android:windowFullscreen" and "android:windowLightStatusBar" is true-->
    <item name="android:windowNoTitle">true</item>
    <item name="android:windowLightStatusBar">true</item>
</style>
```
![壳图20200105-150709](https://user-images.githubusercontent.com/38378650/71776604-5b9d6980-2fcf-11ea-9ac1-c301bec380c3.jpg)

4. Code and effects of the second additional solution
```xml
<style name="Theme.TMessages.Start" parent="@android:style/Theme.Material">
    <item name="android:actionBarStyle">@style/ActionBar.Transparent.TMessages.Start</item>
    <item name="android:colorBackground">@android:color/white</item>
    <!--Set a background image, other images are also possible-->
    <item name="android:windowBackground">@drawable/background_hd</item>
    <item name="android:windowContentOverlay">@null</item>
    <item name="android:colorPrimaryDark">#426482</item>
    <item name="android:colorPrimary">#527da3</item>
    <item name="android:navigationBarColor">#000000</item>
    <item name="android:textViewStyle">@style/MyTextViewStyle</item>
    <item name="android:forceDarkAllowed">false</item>
    <!--set attr "android:windowNoTitle" is true-->
    <item name="android:windowNoTitle">true</item>
</style>
```
![壳图20200105-150656](https://user-images.githubusercontent.com/38378650/71776642-1fb6d400-2fd0-11ea-835b-0d17d3c4af9e.jpg)
