### PR TITLE
Speed up opening the photo editor

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/PaintTypeface.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/PaintTypeface.java
@@ -6,7 +6,6 @@ import android.graphics.fonts.Font;
 import android.graphics.fonts.SystemFonts;
 import android.os.Build;
 import android.text.TextUtils;
-import android.util.Log;
 
 import androidx.annotation.RequiresApi;
 
@@ -37,7 +36,7 @@ public class PaintTypeface {
     public static final PaintTypeface MW_BOLD = new PaintTypeface("mw_bold", "PhotoEditorTypefaceMerriweather", AndroidUtilities.getTypeface(AndroidUtilities.TYPEFACE_MERRIWEATHER_BOLD));
     public static final PaintTypeface COURIER_NEW_BOLD = new PaintTypeface("courier_new_bold", "PhotoEditorTypefaceCourierNew", AndroidUtilities.getTypeface(AndroidUtilities.TYPEFACE_COURIER_NEW_BOLD));
 
-    public final static List<PaintTypeface> BUILT_IN_FONTS = Arrays.asList(ROBOTO_MEDIUM, ROBOTO_ITALIC, ROBOTO_SERIF, ROBOTO_MONO, MW_BOLD, COURIER_NEW_BOLD);
+    public static List<PaintTypeface> builtInFonts;
 
     private static final List<String> preferable = Arrays.asList(
         "Google Sans",
@@ -106,7 +105,7 @@ public class PaintTypeface {
     private static List<PaintTypeface> typefaces;
     public static List<PaintTypeface> get() {
         if (typefaces == null) {
-            typefaces = new ArrayList<>(BUILT_IN_FONTS);
+            typefaces = new ArrayList<>(getBuiltInFonts());
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && SYSTEM_FONTS_ENABLED) {
                 Set<Font> fonts = SystemFonts.getAvailableFonts();
                 Iterator<Font> i = fonts.iterator();
@@ -166,6 +165,13 @@ public class PaintTypeface {
             AndroidUtilities.runOnUIThread(runnable);
         });
         return false;
+    }
+
+    public static List<PaintTypeface> getBuiltInFonts() {
+        if (builtInFonts == null) {
+            builtInFonts = Arrays.asList(ROBOTO_MEDIUM, ROBOTO_ITALIC, ROBOTO_SERIF, ROBOTO_MONO, MW_BOLD, COURIER_NEW_BOLD);
+        }
+        return builtInFonts;
     }
 
     static class Family {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/RenderView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/RenderView.java
@@ -123,7 +123,6 @@ public class RenderView extends TextureView {
             }
         });
 
-        input = new Input(this);
         shapeInput = new ShapeInput(this, () -> {
             if (delegate != null) {
                 delegate.invalidateInputView();
@@ -171,7 +170,7 @@ public class RenderView extends TextureView {
         if (brush instanceof Brush.Shape) {
             shapeInput.process(event, getScaleX());
         } else {
-            input.process(event, getScaleX());
+            getInput().process(event, getScaleX());
         }
         return true;
     }
@@ -253,7 +252,7 @@ public class RenderView extends TextureView {
         if (delegate != null) {
             delegate.resetBrush();
         }
-        input.ignoreOnce();
+        getInput().ignoreOnce();
     }
 
     public void clearShape() {
@@ -282,7 +281,7 @@ public class RenderView extends TextureView {
         if (brush instanceof Brush.Shape) {
             shapeInput.setMatrix(matrix);
         } else {
-            input.setMatrix(matrix);
+            getInput().setMatrix(matrix);
         }
 
         float[] proj = GLMatrix.LoadOrtho(0.0f, internal.bufferWidth, 0.0f, internal.bufferHeight, -1.0f, 1.0f);
@@ -322,7 +321,7 @@ public class RenderView extends TextureView {
     }
 
     public void clearAll() {
-        input.clear(() -> painting.setBrush(brush));
+        getInput().clear(() -> painting.setBrush(brush));
     }
 
     private class CanvasInternal extends DispatchQueue {
@@ -605,6 +604,13 @@ public class RenderView extends TextureView {
             internal.setCurrentContext();
             action.run();
         });
+    }
+
+    private Input getInput() {
+        if (input == null) {
+            input = new Input(this);
+        }
+        return input;
     }
 
     protected void selectBrush(Brush brush) {}

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/LPhotoPaintView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/LPhotoPaintView.java
@@ -272,6 +272,9 @@ public class LPhotoPaintView extends SizeNotifierFrameLayoutPhoto implements IPh
 
         queue = new DispatchQueue("Paint");
 
+        // preload built in fonts
+        Utilities.themeQueue.postRunnable(PaintTypeface::getBuiltInFonts);
+
         bitmapToEdit = bitmap;
         facesBitmap = originalBitmap;
         originalBitmapRotation = originalRotation;
@@ -717,7 +720,6 @@ public class LPhotoPaintView extends SizeNotifierFrameLayoutPhoto implements IPh
         textOptionsView.setPadding(AndroidUtilities.dp(16), 0, AndroidUtilities.dp(16), 0);
         textOptionsView.setVisibility(GONE);
         textOptionsView.setDelegate(this);
-        textOptionsView.setTypeface(PersistColorPalette.getInstance(currentAccount).getCurrentTypeface());
         textOptionsView.setAlignment(PersistColorPalette.getInstance(currentAccount).getCurrentAlignment());
         bottomLayout.addView(textOptionsView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 48));
 
@@ -1486,6 +1488,10 @@ public class LPhotoPaintView extends SizeNotifierFrameLayoutPhoto implements IPh
         entitiesView.setVisibility(VISIBLE);
         renderView.setVisibility(View.VISIBLE);
         renderInputView.setVisibility(View.VISIBLE);
+
+        if (textOptionsView != null) {
+            textOptionsView.setTypeface(PersistColorPalette.getInstance(currentAccount).getCurrentTypeface());
+        }
     }
 
     private int getFrameRotation() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/PaintTextOptionsView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/PaintTextOptionsView.java
@@ -162,7 +162,7 @@ public class PaintTextOptionsView extends LinearLayout {
         if (typefaceCell == null) {
             return;
         }
-        for (PaintTypeface typeface : PaintTypeface.BUILT_IN_FONTS) {
+        for (PaintTypeface typeface : PaintTypeface.getBuiltInFonts()) {
             if (typeface.getKey().equals(key)) {
                 typefaceCell.bind(typeface);
                 return;


### PR DESCRIPTION
**Issue**
The UI is freezing when opening the Photo Editor.

**Fix**
- Built In fonts were loaded in the main thread diring the `LPhotoPaintView` creation. It is now loaded on the background thread and only used after the animation has completed.