### PR TITLE
fixed country code and phone no. population logic

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
@@ -1711,30 +1711,15 @@ public class LoginActivity extends BaseFragment {
                     }
                     if (!newAccount && allowCall) {
                         String number = PhoneFormat.stripExceptNumbers(tm.getLine1Number());
-                        String textToSet = null;
-                        boolean ok = false;
+                        String countryCode = tm.getSimCountryIso();
                         if (!TextUtils.isEmpty(number)) {
-                            if (number.length() > 4) {
-                                for (int a = 4; a >= 1; a--) {
-                                    String sub = number.substring(0, a);
-                                    String country = codesMap.get(sub);
-                                    if (country != null) {
-                                        ok = true;
-                                        textToSet = number.substring(a);
-                                        codeField.setText(sub);
-                                        break;
-                                    }
-                                }
-                                if (!ok) {
-                                    textToSet = number.substring(1);
-                                    codeField.setText(number.substring(0, 1));
-                                }
-                            }
-                            if (textToSet != null) {
                                 phoneField.requestFocus();
-                                phoneField.setText(textToSet);
+                                phoneField.setText(number);
                                 phoneField.setSelection(phoneField.length());
-                            }
+                        }
+                        if(!TextUtils.isEmpty(countryCode))
+                        {
+                            codeField.setText(codesMap.get(countryCode));
                         }
                     }
                 }


### PR DESCRIPTION

**Problem** 

When people try to log in or sign up, the characters in the phone number are used to set the country code, which is incorrect.
This results in country code and phone number being populated incorrectly. 

Example of incorrect behaviour :  
Phone number below is : 6692049100
Country is US

However, 66 is taken for country

![image](https://user-images.githubusercontent.com/48738678/111900680-2cff8900-89f1-11eb-84c3-c7416a27e1b0.png)


**Solution**
Use getSimCountryIso() to retrieve country codes