### PR TITLE
Fix text scaling in web-view

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/WebviewActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/WebviewActivity.java
@@ -217,6 +217,7 @@ public class WebviewActivity extends BaseFragment {
         FrameLayout frameLayout = (FrameLayout) fragmentView;
         if (Build.VERSION.SDK_INT >= 19) {
             webView.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+            webView.getSettings().setLayoutAlgorithm(WebSettings.LayoutAlgorithm.TEXT_AUTOSIZING);
         }
 
         if (Build.VERSION.SDK_INT >= 17) {


### PR DESCRIPTION
Telegram enforces the normal scale type in the app itself but not in web-view. This might lead to unexpected results in all web apps in general, but it's especially noticeable in Flutter web-apps.

Below you can see examples with an [app](https://gallery.flutter.dev/#/reply) from the official Flutter gallery. They were captured on an emulator (Pixel 3A API 34 extension level 7 x86_64) but we also reproduced the issue on physical devices (Samsung S23 Ultra, Google Pixel 7A API 33).

In order to fix this, we can use `WebSettings.LayoutAlgorithm.TEXT_AUTOSIZING`. This shouldn't affect/break anything else.

| System text size | Before | After |
|--------|--------|--------|
| ![Screenshot_20231106_221825](https://github.com/DrKLO/Telegram/assets/2638864/9108a527-b5ae-4aa2-a5df-3fe4c57df5b9) | ![Screenshot_20231106_221836](https://github.com/DrKLO/Telegram/assets/2638864/d2143351-8438-4036-9e3f-be903e2f2a2e) | ![Screenshot_20231106_222102](https://github.com/DrKLO/Telegram/assets/2638864/816cfffb-2940-4f5f-9b07-efb1ae126678) |
| ![Screenshot_20231106_221909](https://github.com/DrKLO/Telegram/assets/2638864/a16d2207-04aa-43a4-908a-f9ef5dd69731) | ![Screenshot_20231106_222005](https://github.com/DrKLO/Telegram/assets/2638864/f8a7f03a-f211-4d3c-bff1-7ad91a6a44ae) | ![Screenshot_20231106_222129](https://github.com/DrKLO/Telegram/assets/2638864/886658e2-3b74-4fe5-91f6-e9d9b77d95d9) |
