### PR TITLE
Fix Premium Cell colors and position

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -10463,7 +10463,10 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
         }
 
         if (dialogsHintCell != null) {
-            SimpleThemeDescription.add(arrayList, dialogsHintCell::updateColors, Theme.key_windowBackgroundWhite, Theme.key_windowBackgroundWhiteBlackText, Theme.key_windowBackgroundWhiteGrayText);
+            arrayList.addAll(SimpleThemeDescription.createThemeDescriptions(() -> {
+                dialogsHintCell.setBackground(Theme.AdaptiveRipple.filledRect());
+            }, Theme.key_windowBackgroundWhite));
+            SimpleThemeDescription.add(arrayList, dialogsHintCell::updateColors, Theme.key_windowBackgroundWhiteBlackText, Theme.key_windowBackgroundWhiteGrayText);
         }
 
         return arrayList;

--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -744,9 +744,15 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
                 filterTabsView.setTranslationY(actionBar.getTranslationY() + tabsYOffset);
                 filterTabsView.setAlpha(filterTabsProgress);
                 viewPages[0].setTranslationY(-(1f - filterTabsProgress) * filterTabsMoveFrom);
+                if (dialogsHintCell != null) {
+                    dialogsHintCell.setTranslationY(actionBar.getTranslationY() + tabsYOffset);
+                }
             } else if (filterTabsView != null && filterTabsView.getVisibility() == View.VISIBLE) {
                 filterTabsView.setTranslationY(actionBar.getTranslationY());
                 filterTabsView.setAlpha(1f);
+                if (dialogsHintCell != null) {
+                    dialogsHintCell.setTranslationY(actionBar.getTranslationY());
+                }
             }
             updateContextViewPosition();
             super.dispatchDraw(canvas);


### PR DESCRIPTION
**Issues**
1. The **background color** was not updated when switching theme. `setBackground` was invoked only once after the initialization. 
2. The cell's position was not updated when opening a forum **in case when the user has folders**.

**Fixes**
1. Add `ThemeDescription` for the cell's background. 
2. The Y value of the `dialogsHintCell` is adjusted to hidden folders.
