### PR TITLE
Fix issue with search in ActionBar

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/EditTextEffects.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/EditTextEffects.java
@@ -147,6 +147,7 @@ public class EditTextEffects extends EditText {
 
             Layout layout = getLayout();
             if (text instanceof Spannable && layout != null) {
+                if (start > layout.getLineCount()) return;
                 int line = layout.getLineForOffset(start);
                 int x = (int) layout.getPrimaryHorizontal(start);
                 int y = (int) ((layout.getLineTop(line) + layout.getLineBottom(line)) / 2f);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/EditTextEffects.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/EditTextEffects.java
@@ -146,8 +146,7 @@ public class EditTextEffects extends EditText {
             invalidateEffects();
 
             Layout layout = getLayout();
-            if (text instanceof Spannable && layout != null) {
-                if (start > layout.getLineCount()) return;
+            if (text instanceof Spannable && layout != null && start <= layout.getLineCount()) {
                 int line = layout.getLineForOffset(start);
                 int x = (int) layout.getPrimaryHorizontal(start);
                 int y = (int) ((layout.getLineTop(line) + layout.getLineBottom(line)) / 2f);


### PR DESCRIPTION
This pull request fixes an issue where searching for the "from:" keyword in the ActionBar would cause the app to crash. The issue was caused by attempting to access a line in the layout that did not exist. The solution is to add a check to ensure that the line offset is within the bounds of the layout before attempting to access it. This fix will prevent the app from crashing when searching for "from:" in the ActionBar.