### PR TITLE
Fix the reaction box position in the outcome message

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -6255,8 +6255,16 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         }
                         if (captionLayout != null && currentPosition != null && currentMessagesGroup != null && currentMessagesGroup.isDocuments) {
                             reactionsLayoutInBubble.positionOffsetY += AndroidUtilities.dp(10);
-                        } else if (!drawPhotoImage && !TextUtils.isEmpty(messageObject.caption) && ((docTitleLayout != null && docTitleLayout.getLineCount() > 1) || currentMessageObject.hasValidReplyMessageObject())) {
+                        } else if (currentMessageObject.hasValidReplyMessageObject()) {
                             reactionsLayoutInBubble.positionOffsetY += AndroidUtilities.dp(10);
+                        } else if (!drawPhotoImage && !TextUtils.isEmpty(messageObject.caption) && ((docTitleLayout != null && docTitleLayout.getLineCount() > 1))) {
+                            if (currentMessageObject.isOut()) {
+                                if (currentMessageObject.isForwarded()) {
+                                    reactionsLayoutInBubble.positionOffsetY -= AndroidUtilities.dp(4);
+                                }
+                            } else {
+                                reactionsLayoutInBubble.positionOffsetY += AndroidUtilities.dp(10);
+                            }
                         } else if (!drawPhotoImage && !TextUtils.isEmpty(messageObject.caption) && !currentMessageObject.isOutOwner()) {
                             reactionsLayoutInBubble.positionOffsetY += AndroidUtilities.dp(10);
                         }


### PR DESCRIPTION
**Issue**
The reaction box's position in the outcome message with 2-lines titled file and the text wasn't handled. `y` was not updated for this case. 
The issue is reproduced for rtl and non-rtl messages. 

![image](https://github.com/DrKLO/Telegram/assets/18448793/3c7f9132-bc11-4bab-b724-b3257a4b713e)


**Fix**
Added one more condition to adjust the `y` position of the reaction box. 

