### PR TITLE
Fixes to utility function which parses integer.

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/Utilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/Utilities.java
@@ -140,32 +140,9 @@ public class Utilities {
         if (value == null) {
             return 0;
         }
-        if (BuildConfig.BUILD_HOST_IS_WINDOWS) {
-            Matcher matcher = pattern.matcher(value);
-            if (matcher.find()) {
-                return Integer.valueOf(matcher.group());
-            }
-        } else {
-            int val = 0;
-            try {
-                int start = -1, end;
-                for (end = 0; end < value.length(); ++end) {
-                    char character = value.charAt(end);
-                    boolean allowedChar = character == '-' || character >= '0' && character <= '9';
-                    if (allowedChar && start < 0) {
-                        start = end;
-                    } else if (!allowedChar && start >= 0) {
-                        end++;
-                        break;
-                    }
-                }
-                if (start >= 0) {
-                    String str = value.subSequence(start, end).toString();
-//                val = parseInt(str);
-                    val = Integer.parseInt(str);
-                }
-            } catch (Exception ignore) {}
-            return val;
+        Matcher matcher = pattern.matcher(value);
+        if (matcher.find()) {
+            return Integer.valueOf(matcher.group());
         }
         return 0;
     }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/Utilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/Utilities.java
@@ -28,7 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Utilities {
-    public static Pattern pattern = Pattern.compile("[\\-0-9]+");
+    public static Pattern pattern = Pattern.compile("-?[0-9]+");
     public static SecureRandom random = new SecureRandom();
     public static Random fastRandom = new Xoroshiro128PlusRandom(random.nextLong());
 


### PR DESCRIPTION
[Fixed regular expression for int](https://github.com/DrKLO/Telegram/commit/9bc4ddd546cbebe89dba67b0a354c3ce1f255aea) 

Previous regular expression allowed numbers like "-1-1-4" and would throw exceptions during runtime.

[Consistent behaviour independent on build host](https://github.com/DrKLO/Telegram/commit/002eb8c87cc87f36144b0e0f53385e2f3fb8beac) 

This is required since Telegram starts a new contest to improve UI for calls, so guys with MacOS or Linux wouldn't be distracted by this.