### PR TITLE
fix the disappearance of the search icon

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/SharedMediaLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/SharedMediaLayout.java
@@ -2714,9 +2714,6 @@ public class SharedMediaLayout extends FrameLayout implements NotificationCenter
         if (searchItemState == 2 && actionBar.isSearchFieldVisible()) {
             ignoreSearchCollapse = true;
             actionBar.closeSearchField();
-            searchItemState = 0;
-            searchItem.setAlpha(0.0f);
-            searchItem.setVisibility(View.INVISIBLE);
         }
     }
 


### PR DESCRIPTION
In SharedMediaLayout when you are searching for somthing and sroll to a mediapage than doesn't support search but you regret and go back the search icon is gone in a mediaPage than do support searching, this behavor is OK in MediaActivity