### PR TITLE
GLIconSettingsView visibility condition

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/PremiumPreviewFragment.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PremiumPreviewFragment.java
@@ -1229,7 +1229,7 @@ public class PremiumPreviewFragment extends BaseFragment implements Notification
                 @Override
                 public void onLongPress() {
                     super.onLongPress();
-                    if (settingsView != null && !BuildVars.DEBUG_PRIVATE_VERSION) {
+                    if (settingsView != null || !BuildVars.DEBUG_PRIVATE_VERSION) {
                         return;
                     }
 


### PR DESCRIPTION
Hello there!

While using the app from Google Play I accidentally noticed that long pressing the star in the premium mode menu causes the settings screen to open.

This small fix should remove this behaviour for release builds