### PR TITLE
Handle keyboard and D-PAD selection in lists

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Adapters/DialogsAdapter.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Adapters/DialogsAdapter.java
@@ -46,6 +46,7 @@ import org.telegram.tgnet.TLRPC;
 import org.telegram.ui.ActionBar.ActionBar;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Cells.ArchiveHintCell;
+import org.telegram.ui.Cells.BaseCell;
 import org.telegram.ui.Cells.DialogCell;
 import org.telegram.ui.Cells.DialogMeUrlCell;
 import org.telegram.ui.Cells.DialogsEmptyCell;
@@ -387,6 +388,9 @@ public class DialogsAdapter extends RecyclerListView.SelectionAdapter {
                 DialogCell dialogCell = new DialogCell(parentFragment, mContext, true, false, currentAccount);
                 dialogCell.setArchivedPullAnimation(pullForegroundDrawable);
                 dialogCell.setPreloader(preloader);
+                if(viewGroup instanceof BaseCell.BaseCellDelegate) {
+                    dialogCell.setDelegate((BaseCell.BaseCellDelegate) viewGroup);
+                }
                 view = dialogCell;
                 break;
             case 1:

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/BaseCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/BaseCell.java
@@ -11,11 +11,22 @@ package org.telegram.ui.Cells;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.view.HapticFeedbackConstants;
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 
+import org.telegram.messenger.MessageObject;
+import org.telegram.tgnet.TLRPC;
+
 public abstract class BaseCell extends ViewGroup {
+    public interface BaseCellDelegate {
+        default void didEnterWithKeyboard(BaseCell cell) {
+        }
+    }
+    private BaseCellDelegate delegate;
+
+    public void setDelegate(BaseCellDelegate delegate) { this.delegate = delegate; }
 
     private final class CheckForTap implements Runnable {
         public void run() {
@@ -46,6 +57,27 @@ public abstract class BaseCell extends ViewGroup {
     private CheckForLongPress pendingCheckForLongPress = null;
     private int pressCount = 0;
     private CheckForTap pendingCheckForTap = null;
+
+    private boolean isSelectButton(int keycode) {
+        switch(keycode) {
+            case KeyEvent.KEYCODE_BUTTON_SELECT:
+            case KeyEvent.KEYCODE_BUTTON_A:
+            case KeyEvent.KEYCODE_ENTER:
+            case KeyEvent.KEYCODE_DPAD_CENTER:
+            case KeyEvent.KEYCODE_NUMPAD_ENTER:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if(isSelectButton(keyCode)) {
+            delegate.didEnterWithKeyboard(this);
+        }
+        return super.onKeyDown(keyCode, event);
+    }
 
     public BaseCell(Context context) {
         super(context);


### PR DESCRIPTION
This pull request enables selection of list items in RecyclerListView by pressing Enter or Dpad's Center button (or other keys as specified by https://developer.android.com/training/tv/start/controllers) on list items. This works on lists where item's focusable property is set to true, for example, on the applications' main chats list.