### PR TITLE
replace playstore app URL in telegram direct

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/BuildVars.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/BuildVars.java
@@ -28,6 +28,7 @@ public class BuildVars {
     //
     public static String SMS_HASH = isStandaloneApp() ? "w0lkcmTZkKh" : (DEBUG_VERSION ? "O2P2z+/jBpJ" : "oLeq9AcOZkT");
     public static String PLAYSTORE_APP_URL = "https://play.google.com/store/apps/details?id=org.telegram.messenger";
+    public static String DIRECT_APP_URL = "https://telegram.org/android";
 
     static {
         if (ApplicationLoader.applicationContext != null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AlertsCreator.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AlertsCreator.java
@@ -379,7 +379,7 @@ public class AlertsCreator {
         builder.setMessage(text);
         builder.setPositiveButton(LocaleController.getString("OK", R.string.OK), null);
         if (updateApp) {
-            builder.setNegativeButton(LocaleController.getString("UpdateApp", R.string.UpdateApp), (dialog, which) -> Browser.openUrl(context, BuildVars.PLAYSTORE_APP_URL));
+            builder.setNegativeButton(LocaleController.getString("UpdateApp", R.string.UpdateApp), (dialog, which) -> Browser.openUrl(context, isStandaloneApp() ? BuildVars.DIRECT_APP_URL : BuildVars.PLAYSTORE_APP_URL));
         }
         return builder.show();
     }


### PR DESCRIPTION
currently users of telegram direct (`org.telegram.messenger.web`) are prompted to open playstore when they click on "update app" button, this changes it so the button opens telegram.org/android instead, as telegram direct version cannot be updated from playstore.