### PR TITLE
[FIX] Add directshare shorctus in the right order

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaDataController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaDataController.java
@@ -2864,6 +2864,8 @@ public class MediaDataController extends BaseController {
                 }
             }
         }
+
+        Collections.reverse(hintsFinal);
         Utilities.globalQueue.postRunnable(() -> {
             try {
                 if (SharedConfig.directShareHash == null) {


### PR DESCRIPTION
Currently the direct share feature is not working properly. 

The app is gathering the ten top Peers and creating the shortcuts to send them messages but they are added in the wrong order. As a result the one shown by android are not the first ones but the last ones which is not right.

The fix is trivial and my implementation is quite straightforward but as I miss any experience in android development it might not be the right one, feel free to correct me.