### PR TITLE
Added keep media time of 1 day.

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/SharedConfig.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SharedConfig.java
@@ -505,15 +505,18 @@ public class SharedConfig {
         lastKeepMediaCheckTime = time;
         File cacheDir = FileLoader.checkDirectory(FileLoader.MEDIA_DIR_CACHE);
         Utilities.globalQueue.postRunnable(() -> {
-            if (keepMedia != 2) {
+            if (keepMedia != 3) {
                 int days;
                 if (keepMedia == 0) {
-                    days = 7;
+                    days = 3;
                 } else if (keepMedia == 1) {
+                    days = 7;
+                } else if (keepMedia == 2) {
                     days = 30;
                 } else {
-                    days = 3;
+                    days = 1;
                 }
+
                 long currentTime = time - 60 * 60 * 24 * days;
                 final SparseArray<File> paths = ImageLoader.getInstance().createMediaPaths();
                 for (int a = 0; a < paths.size(); a++) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/CacheControlActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/CacheControlActivity.java
@@ -687,13 +687,15 @@ public class CacheControlActivity extends BaseFragment {
                     SharedPreferences preferences = MessagesController.getGlobalMainSettings();
                     slideChooseView.setCallback(index -> {
                         if (index == 0) {
-                            SharedConfig.setKeepMedia(3);
+                            SharedConfig.setKeepMedia(4);
                         } else if (index == 1) {
                             SharedConfig.setKeepMedia(0);
                         } else if (index == 2) {
                             SharedConfig.setKeepMedia(1);
                         } else if (index == 3) {
                             SharedConfig.setKeepMedia(2);
+                        } else if (index == 4) {
+                            SharedConfig.setKeepMedia(3);
                         }
                     });
                     int keepMedia = SharedConfig.keepMedia;
@@ -703,7 +705,7 @@ public class CacheControlActivity extends BaseFragment {
                     } else {
                         index = keepMedia + 1;
                     }
-                    slideChooseView.setOptions(index, LocaleController.formatPluralString("Days", 3), LocaleController.formatPluralString("Weeks", 1), LocaleController.formatPluralString("Months", 1), LocaleController.getString("KeepMediaForever", R.string.KeepMediaForever));
+                    slideChooseView.setOptions(index, LocaleController.formatPluralString("Days", 1), LocaleController.formatPluralString("Days", 3), LocaleController.formatPluralString("Weeks", 1), LocaleController.formatPluralString("Months", 1), LocaleController.getString("KeepMediaForever", R.string.KeepMediaForever));
                     break;
                 case 1:
                 default:


### PR DESCRIPTION
Now minimal keep media time is 3 days. 
If you read a lot of channels/groups, media will take up a lot of space. 
If your phone does not have enough memory, you will have to clean cache manually and sometimes it is annoying.
Keep media time of 1 day solves this problem.