### PR TITLE
Fix text alignment in multiline sub menu item

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBarMenuSubItem.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBarMenuSubItem.java
@@ -128,6 +128,7 @@ public class ActionBarMenuSubItem extends FrameLayout {
         textView.setLines(2);
         textView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
         textView.setSingleLine(false);
+        textView.setGravity(Gravity.CENTER_VERTICAL);
     }
 
     public void setTextAndIcon(CharSequence text, int icon, Drawable iconDrawable) {


### PR DESCRIPTION
Align vertically incase the translation fits in one line