### PR TITLE
Fix for a strange vibro flow in telegram

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/EmojiAnimationsOverlay.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/EmojiAnimationsOverlay.java
@@ -205,7 +205,7 @@ public class EmojiAnimationsOverlay implements NotificationCenter.NotificationCe
 
         if (bestView != null) {
             chatActivity.restartSticker(bestView);
-            if (!EmojiData.hasEmojiSupportVibration(bestView.getMessageObject().getStickerEmoji())) {
+            if (EmojiData.hasEmojiSupportVibration(bestView.getMessageObject().getStickerEmoji())) {
                 bestView.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
             }
             showAnimationForCell(bestView, animation, false, true);
@@ -267,7 +267,7 @@ public class EmojiAnimationsOverlay implements NotificationCenter.NotificationCe
             return;
         }
         boolean show = showAnimationForCell(view, -1, true, false);
-        if (show && !EmojiData.hasEmojiSupportVibration(view.getMessageObject().getStickerEmoji())) {
+        if (show && EmojiData.hasEmojiSupportVibration(view.getMessageObject().getStickerEmoji())) {
             view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
         }
 


### PR DESCRIPTION
The original flow:

- check `hasEmojiSupportVibration`
- if not, then vibro
- WTF?!

so fixed the way "if emoji support vibration we will activate the vibro".
If i'm wrong, please explain me your idea :smile: 