### PR TITLE
[WIP] JCenter sunset is announced for a May 1st 2021 (and hence 'jcenter()' repository references are removed)

### DIFF
--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.android.application'
 repositories {
     mavenCentral()
     google()
-    jcenter()
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
         mavenCentral()
         google()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath 'com.google.gms:google-services:4.3.4'
     }
 }


### PR DESCRIPTION
Related links:
 * https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter
 * https://www.infoq.com/news/2021/02/jfrog-jcenter-bintray-closure

Quote (from a link above):
> **_May 1st   |   Bintray, JCenter, GoCenter, and ChartCenter services will no longer be available_**

FYI @DrKLO 