### PR TITLE
feat: Display the number of messages and chats on the notification

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/NotificationsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/NotificationsController.java
@@ -2882,6 +2882,20 @@ public class NotificationsController extends BaseController {
                 }
             }
 
+            String summaryText = LocaleController.formatString("NotificationMessagesPeopleDisplayOrder", R.string.NotificationMessagesPeopleDisplayOrder, LocaleController.formatPluralString("messages", total_unread_count), LocaleController.formatPluralString("FromChats", pushDialogs.size()));
+
+            NotificationCompat.Builder publicBuilder = new NotificationCompat.Builder(ApplicationLoader.applicationContext)
+                    .setSmallIcon(R.drawable.notification)
+                    .setContentText(summaryText)
+                    .setAutoCancel(true)
+                    .setNumber(total_unread_count)
+                    .setColor(0xff11acfa)
+                    .setContentIntent(contentIntent)
+                    .setShowWhen(true)
+                    .setWhen(((long) lastMessageObject.messageOwner.date) * 1000)
+                    .setCategory(NotificationCompat.CATEGORY_MESSAGE);
+            Notification publicNotification = publicBuilder.build();
+
             NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(ApplicationLoader.applicationContext)
                     .setContentTitle(name)
                     .setSmallIcon(R.drawable.notification)
@@ -2892,6 +2906,7 @@ public class NotificationsController extends BaseController {
                     .setGroupSummary(true)
                     .setShowWhen(true)
                     .setWhen(((long) lastMessageObject.messageOwner.date) * 1000)
+                    .setPublicVersion(publicNotification)
                     .setColor(0xff11acfa);
 
             long[] vibrationPattern = null;
@@ -3105,7 +3120,7 @@ public class NotificationsController extends BaseController {
             if (Build.VERSION.SDK_INT >= 26) {
                 mBuilder.setChannelId(validateChannelId(dialog_id, chatName, vibrationPattern, ledColor, sound, importance, configVibrationPattern, configSound, configImportance));
             }
-            showExtraNotifications(mBuilder, notifyAboutLast, detailText);
+            showExtraNotifications(mBuilder, notifyAboutLast, detailText, publicNotification);
             scheduleNotificationRepeat();
         } catch (Exception e) {
             FileLog.e(e);
@@ -3122,7 +3137,7 @@ public class NotificationsController extends BaseController {
     }
 
     @SuppressLint("InlinedApi")
-    private void showExtraNotifications(NotificationCompat.Builder notificationBuilder, boolean notifyAboutLast, String summary) {
+    private void showExtraNotifications(NotificationCompat.Builder notificationBuilder, boolean notifyAboutLast, String summary, Notification publicNotification) {
         Notification mainNotification = notificationBuilder.build();
         if (Build.VERSION.SDK_INT < 18) {
             notificationManager.notify(notificationId, mainNotification);
@@ -3650,6 +3665,7 @@ public class NotificationsController extends BaseController {
                     .setContentIntent(contentIntent)
                     .extend(wearableExtender)
                     .setSortKey("" + (Long.MAX_VALUE - date))
+                    .setPublicVersion(publicNotification)
                     .setCategory(NotificationCompat.CATEGORY_MESSAGE);
 
             Intent dismissIntent = new Intent(ApplicationLoader.applicationContext, NotificationDismissReceiver.class);


### PR DESCRIPTION
Display the number of messages and chats on the notification when "Show sensitive content only when unlocked" option is selected for the Lock Screen.

### Before
![before_crop](https://user-images.githubusercontent.com/44206249/92129723-2ec28000-ee04-11ea-8c08-905d769e42d5.jpg)

### After
![after_crop](https://user-images.githubusercontent.com/44206249/92129730-308c4380-ee04-11ea-9a8a-3acfcadb65ce.jpg)
