### PR TITLE
Add support for importing video stickers

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -4197,6 +4197,9 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 if (header[0] == 0x1f && header[1] == (byte) 0x8b) {
                     return "tgs";
                 }
+                if (header[0] == 0x1A && header[1] == (byte) 0x45 && header[2] == (byte) 0xDF && header[3] == (byte) 0xA3) {
+                    return "webm";
+                }
                 String str = new String(header);
                 if (str != null) {
                     str = str.toLowerCase();

--- a/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SendMessagesHelper.java
@@ -277,6 +277,7 @@ public class SendMessagesHelper extends BaseController implements NotificationCe
         public boolean validated;
         public String mimeType;
         public boolean animated;
+        public boolean video;
         public TLRPC.TL_inputStickerSetItem item;
 
         public void uploadMedia(int account, TLRPC.InputFile inputFile, Runnable onFinish) {
@@ -403,6 +404,7 @@ public class SendMessagesHelper extends BaseController implements NotificationCe
             req.title = title;
             req.short_name = shortName;
             req.animated = uploadMedia.get(0).animated;
+            req.videos = uploadMedia.get(0).video;
             if (software != null) {
                 req.software = software;
                 req.flags |= 8;

--- a/TMessagesProj/src/main/java/org/telegram/tgnet/TLRPC.java
+++ b/TMessagesProj/src/main/java/org/telegram/tgnet/TLRPC.java
@@ -52262,6 +52262,7 @@ public class TLRPC {
         public int flags;
         public boolean masks;
         public boolean animated;
+        public boolean videos;
         public InputUser user_id;
         public String title;
         public String short_name;
@@ -52277,6 +52278,7 @@ public class TLRPC {
             stream.writeInt32(constructor);
             flags = masks ? (flags | 1) : (flags &~ 1);
             flags = animated ? (flags | 2) : (flags &~ 2);
+            flags = videos ? (flags | 16) : (flags &~ 16);
             stream.writeInt32(flags);
             user_id.serializeToStream(stream);
             stream.writeString(title);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/StickerEmojiCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/StickerEmojiCell.java
@@ -124,6 +124,10 @@ public class StickerEmojiCell extends FrameLayout {
             stickerPath = path;
             if (path.validated) {
                 imageView.setImage(ImageLocation.getForPath(path.path), "80_80", null, null, DocumentObject.getSvgRectThumb(Theme.key_dialogBackgroundGray, 1.0f), null, path.animated ? "tgs" : null, 0, null);
+            } else if (path.video) {
+                ImageLocation imageLocation = ImageLocation.getForPath(path.path);
+                imageLocation.imageType = FileLoader.IMAGE_TYPE_ANIMATION;
+                imageView.setImage(imageLocation, "0", null, null, DocumentObject.getSvgRectThumb(Theme.key_dialogBackgroundGray, 1.0f), null, path.animated ? "tgs" : null, 0, null);
             } else {
                 imageView.setImage(null, null, null, null, DocumentObject.getSvgRectThumb(Theme.key_dialogBackgroundGray, 1.0f), null, path.animated ? "tgs" : null, 0, null);
             }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/StickersAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/StickersAlert.java
@@ -288,6 +288,7 @@ public class StickersAlert extends BottomSheet implements NotificationCenter.Not
             BitmapFactory.Options opts = new BitmapFactory.Options();
             opts.inJustDecodeBounds = true;
             Boolean isAnimated = null;
+            Boolean isVideo = null;
             for (int a = 0, N = uris.size(); a < N; a++) {
                 Object obj = uris.get(a);
                 if (obj instanceof Uri) {
@@ -297,9 +298,11 @@ public class StickersAlert extends BottomSheet implements NotificationCenter.Not
                         continue;
                     }
                     boolean animated = "tgs".equals(ext);
+                    boolean video = "webm".equals(ext);
                     if (isAnimated == null) {
                         isAnimated = animated;
-                    } else if (isAnimated != animated) {
+                        isVideo = video;
+                    } else if (isAnimated != animated || isVideo != video) {
                         continue;
                     }
                     if (isDismissed()) {
@@ -307,19 +310,22 @@ public class StickersAlert extends BottomSheet implements NotificationCenter.Not
                     }
                     SendMessagesHelper.ImportingSticker importingSticker = new SendMessagesHelper.ImportingSticker();
                     importingSticker.animated = animated;
-                    importingSticker.path = MediaController.copyFileToCache(uri, ext, (animated ? 64 : 512) * 1024);
+                    importingSticker.video = video;
+                    importingSticker.path = MediaController.copyFileToCache(uri, ext, (animated ? 64 : video ? 256 : 512) * 1024);
                     if (importingSticker.path == null) {
                         continue;
                     }
-                    if (!animated) {
+                    if (!animated && !video) {
                         BitmapFactory.decodeFile(importingSticker.path, opts);
                         if ((opts.outWidth != 512 || opts.outHeight <= 0 || opts.outHeight > 512) && (opts.outHeight != 512 || opts.outWidth <= 0 || opts.outWidth > 512)) {
                             continue;
                         }
                         importingSticker.mimeType = "image/" + ext;
                         importingSticker.validated = true;
-                    } else {
+                    } else if (animated) {
                         importingSticker.mimeType = "application/x-tgsticker";
+                    } else {
+                        importingSticker.mimeType = "video/webm";
                     }
                     if (emoji != null && emoji.size() == N && emoji.get(a) instanceof String) {
                         importingSticker.emoji = emoji.get(a);


### PR DESCRIPTION
This pull request contains a few code changes to enable video stickers importing.

Currently, though documentation of [Importing Stickers to Telegram](https://core.telegram.org/import-stickers) mentions that it is possible to import video stickers the Android client cannot handle them. I've tried to report this issue through e-mail with no response, so decided to try and make the required changes. Hope this finds its way to the developers.

### Changes

-  updating "TL_stickers_createStickerSet"
-  detecting WebM magic bytes
-  adding necessary isVideo fields to certain models
-  changes in "StickerEmojiCell" for previewing WebM to work

###  What needs to be reviewed

-  Whether it is necessary to validate WebM first? If yes, local or remote?
-  code changes made in "StickerEmojiCell"