### PR TITLE
bugfixes Android Contest 2021

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Adapters/MentionsAdapter.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Adapters/MentionsAdapter.java
@@ -719,49 +719,29 @@ public class MentionsAdapter extends RecyclerListView.SelectionAdapter {
                 threadId = 0;
             }
             if (chat != null && info != null && info.participants != null && (!ChatObject.isChannel(chat) || chat.megagroup)) {
-                for (int a = -1; a < info.participants.participants.size(); a++) {
-                    String username;
-                    String firstName;
-                    String lastName;
-                    TLObject object;
-                    int id;
-                    if (a == -1) {
-                        if (chat == null) {
-                            continue;
-                        }
-                        if (usernameString.length() == 0) {
-                            newResult.add(chat);
-                            continue;
-                        }
-                        firstName = chat.title;
-                        lastName = null;
-                        username = chat.username;
-                        object = chat;
-                        id = -chat.id;
-                    } else {
-                        TLRPC.ChatParticipant chatParticipant = info.participants.participants.get(a);
-                        TLRPC.User user = messagesController.getUser(chatParticipant.user_id);
-                        if (user == null || !usernameOnly && UserObject.isUserSelf(user) || newResultsHashMap.indexOfKey(user.id) >= 0) {
-                            continue;
-                        }
-                        if (usernameString.length() == 0) {
-                            if (!user.deleted) {
-                                newResult.add(user);
-                                continue;
-                            }
-                        }
-                        firstName = user.first_name;
-                        lastName = user.last_name;
-                        username = user.username;
-                        object = user;
-                        id = user.id;
+                for (int a = 0; a < info.participants.participants.size(); a++) {
+                    TLRPC.ChatParticipant chatParticipant = info.participants.participants.get(a);
+                    TLRPC.User user = messagesController.getUser(chatParticipant.user_id);
+                    if (user == null || !usernameOnly && UserObject.isUserSelf(user) || newResultsHashMap.indexOfKey(user.id) >= 0) {
+                        continue;
                     }
+                    if (usernameString.length() == 0) {
+                        if (!user.deleted) {
+                            newResult.add(user);
+                            continue;
+                        }
+                    }
+
+                    String firstName = user.first_name;
+                    String lastName = user.last_name;
+                    String username = user.username;
+
                     if (!TextUtils.isEmpty(username) && username.toLowerCase().startsWith(usernameString) ||
                             !TextUtils.isEmpty(firstName) && firstName.toLowerCase().startsWith(usernameString) ||
                             !TextUtils.isEmpty(lastName) && lastName.toLowerCase().startsWith(usernameString) ||
                             hasSpace && ContactsController.formatName(firstName, lastName).toLowerCase().startsWith(usernameString)) {
-                        newResult.add(object);
-                        newMap.put(id, object);
+                        newResult.add(user);
+                        newMap.put(user.id, user);
                     }
                 }
             }

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -15319,6 +15319,22 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                 int prevLoadingUpRow = chatAdapter.loadingUpRow;
                 int prevLoadingDownRow = chatAdapter.loadingDownRow;
                 for (int a = 0, N = removedIndexes.size(); a < N; a++) {
+                    View deletingView = chatListView.getChildAt(removedIndexes.get(a));
+                    if (deletingView instanceof ChatMessageCell) {
+                        MessageObject deletingMessage = ((ChatMessageCell) deletingView).getMessageObject();
+                        for (int i = 0; i < chatListView.getChildCount(); i++) {
+                            View mView = chatListView.getChildAt(i);
+                            if (mView instanceof ChatMessageCell) {
+                                ChatMessageCell cell = (ChatMessageCell) mView;
+                                MessageObject messageObject = cell.getMessageObject();
+                                if (messageObject.isReply() && messageObject.replyMessageObject.getId() == deletingMessage.getId()) {
+                                    messageObject.replyMessageObject = null;
+                                    messageObject.messageOwner.reply_to = null;
+                                    cell.setMessageObject(messageObject, cell.getCurrentMessagesGroup(), true, false);
+                                }
+                            }
+                        }
+                    }
                     chatAdapter.notifyItemRemoved(removedIndexes.get(a));
                 }
                 if (!isThreadChat() || messages.size() <= 3) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -6026,6 +6026,19 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                         getConnectionsManager().cancelRequest(editingMessageObjectReqId, true);
                         editingMessageObjectReqId = 0;
                     }
+
+                    for (int i = 0; i < messages.size(); i++) {
+                        View view = chatListView.getChildAt(i);
+                        if (view instanceof ChatMessageCell) {
+                            ChatMessageCell cell = (ChatMessageCell) view;
+                            MessageObject messageObject = cell.getMessageObject();
+                            if (messageObject.isReply() && messageObject.replyMessageObject.getId() == editingMessageObject.getId()) {
+                                messageObject.replyMessageObject.messageText = editingMessageObject.messageText;
+                                cell.setMessageObject(messageObject, cell.getCurrentMessagesGroup(), true, false);
+                            }
+                        }
+                    }
+
                     updatePinnedMessageView(true);
                     updateBottomOverlay();
                     updateVisibleRows();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AdminLogFilterAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AdminLogFilterAlert.java
@@ -116,8 +116,8 @@ public class AdminLogFilterAlert extends BottomSheet {
         } else {
             pinnedRow = -1;
         }
-        leavingRow = rowCount++;
-        callsRow = rowCount;
+        leavingRow = rowCount;
+        // callsRow = rowCount;
         rowCount += 2;
         allAdminsRow = rowCount;
 
@@ -285,8 +285,8 @@ public class AdminLogFilterAlert extends BottomSheet {
                         currentFilter.pinned = !currentFilter.pinned;
                     } else if (position == leavingRow) {
                         currentFilter.leave = !currentFilter.leave;
-                    } else if (position == callsRow) {
-                        currentFilter.group_call = !currentFilter.group_call;
+//                    } else if (position == callsRow) {
+//                        currentFilter.group_call = !currentFilter.group_call;
                     }
                 }
                 if (currentFilter != null && !currentFilter.join && !currentFilter.leave &&
@@ -450,8 +450,8 @@ public class AdminLogFilterAlert extends BottomSheet {
                         cell.setChecked(currentFilter == null || currentFilter.pinned, false);
                     } else if (position == leavingRow) {
                         cell.setChecked(currentFilter == null || currentFilter.leave, false);
-                    } else if (position == callsRow) {
-                        cell.setChecked(currentFilter == null || currentFilter.group_call, false);
+//                    } else if (position == callsRow) {
+//                        cell.setChecked(currentFilter == null || currentFilter.group_call, false);
                     } else if (position == allAdminsRow) {
                         cell.setChecked(selectedAdmins == null, false);
                     }
@@ -493,8 +493,8 @@ public class AdminLogFilterAlert extends BottomSheet {
                         cell.setText(LocaleController.getString("EventLogFilterPinnedMessages", R.string.EventLogFilterPinnedMessages), "", currentFilter == null || currentFilter.pinned, true);
                     } else if (position == leavingRow) {
                         cell.setText(LocaleController.getString("EventLogFilterLeavingMembers", R.string.EventLogFilterLeavingMembers), "", currentFilter == null || currentFilter.leave, true);
-                    } else if (position == callsRow) {
-                        cell.setText(LocaleController.getString("EventLogFilterCalls", R.string.EventLogFilterCalls), "", currentFilter == null || currentFilter.group_call, false);
+//                    } else if (position == callsRow) {
+//                        cell.setText(LocaleController.getString("EventLogFilterCalls", R.string.EventLogFilterCalls), "", currentFilter == null || currentFilter.group_call, false);
                     } else if (position == allAdminsRow) {
                         cell.setText(LocaleController.getString("EventLogAllAdmins", R.string.EventLogAllAdmins), "", selectedAdmins == null, true);
                     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/UndoView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/UndoView.java
@@ -71,6 +71,7 @@ public class UndoView extends FrameLayout {
 
     private int currentAction;
     private long currentDialogId;
+    private long[] currentDialogsIds;
     private Runnable currentActionRunnable;
     private Runnable currentCancelRunnable;
 
@@ -297,7 +298,14 @@ public class UndoView extends FrameLayout {
             currentCancelRunnable = null;
         }
         if (currentAction == ACTION_CLEAR || currentAction == ACTION_DELETE) {
-            MessagesController.getInstance(currentAccount).removeDialogAction(currentDialogId, currentAction == ACTION_CLEAR, apply);
+            if (currentDialogsIds != null) {
+                for (long did : currentDialogsIds) {
+                    MessagesController.getInstance(currentAccount).removeDialogAction(did, currentAction == ACTION_CLEAR, apply);
+                }
+                currentDialogsIds = null;
+            } else {
+                MessagesController.getInstance(currentAccount).removeDialogAction(currentDialogId, currentAction == ACTION_CLEAR, apply);
+            }
         }
         if (animated != 0) {
             AnimatorSet animatorSet = new AnimatorSet();
@@ -940,6 +948,650 @@ public class UndoView extends FrameLayout {
                 }
             }
             MessagesController.getInstance(currentAccount).addDialogAction(did, currentAction == ACTION_CLEAR);
+        }
+
+        AndroidUtilities.makeAccessibilityAnnouncement(infoTextView.getText() + (subinfoTextView.getVisibility() == VISIBLE ? ". " + subinfoTextView.getText() : ""));
+
+        if (isMultilineSubInfo()) {
+            ViewGroup parent = (ViewGroup) getParent();
+            int width = parent.getMeasuredWidth();
+            if (width == 0) {
+                width = AndroidUtilities.displaySize.x;
+            }
+            width -= AndroidUtilities.dp(16);
+            measureChildWithMargins(subinfoTextView, MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY), 0, MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED), 0);
+            undoViewHeight = subinfoTextView.getMeasuredHeight() + AndroidUtilities.dp(27 + 10);
+        } else if (hasSubInfo()) {
+            undoViewHeight = AndroidUtilities.dp(52);
+        } else if (getParent() instanceof ViewGroup) {
+            ViewGroup parent = (ViewGroup) getParent();
+            int width = parent.getMeasuredWidth() - parent.getPaddingLeft() - parent.getPaddingRight();
+            if (width <= 0) {
+                width = AndroidUtilities.displaySize.x;
+            }
+            width -= AndroidUtilities.dp(16);
+            measureChildWithMargins(infoTextView, MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY), 0, MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED), 0);
+            undoViewHeight = infoTextView.getMeasuredHeight() + AndroidUtilities.dp(currentAction == ACTION_DICE_INFO || currentAction == ACTION_DICE_NO_SEND_INFO || currentAction == ACTION_TEXT_INFO ? 14 : 28);
+            if (currentAction == ACTION_TEXT_INFO) {
+                undoViewHeight = Math.max(undoViewHeight, AndroidUtilities.dp(52));
+            } else if (currentAction == ACTION_PROXIMITY_REMOVED) {
+                undoViewHeight = Math.max(undoViewHeight, AndroidUtilities.dp(50));
+            } else if (infoOnly) {
+                undoViewHeight -= AndroidUtilities.dp(8);
+            }
+        }
+
+        if (getVisibility() != VISIBLE) {
+            setVisibility(VISIBLE);
+            setTranslationY((fromTop ? -1.0f : 1.0f) * (AndroidUtilities.dp(8) + undoViewHeight));
+            AnimatorSet animatorSet = new AnimatorSet();
+            animatorSet.playTogether(ObjectAnimator.ofFloat(this, View.TRANSLATION_Y, (fromTop ? -1.0f : 1.0f) * (AndroidUtilities.dp(8) + undoViewHeight), (fromTop ? 1.0f : -1.0f) * additionalTranslationY));
+            animatorSet.setInterpolator(new DecelerateInterpolator());
+            animatorSet.setDuration(180);
+            animatorSet.start();
+        }
+    }
+
+    public void showWithActionFew(long[] did, int action, Runnable actionRunnable) {
+        showWithActionFew(did, action, null, null, actionRunnable, null);
+    }
+
+    public void showWithActionFew(long[] did, int action, Object infoObject) {
+        showWithActionFew(did, action, infoObject, null, null, null);
+    }
+
+    public void showWithAction(long[] did, int action, Runnable actionRunnable, Runnable cancelRunnable) {
+        showWithActionFew(did, action, null, null, actionRunnable, cancelRunnable);
+    }
+
+    public void showWithAction(long[] did, int action, Object infoObject, Runnable actionRunnable, Runnable cancelRunnable) {
+        showWithActionFew(did, action, infoObject, null, actionRunnable, cancelRunnable);
+    }
+
+    public void showWithActionFew(long[] dids, int action, Object infoObject, Object infoObject2, Runnable actionRunnable, Runnable cancelRunnable) {
+        if (currentActionRunnable != null) {
+            currentActionRunnable.run();
+        }
+        isShown = true;
+        currentActionRunnable = actionRunnable;
+        currentCancelRunnable = cancelRunnable;
+        currentDialogsIds = dids;
+        currentAction = action;
+        timeLeft = 5000;
+        currentInfoObject = infoObject;
+        lastUpdateTime = SystemClock.elapsedRealtime();
+        undoTextView.setText(LocaleController.getString("Undo", R.string.Undo).toUpperCase());
+        undoImageView.setVisibility(VISIBLE);
+        leftImageView.setPadding(0, 0, 0, 0);
+        infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15);
+        avatarImageView.setVisibility(GONE);
+
+        infoTextView.setGravity(Gravity.LEFT | Gravity.TOP);
+        FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) infoTextView.getLayoutParams();
+        layoutParams.height = LayoutHelper.WRAP_CONTENT;
+        layoutParams.bottomMargin = 0;
+
+        leftImageView.setScaleType(ImageView.ScaleType.CENTER);
+        FrameLayout.LayoutParams layoutParams2 = (FrameLayout.LayoutParams) leftImageView.getLayoutParams();
+        layoutParams2.gravity = Gravity.CENTER_VERTICAL | Gravity.LEFT;
+        layoutParams2.topMargin = layoutParams2.bottomMargin = 0;
+        layoutParams2.leftMargin = AndroidUtilities.dp(3);
+        layoutParams2.width = AndroidUtilities.dp(54);
+        layoutParams2.height = LayoutHelper.WRAP_CONTENT;
+
+        infoTextView.setMinHeight(0);
+        boolean infoOnly = false;
+
+        if (isTooltipAction()) {
+            CharSequence infoText;
+            String subInfoText;
+            int icon;
+            int size = 36;
+            boolean iconIsDrawable = false;
+            if (action == ACTION_VOIP_INVITED) {
+                TLRPC.User user = (TLRPC.User) infoObject;
+                infoText = AndroidUtilities.replaceTags(LocaleController.formatString("VoipGroupInvitedUser", R.string.VoipGroupInvitedUser, UserObject.getFirstName(user)));
+                subInfoText = null;
+                icon = 0;
+                AvatarDrawable avatarDrawable = new AvatarDrawable();
+                avatarDrawable.setTextSize(AndroidUtilities.dp(12));
+                avatarDrawable.setInfo(user);
+                avatarImageView.setImage(ImageLocation.getForUser(user, false), "50_50", avatarDrawable, user);
+                avatarImageView.setVisibility(VISIBLE);
+                timeLeft = 3000;
+            } else if (action == ACTION_VOIP_LINK_COPIED) {
+                infoText = LocaleController.getString("VoipGroupCopyInviteLinkCopied", R.string.VoipGroupCopyInviteLinkCopied);
+                subInfoText = null;
+                icon = R.raw.voip_invite;
+                timeLeft = 3000;
+            } else if (action == ACTION_VOIP_MUTED) {
+                TLRPC.User user = (TLRPC.User) infoObject;
+                infoText = AndroidUtilities.replaceTags(LocaleController.formatString("VoipGroupUserCantNowSpeak", R.string.VoipGroupUserCantNowSpeak, UserObject.getFirstName(user)));
+                subInfoText = null;
+                icon = R.raw.voip_muted;
+                timeLeft = 3000;
+            } else if (action == ACTION_VOIP_MUTED_FOR_YOU) {
+                TLRPC.User user = (TLRPC.User) infoObject;
+                infoText = AndroidUtilities.replaceTags(LocaleController.formatString("VoipGroupUserCantNowSpeakForYou", R.string.VoipGroupUserCantNowSpeakForYou, UserObject.getFirstName(user)));
+                subInfoText = null;
+                icon = R.raw.voip_muted;
+                timeLeft = 3000;
+            } else if (action == ACTION_VOIP_UNMUTED) {
+                TLRPC.User user = (TLRPC.User) infoObject;
+                infoText = AndroidUtilities.replaceTags(LocaleController.formatString("VoipGroupUserCanNowSpeak", R.string.VoipGroupUserCanNowSpeak, UserObject.getFirstName(user)));
+                subInfoText = null;
+                icon = R.raw.voip_unmuted;
+                timeLeft = 3000;
+            } else if (action == ACTION_VOIP_UNMUTED_FOR_YOU) {
+                TLRPC.User user = (TLRPC.User) infoObject;
+                infoText = AndroidUtilities.replaceTags(LocaleController.formatString("VoipGroupUserCanNowSpeakForYou", R.string.VoipGroupUserCanNowSpeakForYou, UserObject.getFirstName(user)));
+                subInfoText = null;
+                icon = R.raw.voip_unmuted;
+                timeLeft = 3000;
+            } else if (action == ACTION_VOIP_REMOVED) {
+                TLRPC.User user = (TLRPC.User) infoObject;
+                infoText = AndroidUtilities.replaceTags(LocaleController.formatString("VoipGroupRemovedFromGroup", R.string.VoipGroupRemovedFromGroup, UserObject.getFirstName(user)));
+                subInfoText = null;
+                icon = R.raw.voip_group_removed;
+                timeLeft = 3000;
+            } else if (action == ACTION_OWNER_TRANSFERED_CHANNEL || action == ACTION_OWNER_TRANSFERED_GROUP) {
+                TLRPC.User user = (TLRPC.User) infoObject;
+                if (action == ACTION_OWNER_TRANSFERED_CHANNEL) {
+                    infoText = AndroidUtilities.replaceTags(LocaleController.formatString("EditAdminTransferChannelToast", R.string.EditAdminTransferChannelToast, UserObject.getFirstName(user)));
+                } else {
+                    infoText = AndroidUtilities.replaceTags(LocaleController.formatString("EditAdminTransferGroupToast", R.string.EditAdminTransferGroupToast, UserObject.getFirstName(user)));
+                }
+                subInfoText = null;
+                icon = R.raw.contact_check;
+            } else if (action == ACTION_CONTACT_ADDED) {
+                TLRPC.User user = (TLRPC.User) infoObject;
+                infoText = LocaleController.formatString("NowInContacts", R.string.NowInContacts, UserObject.getFirstName(user));
+                subInfoText = null;
+                icon = R.raw.contact_check;
+            } else if (action == ACTION_PROFILE_PHOTO_CHANGED) {
+                if (dids[0] > 0) {
+                    if (infoObject == null) {
+                        infoText = LocaleController.getString("MainProfilePhotoSetHint", R.string.MainProfilePhotoSetHint);
+                    } else {
+                        infoText = LocaleController.getString("MainProfileVideoSetHint", R.string.MainProfileVideoSetHint);
+                    }
+                } else {
+                    TLRPC.Chat chat = MessagesController.getInstance(UserConfig.selectedAccount).getChat((int) -dids[0]);
+                    if (ChatObject.isChannel(chat) && !chat.megagroup) {
+                        if (infoObject == null) {
+                            infoText = LocaleController.getString("MainChannelProfilePhotoSetHint", R.string.MainChannelProfilePhotoSetHint);
+                        } else {
+                            infoText = LocaleController.getString("MainChannelProfileVideoSetHint", R.string.MainChannelProfileVideoSetHint);
+                        }
+                    } else {
+                        if (infoObject == null) {
+                            infoText = LocaleController.getString("MainGroupProfilePhotoSetHint", R.string.MainGroupProfilePhotoSetHint);
+                        } else {
+                            infoText = LocaleController.getString("MainGroupProfileVideoSetHint", R.string.MainGroupProfileVideoSetHint);
+                        }
+                    }
+                }
+                subInfoText = null;
+                icon = R.raw.contact_check;
+            } else if (action == ACTION_CHAT_UNARCHIVED) {
+                infoText = LocaleController.getString("ChatWasMovedToMainList", R.string.ChatWasMovedToMainList);
+                subInfoText = null;
+                icon = R.raw.contact_check;
+            } else if (action == ACTION_ARCHIVE_HIDDEN) {
+                infoText = LocaleController.getString("ArchiveHidden", R.string.ArchiveHidden);
+                subInfoText = LocaleController.getString("ArchiveHiddenInfo", R.string.ArchiveHiddenInfo);
+                icon = R.raw.chats_swipearchive;
+                size = 48;
+            } else if (currentAction == ACTION_QUIZ_CORRECT) {
+                infoText = LocaleController.getString("QuizWellDone", R.string.QuizWellDone);
+                subInfoText = LocaleController.getString("QuizWellDoneInfo", R.string.QuizWellDoneInfo);
+                icon = R.raw.wallet_congrats;
+                size = 44;
+            } else if (currentAction == ACTION_QUIZ_INCORRECT) {
+                infoText = LocaleController.getString("QuizWrongAnswer", R.string.QuizWrongAnswer);
+                subInfoText = LocaleController.getString("QuizWrongAnswerInfo", R.string.QuizWrongAnswerInfo);
+                icon = R.raw.wallet_science;
+                size = 44;
+            } else if (action == ACTION_ARCHIVE_PINNED) {
+                infoText = LocaleController.getString("ArchivePinned", R.string.ArchivePinned);
+                if (MessagesController.getInstance(currentAccount).dialogFilters.isEmpty()) {
+                    subInfoText = LocaleController.getString("ArchivePinnedInfo", R.string.ArchivePinnedInfo);
+                } else {
+                    subInfoText = null;
+                }
+                icon = R.raw.chats_infotip;
+            } else if (action == ACTION_ADDED_TO_FOLDER || action == ACTION_REMOVED_FROM_FOLDER) {
+                MessagesController.DialogFilter filter = (MessagesController.DialogFilter) infoObject2;
+                if (dids[0] != 0) {
+                    int lowerId = (int) dids[0];
+                    if (lowerId == 0) {
+                        TLRPC.EncryptedChat encryptedChat = MessagesController.getInstance(currentAccount).getEncryptedChat((int) (dids[0] >> 32));
+                        lowerId = encryptedChat.user_id;
+                    }
+                    if (lowerId > 0) {
+                        TLRPC.User user = MessagesController.getInstance(currentAccount).getUser(lowerId);
+                        if (action == ACTION_ADDED_TO_FOLDER) {
+                            infoText = AndroidUtilities.replaceTags(LocaleController.formatString("FilterUserAddedToExisting", R.string.FilterUserAddedToExisting, UserObject.getFirstName(user), filter.name));
+                        } else {
+                            infoText = AndroidUtilities.replaceTags(LocaleController.formatString("FilterUserRemovedFrom", R.string.FilterUserRemovedFrom, UserObject.getFirstName(user), filter.name));
+                        }
+                    } else {
+                        TLRPC.Chat chat = MessagesController.getInstance(currentAccount).getChat(-lowerId);
+                        if (action == ACTION_ADDED_TO_FOLDER) {
+                            infoText = AndroidUtilities.replaceTags(LocaleController.formatString("FilterChatAddedToExisting", R.string.FilterChatAddedToExisting, chat.title, filter.name));
+                        } else {
+                            infoText = AndroidUtilities.replaceTags(LocaleController.formatString("FilterChatRemovedFrom", R.string.FilterChatRemovedFrom, chat.title, filter.name));
+                        }
+                    }
+                } else {
+                    if (action == ACTION_ADDED_TO_FOLDER) {
+                        infoText = AndroidUtilities.replaceTags(LocaleController.formatString("FilterChatsAddedToExisting", R.string.FilterChatsAddedToExisting, LocaleController.formatPluralString("Chats", (Integer) infoObject), filter.name));
+                    } else {
+                        infoText = AndroidUtilities.replaceTags(LocaleController.formatString("FilterChatsRemovedFrom", R.string.FilterChatsRemovedFrom, LocaleController.formatPluralString("Chats", (Integer) infoObject), filter.name));
+                    }
+                }
+                subInfoText = null;
+                icon = R.raw.contact_check;
+            } else if (action == ACTION_CACHE_WAS_CLEARED) {
+                infoText = this.infoText;
+                subInfoText = null;
+                icon = R.raw.chats_infotip;
+            } else {
+                if (action == ACTION_ARCHIVE_HINT) {
+                    infoText = LocaleController.getString("ChatArchived", R.string.ChatArchived);
+                } else {
+                    infoText = LocaleController.getString("ChatsArchived", R.string.ChatsArchived);
+                }
+                if (MessagesController.getInstance(currentAccount).dialogFilters.isEmpty()) {
+                    subInfoText = LocaleController.getString("ChatArchivedInfo", R.string.ChatArchivedInfo);
+                } else {
+                    subInfoText = null;
+                }
+                icon = R.raw.chats_infotip;
+            }
+
+            infoTextView.setText(infoText);
+            if (icon != 0) {
+                if (iconIsDrawable) {
+                    leftImageView.setImageResource(icon);
+                } else {
+                    leftImageView.setAnimation(icon, size, size);
+                }
+                leftImageView.setVisibility(VISIBLE);
+                if (!iconIsDrawable) {
+                    leftImageView.setProgress(0);
+                    leftImageView.playAnimation();
+                }
+            } else {
+                leftImageView.setVisibility(GONE);
+            }
+
+            if (subInfoText != null) {
+                layoutParams.leftMargin = AndroidUtilities.dp(58);
+                layoutParams.topMargin = AndroidUtilities.dp(6);
+                layoutParams.rightMargin = AndroidUtilities.dp(8);
+                layoutParams = (FrameLayout.LayoutParams) subinfoTextView.getLayoutParams();
+                layoutParams.rightMargin = AndroidUtilities.dp(8);
+                subinfoTextView.setText(subInfoText);
+                subinfoTextView.setVisibility(VISIBLE);
+                infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
+                infoTextView.setTypeface(AndroidUtilities.getTypeface("fonts/rmedium.ttf"));
+            } else {
+                layoutParams.leftMargin = AndroidUtilities.dp(58);
+                layoutParams.topMargin = AndroidUtilities.dp(13);
+                layoutParams.rightMargin = AndroidUtilities.dp(8);
+                subinfoTextView.setVisibility(GONE);
+                infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15);
+                infoTextView.setTypeface(Typeface.DEFAULT);
+            }
+
+            undoButton.setVisibility(GONE);
+        } else if (currentAction == ACTION_IMPORT_NOT_MUTUAL || currentAction == ACTION_IMPORT_GROUP_NOT_ADMIN || currentAction == ACTION_IMPORT_INFO ||
+                currentAction == ACTION_PLAYBACK_SPEED_DISABLED || currentAction == ACTION_PLAYBACK_SPEED_ENABLED || currentAction == ACTION_TEXT_COPIED ||
+                currentAction == ACTION_FWD_MESSAGES || currentAction == ACTION_NOTIFY_ON || currentAction == ACTION_NOTIFY_OFF) {
+            undoImageView.setVisibility(GONE);
+            leftImageView.setVisibility(VISIBLE);
+
+            infoTextView.setTypeface(Typeface.DEFAULT);
+
+            if (currentAction == ACTION_IMPORT_NOT_MUTUAL) {
+                infoTextView.setText(LocaleController.getString("ImportMutualError", R.string.ImportMutualError));
+                leftImageView.setAnimation(R.raw.error, 36, 36);
+                infoOnly = true;
+                layoutParams.topMargin = AndroidUtilities.dp(10);
+                infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
+            } else if (currentAction == ACTION_IMPORT_GROUP_NOT_ADMIN) {
+                infoTextView.setText(LocaleController.getString("ImportNotAdmin", R.string.ImportNotAdmin));
+                leftImageView.setAnimation(R.raw.error, 36, 36);
+                infoOnly = true;
+                layoutParams.topMargin = AndroidUtilities.dp(10);
+                infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
+            } else if (currentAction == ACTION_IMPORT_INFO) {
+                infoTextView.setText(LocaleController.getString("ImportedInfo", R.string.ImportedInfo));
+                leftImageView.setAnimation(R.raw.imported, 36, 36);
+                leftImageView.setPadding(0, 0, 0, AndroidUtilities.dp(5));
+                infoOnly = true;
+                layoutParams.topMargin = AndroidUtilities.dp(10);
+                infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
+            } else if (currentAction == ACTION_PLAYBACK_SPEED_DISABLED) {
+                infoTextView.setText(LocaleController.getString("AudioSpeedNormal", R.string.AudioSpeedNormal));
+                leftImageView.setAnimation(R.raw.audio_stop_speed, 36, 36);
+                timeLeft = 3000;
+                infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15);
+            } else if (currentAction == ACTION_PLAYBACK_SPEED_ENABLED) {
+                infoTextView.setText(LocaleController.getString("AudioSpeedFast", R.string.AudioSpeedFast));
+                leftImageView.setAnimation(R.raw.audio_speed, 36, 36);
+                timeLeft = 3000;
+                infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15);
+            } else if (currentAction == ACTION_TEXT_COPIED) {
+                infoTextView.setText(LocaleController.getString("MessageCopied", R.string.MessageCopied));
+                leftImageView.setAnimation(R.raw.copy, 30, 30);
+                timeLeft = 3000;
+                infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15);
+            } else if (currentAction == ACTION_NOTIFY_ON) {
+                infoTextView.setText(LocaleController.getString("ChannelNotifyMembersInfoOn", R.string.ChannelNotifyMembersInfoOn));
+                leftImageView.setAnimation(R.raw.silent_unmute, 30, 30);
+                timeLeft = 3000;
+                infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15);
+            } else if (currentAction == ACTION_NOTIFY_OFF) {
+                infoTextView.setText(LocaleController.getString("ChannelNotifyMembersInfoOff", R.string.ChannelNotifyMembersInfoOff));
+                leftImageView.setAnimation(R.raw.silent_mute, 30, 30);
+                timeLeft = 3000;
+                infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15);
+            } else if (currentAction == ACTION_FWD_MESSAGES) {
+                Integer count = (Integer) infoObject;
+                if (infoObject2 == null) {
+                    if (dids[0] == UserConfig.getInstance(currentAccount).clientUserId) {
+                        if (count == 1) {
+                            infoTextView.setText(AndroidUtilities.replaceTags(LocaleController.getString("FwdMessageToSavedMessages", R.string.FwdMessageToSavedMessages)));
+                        } else {
+                            infoTextView.setText(AndroidUtilities.replaceTags(LocaleController.getString("FwdMessagesToSavedMessages", R.string.FwdMessagesToSavedMessages)));
+                        }
+                        leftImageView.setAnimation(R.raw.saved_messages, 30, 30);
+                    } else {
+                        int lowerId = (int) dids[0];
+                        if (lowerId < 0) {
+                            TLRPC.Chat chat = MessagesController.getInstance(currentAccount).getChat(-lowerId);
+                            if (count == 1) {
+                                infoTextView.setText(AndroidUtilities.replaceTags(LocaleController.formatString("FwdMessageToGroup", R.string.FwdMessageToGroup, chat.title)));
+                            } else {
+                                infoTextView.setText(AndroidUtilities.replaceTags(LocaleController.formatString("FwdMessagesToGroup", R.string.FwdMessagesToGroup, chat.title)));
+                            }
+                        } else {
+                            TLRPC.User user = MessagesController.getInstance(currentAccount).getUser(lowerId);
+                            if (count == 1) {
+                                infoTextView.setText(AndroidUtilities.replaceTags(LocaleController.formatString("FwdMessageToUser", R.string.FwdMessageToUser, UserObject.getFirstName(user))));
+                            } else {
+                                infoTextView.setText(AndroidUtilities.replaceTags(LocaleController.formatString("FwdMessagesToUser", R.string.FwdMessagesToUser, UserObject.getFirstName(user))));
+                            }
+                        }
+                        leftImageView.setAnimation(R.raw.forward, 30, 30);
+                    }
+                } else {
+                    int amount = (Integer) infoObject2;
+                    if (count == 1) {
+                        infoTextView.setText(AndroidUtilities.replaceTags(LocaleController.formatString("FwdMessageToChats", R.string.FwdMessageToChats, LocaleController.formatPluralString("Chats", amount))));
+                    } else {
+                        infoTextView.setText(AndroidUtilities.replaceTags(LocaleController.formatString("FwdMessagesToChats", R.string.FwdMessagesToChats, LocaleController.formatPluralString("Chats", amount))));
+                    }
+                    leftImageView.setAnimation(R.raw.forward, 30, 30);
+                }
+                timeLeft = 3000;
+            }
+            subinfoTextView.setVisibility(GONE);
+            undoTextView.setTextColor(Theme.getColor(Theme.key_undo_cancelColor));
+            undoButton.setVisibility(GONE);
+
+            layoutParams.leftMargin = AndroidUtilities.dp(58);
+            layoutParams.rightMargin = AndroidUtilities.dp(8);
+
+            leftImageView.setProgress(0);
+            leftImageView.playAnimation();
+        } else if (currentAction == ACTION_PROXIMITY_SET || currentAction == ACTION_PROXIMITY_REMOVED) {
+            int radius = (Integer) infoObject;
+            TLRPC.User user = (TLRPC.User) infoObject2;
+
+            undoImageView.setVisibility(GONE);
+            leftImageView.setVisibility(VISIBLE);
+
+            if (radius != 0) {
+                infoTextView.setTypeface(AndroidUtilities.getTypeface("fonts/rmedium.ttf"));
+                infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
+                leftImageView.clearLayerColors();
+                leftImageView.setLayerColor("BODY.**", Theme.getColor(Theme.key_undo_infoColor));
+                leftImageView.setLayerColor("Wibe Big.**", Theme.getColor(Theme.key_undo_infoColor));
+                leftImageView.setLayerColor("Wibe Big 3.**", Theme.getColor(Theme.key_undo_infoColor));
+                leftImageView.setLayerColor("Wibe Small.**", Theme.getColor(Theme.key_undo_infoColor));
+
+                infoTextView.setText(LocaleController.getString("ProximityAlertSet", R.string.ProximityAlertSet));
+                leftImageView.setAnimation(R.raw.ic_unmute, 28, 28);
+                subinfoTextView.setVisibility(VISIBLE);
+                subinfoTextView.setSingleLine(false);
+                subinfoTextView.setMaxLines(3);
+
+                if (user != null) {
+                    subinfoTextView.setText(LocaleController.formatString("ProximityAlertSetInfoUser", R.string.ProximityAlertSetInfoUser, UserObject.getFirstName(user), LocaleController.formatDistance(radius, 2)));
+                } else {
+                    subinfoTextView.setText(LocaleController.formatString("ProximityAlertSetInfoGroup2", R.string.ProximityAlertSetInfoGroup2, LocaleController.formatDistance(radius, 2)));
+                }
+                undoButton.setVisibility(GONE);
+
+                layoutParams.topMargin = AndroidUtilities.dp(6);
+            } else {
+                infoTextView.setTypeface(Typeface.DEFAULT);
+                infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15);
+                leftImageView.clearLayerColors();
+                leftImageView.setLayerColor("Body Main.**", Theme.getColor(Theme.key_undo_infoColor));
+                leftImageView.setLayerColor("Body Top.**", Theme.getColor(Theme.key_undo_infoColor));
+                leftImageView.setLayerColor("Line.**", Theme.getColor(Theme.key_undo_infoColor));
+                leftImageView.setLayerColor("Curve Big.**", Theme.getColor(Theme.key_undo_infoColor));
+                leftImageView.setLayerColor("Curve Small.**", Theme.getColor(Theme.key_undo_infoColor));
+
+                layoutParams.topMargin = AndroidUtilities.dp(14);
+
+                infoTextView.setText(LocaleController.getString("ProximityAlertCancelled", R.string.ProximityAlertCancelled));
+                leftImageView.setAnimation(R.raw.ic_mute, 28, 28);
+                subinfoTextView.setVisibility(GONE);
+                undoTextView.setTextColor(Theme.getColor(Theme.key_undo_cancelColor));
+                undoButton.setVisibility(VISIBLE);
+            }
+
+            layoutParams.leftMargin = AndroidUtilities.dp(58);
+
+            leftImageView.setProgress(0);
+            leftImageView.playAnimation();
+        } else if (currentAction == ACTION_QR_SESSION_ACCEPTED) {
+            TLRPC.TL_authorization authorization = (TLRPC.TL_authorization) infoObject;
+
+            infoTextView.setText(LocaleController.getString("AuthAnotherClientOk", R.string.AuthAnotherClientOk));
+            leftImageView.setAnimation(R.raw.contact_check, 36, 36);
+
+            layoutParams.leftMargin = AndroidUtilities.dp(58);
+            layoutParams.topMargin = AndroidUtilities.dp(6);
+            subinfoTextView.setText(authorization.app_name);
+            subinfoTextView.setVisibility(VISIBLE);
+            infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
+            infoTextView.setTypeface(AndroidUtilities.getTypeface("fonts/rmedium.ttf"));
+
+            undoTextView.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteRedText2));
+            undoImageView.setVisibility(GONE);
+            undoButton.setVisibility(VISIBLE);
+            leftImageView.setVisibility(VISIBLE);
+
+            leftImageView.setProgress(0);
+            leftImageView.playAnimation();
+        } else if (currentAction == ACTION_FILTERS_AVAILABLE) {
+            timeLeft = 10000;
+            undoTextView.setText(LocaleController.getString("Open", R.string.Open).toUpperCase());
+            infoTextView.setText(LocaleController.getString("FilterAvailableTitle", R.string.FilterAvailableTitle));
+            leftImageView.setAnimation(R.raw.filter_new, 36, 36);
+            int margin = (int) Math.ceil(undoTextView.getPaint().measureText(undoTextView.getText().toString())) + AndroidUtilities.dp(26);
+
+            layoutParams.leftMargin = AndroidUtilities.dp(58);
+            layoutParams.rightMargin = margin;
+            layoutParams.topMargin = AndroidUtilities.dp(6);
+
+            layoutParams = (FrameLayout.LayoutParams) subinfoTextView.getLayoutParams();
+            layoutParams.rightMargin = margin;
+
+            String text = LocaleController.getString("FilterAvailableText", R.string.FilterAvailableText);
+            SpannableStringBuilder builder = new SpannableStringBuilder(text);
+            int index1 = text.indexOf('*');
+            int index2 = text.lastIndexOf('*');
+            if (index1 >= 0 && index2 >= 0 && index1 != index2) {
+                builder.replace(index2, index2 + 1, "");
+                builder.replace(index1, index1 + 1, "");
+                builder.setSpan(new URLSpanNoUnderline("tg://settings/folders"), index1, index2 - 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            }
+            subinfoTextView.setText(builder);
+            subinfoTextView.setVisibility(VISIBLE);
+            subinfoTextView.setSingleLine(false);
+            subinfoTextView.setMaxLines(2);
+            undoButton.setVisibility(VISIBLE);
+            undoImageView.setVisibility(GONE);
+            leftImageView.setVisibility(VISIBLE);
+
+            leftImageView.setProgress(0);
+            leftImageView.playAnimation();
+        } else if (currentAction == ACTION_DICE_INFO || currentAction == ACTION_DICE_NO_SEND_INFO) {
+            timeLeft = 4000;
+            infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
+            infoTextView.setGravity(Gravity.CENTER_VERTICAL);
+            infoTextView.setMinHeight(AndroidUtilities.dp(30));
+            String emoji = (String) infoObject;
+            if ("\uD83C\uDFB2".equals(emoji)) {
+                infoTextView.setText(AndroidUtilities.replaceTags(LocaleController.getString("DiceInfo2", R.string.DiceInfo2)));
+                leftImageView.setImageResource(R.drawable.dice);
+            } else{
+                if ("\uD83C\uDFAF".equals(emoji)) {
+                    infoTextView.setText(AndroidUtilities.replaceTags(LocaleController.getString("DartInfo", R.string.DartInfo)));
+                } else {
+                    String info = LocaleController.getServerString("DiceEmojiInfo_" + emoji);
+                    if (!TextUtils.isEmpty(info)) {
+                        infoTextView.setText(Emoji.replaceEmoji(info, infoTextView.getPaint().getFontMetricsInt(), AndroidUtilities.dp(14), false));
+                    } else {
+                        infoTextView.setText(Emoji.replaceEmoji(LocaleController.formatString("DiceEmojiInfo", R.string.DiceEmojiInfo, emoji), infoTextView.getPaint().getFontMetricsInt(), AndroidUtilities.dp(14), false));
+                    }
+                }
+                leftImageView.setImageDrawable(Emoji.getEmojiDrawable(emoji));
+                leftImageView.setScaleType(ImageView.ScaleType.FIT_XY);
+                layoutParams.topMargin = AndroidUtilities.dp(14);
+                layoutParams.bottomMargin = AndroidUtilities.dp(14);
+                layoutParams2.leftMargin = AndroidUtilities.dp(14);
+                layoutParams2.width = AndroidUtilities.dp(26);
+                layoutParams2.height = AndroidUtilities.dp(26);
+            }
+            undoTextView.setText(LocaleController.getString("SendDice", R.string.SendDice));
+
+            int margin;
+            if (currentAction == ACTION_DICE_INFO) {
+                margin = (int) Math.ceil(undoTextView.getPaint().measureText(undoTextView.getText().toString())) + AndroidUtilities.dp(26);
+                undoTextView.setVisibility(VISIBLE);
+                undoTextView.setTextColor(Theme.getColor(Theme.key_undo_cancelColor));
+                undoImageView.setVisibility(GONE);
+                undoButton.setVisibility(VISIBLE);
+            } else {
+                margin = AndroidUtilities.dp(8);
+                undoTextView.setVisibility(GONE);
+                undoButton.setVisibility(GONE);
+            }
+
+            layoutParams.leftMargin = AndroidUtilities.dp(58);
+            layoutParams.rightMargin = margin;
+            layoutParams.topMargin = AndroidUtilities.dp(6);
+            layoutParams.bottomMargin = AndroidUtilities.dp(7);
+            layoutParams.height = TableLayout.LayoutParams.MATCH_PARENT;
+
+            subinfoTextView.setVisibility(GONE);
+            leftImageView.setVisibility(VISIBLE);
+        } else if (currentAction == ACTION_TEXT_INFO) {
+            CharSequence info = (CharSequence) infoObject;
+            timeLeft = Math.max(4000, Math.min(info.length() / 50 * 1600, 10000));
+            infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
+            infoTextView.setGravity(Gravity.CENTER_VERTICAL);
+            infoTextView.setText(info);
+
+            undoTextView.setVisibility(GONE);
+            undoButton.setVisibility(GONE);
+            layoutParams.leftMargin = AndroidUtilities.dp(58);
+            layoutParams.rightMargin = AndroidUtilities.dp(8);
+            layoutParams.topMargin = AndroidUtilities.dp(6);
+            layoutParams.bottomMargin = AndroidUtilities.dp(7);
+            layoutParams.height = TableLayout.LayoutParams.MATCH_PARENT;
+
+            layoutParams2.gravity = Gravity.TOP | Gravity.LEFT;
+            layoutParams2.topMargin = layoutParams2.bottomMargin = AndroidUtilities.dp(8);
+
+            leftImageView.setVisibility(VISIBLE);
+            leftImageView.setAnimation(R.raw.chats_infotip, 36, 36);
+            leftImageView.setProgress(0);
+            leftImageView.playAnimation();
+        } else if (currentAction == ACTION_THEME_CHANGED) {
+            infoTextView.setText(LocaleController.getString("ColorThemeChanged", R.string.ColorThemeChanged));
+            leftImageView.setImageResource(R.drawable.toast_pallete);
+
+            layoutParams.leftMargin = AndroidUtilities.dp(58);
+            layoutParams.rightMargin = AndroidUtilities.dp(48);
+            layoutParams.topMargin = AndroidUtilities.dp(6);
+
+            layoutParams = (FrameLayout.LayoutParams) subinfoTextView.getLayoutParams();
+            layoutParams.rightMargin = AndroidUtilities.dp(48);
+
+            String text = LocaleController.getString("ColorThemeChangedInfo", R.string.ColorThemeChangedInfo);
+            SpannableStringBuilder builder = new SpannableStringBuilder(text);
+            int index1 = text.indexOf('*');
+            int index2 = text.lastIndexOf('*');
+            if (index1 >= 0 && index2 >= 0 && index1 != index2) {
+                builder.replace(index2, index2 + 1, "");
+                builder.replace(index1, index1 + 1, "");
+                builder.setSpan(new URLSpanNoUnderline("tg://settings/themes"), index1, index2 - 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            }
+            subinfoTextView.setText(builder);
+            subinfoTextView.setVisibility(VISIBLE);
+            subinfoTextView.setSingleLine(false);
+            subinfoTextView.setMaxLines(2);
+            undoTextView.setVisibility(GONE);
+            undoButton.setVisibility(VISIBLE);
+            leftImageView.setVisibility(VISIBLE);
+        } else if (currentAction == ACTION_ARCHIVE || currentAction == ACTION_ARCHIVE_FEW) {
+            if (action == ACTION_ARCHIVE) {
+                infoTextView.setText(LocaleController.getString("ChatArchived", R.string.ChatArchived));
+            } else {
+                infoTextView.setText(LocaleController.getString("ChatsArchived", R.string.ChatsArchived));
+            }
+
+            layoutParams.leftMargin = AndroidUtilities.dp(58);
+            layoutParams.topMargin = AndroidUtilities.dp(13);
+            layoutParams.rightMargin = 0;
+
+            infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15);
+            undoButton.setVisibility(VISIBLE);
+            infoTextView.setTypeface(Typeface.DEFAULT);
+            subinfoTextView.setVisibility(GONE);
+
+            leftImageView.setVisibility(VISIBLE);
+            leftImageView.setAnimation(R.raw.chats_archived, 36, 36);
+            leftImageView.setProgress(0);
+            leftImageView.playAnimation();
+        } else {
+            layoutParams.leftMargin = AndroidUtilities.dp(45);
+            layoutParams.topMargin = AndroidUtilities.dp(13);
+            layoutParams.rightMargin = 0;
+
+            infoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15);
+            undoButton.setVisibility(VISIBLE);
+            infoTextView.setTypeface(Typeface.DEFAULT);
+            subinfoTextView.setVisibility(GONE);
+            leftImageView.setVisibility(GONE);
+
+            if (currentAction == ACTION_CLEAR) {
+                infoTextView.setText(LocaleController.getString("HistoryClearedUndo", R.string.HistoryClearedUndo));
+            } else {
+                infoTextView.setText(LocaleController.getString("ChatsDeletedUndo", R.string.ChatsDeletedUndo));
+                for (long did: dids) {
+                    MessagesController.getInstance(currentAccount).addDialogAction(did, currentAction == ACTION_CLEAR);
+                }
+            }
         }
 
         AndroidUtilities.makeAccessibilityAnnouncement(infoTextView.getText() + (subinfoTextView.getVisibility() == VISIBLE ? ". " + subinfoTextView.getText() : ""));

