### PR TITLE
Fix switch_inline_query_current_chat

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -6922,7 +6922,7 @@ public class ChatActivityEnterView extends BlurredFrameLayout implements Notific
                 return true;
             }
             if (button.same_peer) {
-                long uid = messageObject.messageOwner.from_id.user_id;
+                long uid = messageObject.messageOwner.peer_id.user_id;
                 if (messageObject.messageOwner.via_bot_id != 0) {
                     uid = messageObject.messageOwner.via_bot_id;
                 }


### PR DESCRIPTION
Then bot send keyboard with switch_inline_query_current_chat param, app wrong select user id and set Field text to @user_name and query, but right is @bot_user_name and query.