### PR TITLE
Raise gif maximum size to align with telegram desktop

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -2902,7 +2902,7 @@ public class MessageObject {
                     height = attribute.h;
                 }
             }
-            if (animated && width <= 1280 && height <= 1280) {
+            if (animated && width <= 1440 && height <= 1440) {
                 return true;
             }
         }


### PR DESCRIPTION
It seems that the maximum gif size on telegram desktop is 1440px. Larger than that, and it displays as a video.
On iOS there is no limit to resolution, with video files up to 5000px still displaying as a gif provided there's no audio track.
This change would bring the android app into line with telegram desktop, but I'm not sure whether we could scrap the resolution check, and be more inline with the iOS app?