### PR TITLE
Update theme icon in the drawer when theme is changed from settings

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/DrawerProfileCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/DrawerProfileCell.java
@@ -436,6 +436,15 @@ public class DrawerProfileCell extends FrameLayout implements NotificationCenter
         NotificationCenter.getGlobalInstance().postNotificationName(NotificationCenter.needSetDayNightTheme, themeInfo, false, pos, -1, toDark, darkThemeView);
     }
 
+    public void updateSunDrawable(boolean toDark) {
+        if (toDark) {
+            sunDrawable.setCustomEndFrame(36);
+        } else {
+            sunDrawable.setCustomEndFrame(0);
+        }
+        darkThemeView.playAnimation();
+    }
+
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();

--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -5674,6 +5674,10 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
                         themeSwitchSunView.setVisibility(View.VISIBLE);
                         themeSwitchSunView.invalidate();
                     }
+                    if (sideMenu != null) {
+                        final DrawerProfileCell profileCell = (DrawerProfileCell) sideMenu.getChildAt(0);
+                        profileCell.updateSunDrawable(toDark);
+                    }
                     themeSwitchImageView.setImageBitmap(bitmap);
                     themeSwitchImageView.setVisibility(View.VISIBLE);
                     themeSwitchSunDrawable = darkThemeView.getAnimatedDrawable();


### PR DESCRIPTION
When user changes theme in the chat settings by clicking on `Switch to Day Mode` or `Switch to Night Mode` button, the button icon in the drawer doesn't change.

### Steps to reproduce:

1.  Go to `Chat Settings` in the settings menu.
2.  In the chat settings, change theme by clicking on `Switch to Day Mode` or `Switch to Night Mode`.
3.  After changing the theme come back to initial page (`LaunchActivity`).
4.  Open the drawer and check the theme button in the drawer, (it shows wrong image (sun instead of moon or moon instead of sun)).
5.  Now change the theme from drawer button the button animation doesn't trigger.