--- a/TMessagesProj/src/main/java/org/telegram/ui/GroupCallActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/GroupCallActivity.java
@@ -2831,7 +2831,7 @@ public class GroupCallActivity extends BottomSheet implements NotificationCenter
             items.add(LocaleController.getString("VoipGroupOpenProfile", R.string.VoipGroupOpenProfile));
             icons.add(R.drawable.msg_openprofile);
             options.add(6);
-            if (!isAdmin) {
+            if (!isAdmin && ChatObject.canBlockUsers(currentChat)) {
                 items.add(LocaleController.getString("VoipGroupUserRemove", R.string.VoipGroupUserRemove));
                 icons.add(R.drawable.msg_block2);
                 options.add(2);

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -148,6 +148,7 @@
     <string name="ChatsMute">Mute</string>
     <string name="ChatsUnmute">Unmute</string>
     <string name="ChatDeletedUndo">Chat deleted</string>
+    <string name="ChatsDeletedUndo">Chats deleted.</string>
     <string name="GroupDeletedUndo">Group deleted.</string>
     <string name="ChannelDeletedUndo">Channel deleted.</string>
     <string name="ArchivePinned">Archive pinned.</string>


### PR DESCRIPTION
1. Updating messages that are replies of edited message (https://bugs.telegram.org/c/179)
2. Changing messages previews that are replies of deleted message
(https://bugs.telegram.org/c/561)
3. Voice chats filter in recent actions of channels are not visible now (https://bugs.telegram.org/c/561)
4. Added 'Undo' after deleting multiple chats (https://bugs.telegram.org/c/678)
5. Remove option on Voice Chats is now invisible for users without ban permission (https://bugs.telegram.org/c/927)
6. The group name is not visible now in the mention list (https://bugs.telegram.org/c/939)