### PR TITLE
remove the splash

### DIFF
--- a/TMessagesProj/src/main/res/values-v21/styles.xml
+++ b/TMessagesProj/src/main/res/values-v21/styles.xml
@@ -13,8 +13,8 @@
 
     <style name="Theme.TMessages.Start" parent="@android:style/Theme.Material">
         <item name="android:actionBarStyle">@style/ActionBar.Transparent.TMessages.Start</item>
-        <item name="android:colorBackground">@android:color/white</item>
-        <item name="android:windowBackground">@android:color/white</item>
+        <item name="android:colorBackground">@android:color/black</item>
+        <item name="android:windowBackground">@android:color/black</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:colorPrimaryDark">#426482</item>
         <item name="android:colorPrimary">#527da3</item>

--- a/TMessagesProj/src/main/res/values/styles.xml
+++ b/TMessagesProj/src/main/res/values/styles.xml
@@ -5,8 +5,8 @@
 
     <style name="Theme.TMessages.Start" parent="@android:style/Theme.Holo.Light">
         <item name="android:actionBarStyle">@style/ActionBar.Transparent.TMessages.Start</item>
-        <item name="android:colorBackground">@android:color/white</item>
-        <item name="android:windowBackground">@android:color/white</item>
+        <item name="android:colorBackground">@android:color/black</item>
+        <item name="android:windowBackground">@android:color/black</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:textViewStyle">@style/MyTextViewStyle</item>
     </style>


### PR DESCRIPTION
When nigth is theme loading TG app display shortly white shiny color background. Thats burning eyes in the dark.
So default start now use dark color.
before
![Screenshot_20220308-170803_Telegraher_DEBUG](https://user-images.githubusercontent.com/3670331/157294930-9064946d-9cba-4d6b-8d90-c3aca8ee8b63.png)


after
![Screenshot_20220308-180903_Telegraher_DEBUG](https://user-images.githubusercontent.com/3670331/157294981-a3d779cf-40e3-4bc6-a53d-f7f55ccdaa29.png)

