### PR TITLE
Fix ipv6 connection hangs when in v4 environment

### DIFF
--- a/TMessagesProj/jni/tgnet/Connection.cpp
+++ b/TMessagesProj/jni/tgnet/Connection.cpp
@@ -305,9 +305,7 @@ void Connection::connect() {
             ipv6 = value % 3 == 0 ? TcpAddressFlagIpv6 : 0;
             ConnectionsManager::getInstance(currentDatacenter->instanceNum).lastProtocolIsIpv6 = ipv6 != 0;
         }
-        if (connectionType == ConnectionTypeGeneric) {
-            ConnectionsManager::getInstance(currentDatacenter->instanceNum).lastProtocolUsefullData = false;
-        }
+        ConnectionsManager::getInstance(currentDatacenter->instanceNum).lastProtocolUsefullData = false;
     } else {
         ipv6 = 0;
     }


### PR DESCRIPTION
Since connection will be reset to `USE_IPV4_IPV6_RANDOM` when connection failed even in pure v4 environment.

https://github.com/DrKLO/Telegram/blob/0e17caa7a6facd8220077ee708c4acc942a175d1/TMessagesProj/jni/tgnet/Connection.cpp#L699-L702

However, it does not reset `lastProtocolUsefullData` correctly if `connectionType` is not `ConnectionTypeGeneric` (usually problem occurs when `ConnectionTypeGenericMedia`) and `lastProtocolUsefullData` will be set `false` only here.

https://github.com/DrKLO/Telegram/blob/0e17caa7a6facd8220077ee708c4acc942a175d1/TMessagesProj/jni/tgnet/Connection.cpp#L299-L311

So it always connect as ipv6 if `lastProtocolUsefullData` is `true` and `RAND_bytes` got 0, 3, 6 even there is no ipv6 capability.

I try to fix it using always reset `lastProtocolUsefullData` to `false` when `USE_IPV4_IPV6_RANDOM` is meet.