### PR TITLE
Fix return value of onKeyDispatch instead of returning always false.

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -5993,7 +5993,7 @@ public class LaunchActivity extends BasePermissionsActivity implements ActionBar
             }
         }
         try {
-            super.dispatchKeyEvent(event);
+            return super.dispatchKeyEvent(event);
         } catch (Exception e) {
             FileLog.e(e);
         }


### PR DESCRIPTION
onKeyDispatchEvent method in LaunchActivity always returned false if event was bubbled up to super.dispatchKeyEvent.
This created various bugs with hardware keyboards: for example, backspace button was handled twice, while cursor buttons didn't work at all.
This pull request fixes those issues.