### PR TITLE
Call super.onBackPressed in BubbleActivity to preserve bubble

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/BubbleActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/BubbleActivity.java
@@ -299,7 +299,6 @@ public class BubbleActivity extends Activity implements ActionBarLayout.ActionBa
 
     @Override
     public void onBackPressed() {
-        super.onBackPressed();
         if (passcodeView.getVisibility() == View.VISIBLE) {
             finish();
             return;
@@ -309,7 +308,7 @@ public class BubbleActivity extends Activity implements ActionBarLayout.ActionBa
         } else if (drawerLayoutContainer.isDrawerOpened()) {
             drawerLayoutContainer.closeDrawer(false);
         } else {
-            actionBarLayout.onBackPressed();
+            super.onBackPressed()
         }
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/BubbleActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/BubbleActivity.java
@@ -308,7 +308,7 @@ public class BubbleActivity extends Activity implements ActionBarLayout.ActionBa
         } else if (drawerLayoutContainer.isDrawerOpened()) {
             drawerLayoutContainer.closeDrawer(false);
         } else {
-            super.onBackPressed()
+            super.onBackPressed();
         }
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/BubbleActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/BubbleActivity.java
@@ -299,6 +299,7 @@ public class BubbleActivity extends Activity implements ActionBarLayout.ActionBa
 
     @Override
     public void onBackPressed() {
+        super.onBackPressed();
         if (passcodeView.getVisibility() == View.VISIBLE) {
             finish();
             return;


### PR DESCRIPTION
Expanded bubble activity disappears onBackPressed as opposed to being collapsed into a bubble on the screen. Call super to preserve bubble.

Note that although this change fixes this UX issue, it might not be the solution you want, given the app does its own management of view transitions and task mgmt.