### PR TITLE
fix:When the application enters the 4:3 preview screen process, it wi…

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/camera/CameraController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/camera/CameraController.java
@@ -173,9 +173,6 @@ public class CameraController implements MediaRecorder.OnInfoListener {
                             List<Camera.Size> list = params.getSupportedPreviewSizes();
                             for (int a = 0; a < list.size(); a++) {
                                 Camera.Size size = list.get(a);
-                                if (size.width == 1280 && size.height != 720) {
-                                    continue;
-                                }
                                 if (size.height < 2160 && size.width < 2160) {
                                     cameraInfo.previewSizes.add(new Size(size.width, size.height));
                                     if (BuildVars.LOGS_ENABLED) {


### PR DESCRIPTION
…ll forcibly select a minimum resolution


CameraController.java
```
      if (size.width == 1280 && size.height != 720) {
          continue;
      }
```
This will filter out 1280x960 resolution


CameraView.java
```
} else {
            if (Math.abs(screenSize - size4to3) < 0.1f) {
                aspectRatio = new Size(4, 3);
                wantedWidth = 1280;
                wantedHeight = 960;
```
After entering the 4:3 resolution branch, wantedresolution is 1280x960

CameraController.java
```
 for (int a = 0; a < choices.size(); a++) {
            Size option = choices.get(a);
            if (notBigger && (option.getHeight() > height || option.getWidth() > width)) {
                continue;
            }
            if (option.getHeight() == option.getWidth() * h / w && option.getWidth() >= width && option.getHeight() >= height) {
                bigEnoughWithAspectRatio.add(option);
            } else if (option.getHeight() * option.getWidth() <= width * height * 4) {
                bigEnough.add(option);
            }
        }
```
`option.getHeight() > height || option.getWidth() > width)`
`option.getWidth() >= width && option.getHeight() >= height`
The above two judgments result in only 1280x960 being selected, but it is not in the candidate list.
Finally, go into the bottom-line strategy and chose a very small resolution.

CameraController.java
```
  if (size.width == 1280 && size.height != 720) {
      continue;
  }
```
**The meaning of the code here is unclear, or I hope there are other solutions to fix this problem.**

