### PR TITLE
fix update colors in EmojiView and ChatActivityEnterView

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/PhotoViewerCaptionEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/PhotoViewerCaptionEnterView.java
@@ -284,6 +284,9 @@ public class PhotoViewerCaptionEnterView extends FrameLayout implements Notifica
     public void updateColors() {
         Theme.setDrawableColor(drawable, Theme.getColor(Theme.key_dialogFloatingButton));
         Theme.setDrawableColor(checkDrawable, Theme.getColor(Theme.key_dialogFloatingIcon));
+        if (emojiView != null) {
+            emojiView.updateColors();
+        }
     }
 
     public boolean hideActionMode() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -5475,6 +5475,9 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
             if (doneItem != null) {
                 doneItem.setIconColor(Theme.getColor(Theme.key_actionBarDefaultIcon));
             }
+            if (commentView != null) {
+                commentView.updateColors();
+            }
         };
 
         ArrayList<ThemeDescription> arrayList = new ArrayList<>();
@@ -5817,6 +5820,15 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
         arrayList.add(new ThemeDescription(null, 0, null, null, null, null, Theme.key_player_progress));
         arrayList.add(new ThemeDescription(null, 0, null, null, null, null, Theme.key_player_button));
         arrayList.add(new ThemeDescription(null, 0, null, null, null, null, Theme.key_player_buttonActive));
+        
+        if (commentView != null) {
+            arrayList.add(new ThemeDescription(commentView, 0, null, Theme.chat_composeBackgroundPaint, null, null, Theme.key_chat_messagePanelBackground));
+            arrayList.add(new ThemeDescription(commentView, 0, null, null, new Drawable[]{Theme.chat_composeShadowDrawable}, null, Theme.key_chat_messagePanelShadow));
+            arrayList.add(new ThemeDescription(commentView, ThemeDescription.FLAG_TEXTCOLOR, new Class[]{ChatActivityEnterView.class}, new String[]{"messageEditText"}, null, null, null, Theme.key_chat_messagePanelText));
+            arrayList.add(new ThemeDescription(commentView, ThemeDescription.FLAG_CURSORCOLOR, new Class[]{ChatActivityEnterView.class}, new String[]{"messageEditText"}, null, null, null, Theme.key_chat_messagePanelCursor));
+            arrayList.add(new ThemeDescription(commentView, ThemeDescription.FLAG_HINTTEXTCOLOR, new Class[]{ChatActivityEnterView.class}, new String[]{"messageEditText"}, null, null, null, Theme.key_chat_messagePanelHint));
+            arrayList.add(new ThemeDescription(commentView, ThemeDescription.FLAG_IMAGECOLOR, new Class[]{ChatActivityEnterView.class}, new String[]{"sendButton"}, null, null, null, Theme.key_chat_messagePanelSend));
+        }
 
         return arrayList;
     }


### PR DESCRIPTION
PhotoViewerCaptionEnterView:
When theme changes the emojiView keeps the old theme
steps to reproduce:
start the app with a theme
-open(to start a emojiview instance) emojiView in send picture(PhotoViewerCaptionEnterView), it will match theme, then
-change theme(with diferent color to be noticiable), the emojiView in send picture will have the last theme used
fixes updatecolor in all cases(auto night theme, theme switch in DrawerProfileCell, and all others)

DialogsActivity:
if writing a message while sharing, and auto night theme triggered, the ChatActivityEnterView and EmojiView will stay with the old theme