### PR TITLE
Fixed incorrect order in proxy list

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/SharedConfig.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SharedConfig.java
@@ -1102,7 +1102,7 @@ public class SharedConfig {
                         data.readString(false),
                         data.readString(false),
                         data.readString(false));
-                proxyList.add(info);
+                proxyList.add(0, info);
                 if (currentProxy == null && !TextUtils.isEmpty(proxyAddress)) {
                     if (proxyAddress.equals(info.address) && proxyPort == info.port && proxyUsername.equals(info.username) && proxyPassword.equals(info.password)) {
                         currentProxy = info;
@@ -1121,7 +1121,7 @@ public class SharedConfig {
         SerializedData serializedData = new SerializedData();
         int count = proxyList.size();
         serializedData.writeInt32(count);
-        for (int a = 0; a < count; a++) {
+        for (int a = count - 1; a >= 0; a--) {
             ProxyInfo info = proxyList.get(a);
             serializedData.writeString(info.address != null ? info.address : "");
             serializedData.writeInt32(info.port);
@@ -1143,7 +1143,7 @@ public class SharedConfig {
                 return info;
             }
         }
-        proxyList.add(proxyInfo);
+        proxyList.add(0, proxyInfo);
         saveProxyList();
         return proxyInfo;
     }


### PR DESCRIPTION
Recently added proxies will appear on the top instead of bottom of the list of proxies (https://bugs.telegram.org/c/1128)