### PR TITLE
space waste fix

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
@@ -1807,12 +1807,12 @@ public class AndroidUtilities {
 
     public static int getMinTabletSide() {
         if (!isSmallTablet()) {
-            int smallSide = Math.min(displaySize.x, displaySize.y);
-            int leftSide = smallSide * 35 / 100;
+            int theSide = displaySize.x;
+            int leftSide = theSide * 35 / 100;
             if (leftSide < dp(320)) {
                 leftSide = dp(320);
             }
-            return smallSide - leftSide;
+            return theSide - leftSide;
         } else {
             int smallSide = Math.min(displaySize.x, displaySize.y);
             int maxSide = Math.max(displaySize.x, displaySize.y);


### PR DESCRIPTION
for large tablets in landscape orientation
no need to pickiup the small one, just use the x

before
![space_waste_nopr](https://user-images.githubusercontent.com/3670331/157108911-b6af5f4a-7ca0-422b-b559-4a43571f5ccc.png)
.
after
![space_waste_pr](https://user-images.githubusercontent.com/3670331/157108963-a70988d0-22f6-4287-9e41-385dd1568331.png)

