### PR TITLE
Allow sending pictures up to 2560px

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
@@ -2477,7 +2477,7 @@ public class AndroidUtilities {
 
     public static int getPhotoSize() {
         if (photoSize == null) {
-            photoSize = 1280;
+            photoSize = 2560;
         }
         return photoSize;
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Crop/CropView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Crop/CropView.java
@@ -42,7 +42,7 @@ import java.util.ArrayList;
 
 public class CropView extends FrameLayout implements CropAreaView.AreaViewListener, CropGestureDetector.CropGestureListener {
     private static final float EPSILON = 0.00001f;
-    private static final int RESULT_SIDE = 1280;
+    private static final int RESULT_SIDE = 2560;
     private static final float MAX_SCALE = 30.0f;
 
     public CropAreaView areaView;


### PR DESCRIPTION
- This PR will allow sending pictures up to 2560px.

- Telegram API already allows to send photos with that size.

- Telegram Desktop and some forks (e.g. Nekogram) also supports this.

- There is also bug report for this: https://bugs.telegram.org/c/15370