### PR TITLE
[Fix] fix initiating new call in active call

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPService.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPService.java
@@ -900,12 +900,6 @@ public class VoIPService extends VoIPBaseService {
 					FileLog.d("phone.discardCall " + response);
 				}
 			}
-			if (!wasNotConnected) {
-				AndroidUtilities.cancelRunOnUIThread(stopper);
-				if (onDone != null) {
-					onDone.run();
-				}
-			}
 		}, ConnectionsManager.RequestFlagFailOnServerErrors);
 	}
 


### PR DESCRIPTION
There is possibility to start a new call in the active call but it doesn't works.

There is a check: a new call will not start if there is already a current call (in the code it is written as "if instance of the VoIP service == null")
This instance becomes null when this voipService is destroyed. That is, in the usual case, we (or the interlocutor) end the call and the service is destroyed (the callEnded method is called).
After that, we can start a new call.

In this service's method (declineIncomingCall), which is called to end the call, you can pass the Runnable onDone, which will be executed after sending a request to end the call to the server.
When you try to end a call to start a new one (after clicking in the "I agree to end the call and start a new one" dialog), the onDone parameter passes the doInitiateCall method, which starts a new call.

Now to the code: as you can see in the code I removed, the runnable "stopper" is canceled (in which onDone and callEnded are called) and onDone is simply called. That is, the app tries to start the call without completing the service (without calling callEnded). Therefore, the app can not start the call in this case, since the service instance is not null (the check I wrote about above).

This is the bug. I tried to start another one during the call, the dialog came out, I clicked OK, the current call ended, but the new one did not start in the end.
It is logical to end the service and start a new call, that is, do not cancel this stopper.

