### PR TITLE
Fix stickers sending and improve its UX

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
@@ -6030,16 +6030,20 @@ public class SendMessagesHelper extends BaseController implements NotificationCe
                 inputContent.releasePermission();
             }
             if (error) {
-                AndroidUtilities.runOnUIThread(() -> {
-                    try {
-                        Toast toast = Toast.makeText(ApplicationLoader.applicationContext, LocaleController.getString("UnsupportedAttachment", R.string.UnsupportedAttachment), Toast.LENGTH_SHORT);
-                        toast.show();
-                    } catch (Exception e) {
-                        FileLog.e(e);
-                    }
-                });
+                showUnsupportedAttachmentError();
             }
         }).start();
+    }
+
+    private static void showUnsupportedAttachmentError() {
+        AndroidUtilities.runOnUIThread(() -> {
+            try {
+                Toast toast = Toast.makeText(ApplicationLoader.applicationContext, LocaleController.getString("UnsupportedAttachment", R.string.UnsupportedAttachment), Toast.LENGTH_SHORT);
+                toast.show();
+            } catch (Exception e) {
+                FileLog.e(e);
+            }
+        });
     }
 
     @UiThread
@@ -7201,7 +7205,10 @@ public class SendMessagesHelper extends BaseController implements NotificationCe
                         mediaCount = 0;
                     }
                     mediaCount++;
-                    prepareSendingDocumentInternal(accountInstance, sendAsDocuments.get(a), sendAsDocumentsOriginal.get(a), sendAsDocumentsUri.get(a), extension, dialogId, replyToMsg, replyToTopMsg, sendAsDocumentsCaptions.get(a), sendAsDocumentsEntities.get(a), editingMessageObject, groupId2, mediaCount == 10 || a == documentsCount - 1, forceDocument, notify, scheduleDate, null);
+                    boolean error = !prepareSendingDocumentInternal(accountInstance, sendAsDocuments.get(a), sendAsDocumentsOriginal.get(a), sendAsDocumentsUri.get(a), extension, dialogId, replyToMsg, replyToTopMsg, sendAsDocumentsCaptions.get(a), sendAsDocumentsEntities.get(a), editingMessageObject, groupId2, mediaCount == 10 || a == documentsCount - 1, forceDocument, notify, scheduleDate, null);
+                    if (error) {
+                        showUnsupportedAttachmentError();
+                    }
                 }
             }
             if (BuildVars.LOGS_ENABLED) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
@@ -5586,7 +5586,7 @@ public class SendMessagesHelper extends BaseController implements NotificationCe
         MimeTypeMap myMime = MimeTypeMap.getSingleton();
         TLRPC.TL_documentAttributeAudio attributeAudio = null;
         String extension = null;
-        if (uri != null) {
+        if (uri != null && path == null) {
             boolean hasExt = false;
             if (mime != null) {
                 extension = myMime.getExtensionFromMimeType(mime);


### PR DESCRIPTION
**Description of the problem from user perspective:**

Some stickers aren't sent to Telegram when using Facemoji keyboard.

**Steps to reproduce:**

1. Install Telegram and Facemoji keyboard (or any other keyboard that uses `webp` file format for stickers)
2. Open any group or chat in Telegram
3. Press the sticker button in Facemoji, select "Hot" category and try to send any not-animated sticker. If this sticker is in `webp` format, it won't be sent. No error messages are shown

https://user-images.githubusercontent.com/2638864/107880185-0a181b80-6eff-11eb-876c-78750c512c43.mp4


**Cause of the problem**

When calling [prepareSendingDocumentInternal](https://github.com/DrKLO/Telegram/blob/3480f19272fbe7679172dc51473e19fcf184501c/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java#L5576), there is an attempt to [copy the file to cache](https://github.com/DrKLO/Telegram/blob/3480f19272fbe7679172dc51473e19fcf184501c/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java#L5599) even though access permission for content URI associated with this file [was already released](https://github.com/DrKLO/Telegram/blob/3480f19272fbe7679172dc51473e19fcf184501c/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java#L7193), which leads to `SecurityException` [here](https://github.com/DrKLO/Telegram/blob/3480f19272fbe7679172dc51473e19fcf184501c/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java#L4119):

```
java.lang.SecurityException: Permission Denial: reading androidx.core.content.FileProvider uri content://com.simejikeyboard.FileProvider/root/storage/emulated/0/Android/data/com.simejikeyboard/files/tmp/facemoji_share/1613316979436.webp from pid=20479, uid=10949 requires the provider be exported, or grantUriPermission()
    at android.os.Parcel.createException(Parcel.java:2074)
    at android.os.Parcel.readException(Parcel.java:2042)
    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:188)
    at android.database.DatabaseUtils.readExceptionWithFileNotFoundExceptionFromParcel(DatabaseUtils.java:151)
    at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:705)
    at android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:1702)
    at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1518)
    at android.content.ContentResolver.openInputStream(ContentResolver.java:1202)
    at org.telegram.messenger.MediaController.copyFileToCache(MediaController.java:4098)
    at org.telegram.messenger.SendMessagesHelper.prepareSendingDocumentInternal(SendMessagesHelper.java:5599)
    at org.telegram.messenger.SendMessagesHelper.lambda$prepareSendingMedia$85(SendMessagesHelper.java:7204)
    at org.telegram.messenger.-$$Lambda$SendMessagesHelper$FlIwzJmV2SCMvUBAdUxDw_pTq94.run(Unknown Source:22)
    at android.os.Handler.handleCallback(Handler.java:883)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loop(Looper.java:224)
    at org.telegram.messenger.DispatchQueue.run(DispatchQueue.java:117)


```

**Solution:**

We should check whether the file is already copied to cache. If it is (which is the case), there's no need to copy it again.


https://user-images.githubusercontent.com/2638864/107880307-bce87980-6eff-11eb-8784-61ddad2d3265.mp4


**Other observations/suggestions:**

**No error messages are shown when sticker sending failed**
We should show a user friendly message when sticker sending failed.
The method [prepareSendingDocumentInternal](https://github.com/DrKLO/Telegram/blob/3480f19272fbe7679172dc51473e19fcf184501c/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java#L5576) returns boolean value indicating whether the file was sent successfully or not. But this result value wasn't used in some places, including when sending stickers. It's now fixed in [c03b3cc](https://github.com/DrKLO/Telegram/pull/1615/commits/c03b3cc7c66f951263b720f53f01de4ab6ebd663).


https://user-images.githubusercontent.com/2638864/107882593-fe7f2180-6f0b-11eb-9762-7f701b9c36a9.mp4



**Wrong `mime` value**
In some situations [prepareSendingDocumentInternal](https://github.com/DrKLO/Telegram/blob/3480f19272fbe7679172dc51473e19fcf184501c/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java#L5576) accepts wrong `mime` value, which might lead to subtle bugs.

For instance, in the case of `webp` the value of `mime` is `webp`, which is not a valid mime type. This can lead to the following:

1. [MimeTypeMap.getExtensionsFromMimeType](https://github.com/DrKLO/Telegram/blob/3480f19272fbe7679172dc51473e19fcf184501c/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java#L5592) returns null
2. Later the `extension` variable is [assigned](https://github.com/DrKLO/Telegram/blob/3480f19272fbe7679172dc51473e19fcf184501c/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java#L5595) to `txt` which is wrong

One possible solution to this would be to check whether the `mime` is actually a valid mime type. If it's not, we can assume that it's the file extension. But this is not reliable.

A better approach would be to enforce `mime` to be a valid mime type. For that, we need to check all places where `prepareSendingDocumentInternal` is called.