### PR TITLE
Fix "view thread" not showing up on replies

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -17952,7 +17952,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                             options.add(3);
                             icons.add(R.drawable.msg_copy);
                         }
-                        if (!isThreadChat() && chatMode != MODE_SCHEDULED && currentChat != null && (currentChat.has_link || message.hasReplies()) && currentChat.megagroup && message.canViewThread()) {
+                        if (!isThreadChat() && chatMode != MODE_SCHEDULED && currentChat != null && currentChat.megagroup && message.canViewThread()) {
                             if (message.hasReplies()) {
                                 items.add(LocaleController.formatPluralString("ViewReplies", message.getRepliesCount()));
                             } else {
@@ -18174,7 +18174,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                             options.add(3);
                             icons.add(R.drawable.msg_copy);
                         }
-                        if (!isThreadChat() && chatMode != MODE_SCHEDULED && currentChat != null && (currentChat.has_link || message.hasReplies()) && currentChat.megagroup && message.canViewThread()) {
+                        if (!isThreadChat() && chatMode != MODE_SCHEDULED && currentChat != null && currentChat.megagroup && message.canViewThread()) {
                             if (message.hasReplies()) {
                                 items.add(LocaleController.formatPluralString("ViewReplies", message.getRepliesCount()));
                             } else {


### PR DESCRIPTION
This part of the check means "view thread" will only show up if there is a channel linked to the group.
I'm unable to test this patch, but I'm pretty confident in it given how simple the change is.
Related tdesktop pull request (tested): https://github.com/telegramdesktop/tdesktop/pull/10377