### PR TITLE
Fix black screen in topics (Forwarding messages)

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/LNavigation/LNavigation.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LNavigation/LNavigation.java
@@ -1357,10 +1357,12 @@ public class LNavigation extends FrameLayout implements INavigationLayout, Float
             lastFragment.onTransitionAnimationStart(false, true);
             if (newLastFragment != null) {
                 newLastFragment.setPaused(false);
+                newLastFragment.onTransitionAnimationStart(true, false);
             }
 
             if (swipeProgress == 0) {
                 customAnimation = lastFragment.onCustomTransitionAnimation(false, () -> {
+                    lastFragment.onTransitionAnimationEnd(false, true);
                     onCloseAnimationEnd(lastFragment, newLastFragment);
 
                     customAnimation = null;


### PR DESCRIPTION
When you try to forward any message from topic to a topic, the screen becomes black if you use Alternative navigation. We have to use animation start and end to fix this issue