### PR TITLE
Fix apkdiff not checking entire files

### DIFF
--- a/apkdiff.py
+++ b/apkdiff.py
@@ -8,7 +8,7 @@ def compareFiles(first, second):
 		if firstBytes != secondBytes:
 			return False
 
-		if firstBytes != b"" or secondBytes != b"":
+		if firstBytes == b"":
 			break
 
 	return True


### PR DESCRIPTION
I noticed that `apkdiff.py` was only checking the first 4096 bytes of each file. I have added a fix so now it checks the entire contents of the file.

Before, I was able to modify the end of a file in an apk and it output that it was the same as the original. Now it correctly outputs they are different. See screenshots

![photo_2020-01-06_23-24-26](https://user-images.githubusercontent.com/1645882/71876529-c2a84480-30db-11ea-8742-400f61887f23.jpg)
![photo_2020-01-06_23-24-10](https://user-images.githubusercontent.com/1645882/71876547-cf2c9d00-30db-11ea-87cb-aa6970fc1c26.jpg)
