### PR TITLE
Feature/contacts enhancements

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/ContactsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ContactsController.java
@@ -15,6 +15,7 @@ import android.content.ContentProviderOperation;
 import android.content.ContentProviderResult;
 import android.content.ContentResolver;
 import android.content.ContentValues;
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.database.ContentObserver;
@@ -36,6 +37,7 @@ import org.telegram.PhoneFormat.PhoneFormat;
 import org.telegram.tgnet.ConnectionsManager;
 import org.telegram.tgnet.TLObject;
 import org.telegram.tgnet.TLRPC;
+import org.telegram.ui.ActionBar.BaseFragment;
 import org.telegram.ui.Components.Bulletin;
 
 import java.text.CollationKey;
@@ -2452,6 +2454,55 @@ public class ContactsController extends BaseController {
                 getNotificationCenter().postNotificationName(NotificationCenter.contactsDidLoad);
             });
         }, ConnectionsManager.RequestFlagFailOnServerErrors | ConnectionsManager.RequestFlagCanCompress);
+    }
+
+    public void deleteContactsUndoable(Context context, BaseFragment fragment, final ArrayList<TLRPC.User> users) {
+        if (users == null || users.isEmpty()) {
+            return;
+        }
+
+        HashMap<TLRPC.User, TLRPC.TL_contact> deletedContacts = new HashMap<>();
+
+        for (int i = 0, N = users.size(); i < N; i++) {
+            TLRPC.User user = users.get(i);
+            TLRPC.TL_contact contact = contactsDict.get(user.id);
+
+            user.contact = false;
+            contacts.remove(contact);
+            contactsDict.remove(user.id);
+
+            deletedContacts.put(user, contact);
+        }
+        buildContactsSectionsArrays(false);
+        getNotificationCenter().postNotificationName(NotificationCenter.updateInterfaces, MessagesController.UPDATE_MASK_NAME);
+        getNotificationCenter().postNotificationName(NotificationCenter.contactsDidLoad);
+        Log.e("AAA", "Fake delete");
+
+        Bulletin.SimpleLayout layout = new Bulletin.SimpleLayout(context, fragment.getResourceProvider());
+        layout.setTimer();
+        layout.textView.setText(LocaleController.formatPluralString("ContactsDeletedUndo", deletedContacts.size()));
+        Bulletin.UndoButton undoButton = new Bulletin.UndoButton(context, true, true, fragment.getResourceProvider());
+        undoButton.setUndoAction(() -> {
+            for (HashMap.Entry<TLRPC.User, TLRPC.TL_contact> entry : deletedContacts.entrySet()) {
+                TLRPC.User user = entry.getKey();
+                TLRPC.TL_contact contact = entry.getValue();
+
+                user.contact = true;
+                contacts.add(contact);
+                contactsDict.put(user.id, contact);
+            }
+            buildContactsSectionsArrays(true);
+            getNotificationCenter().postNotificationName(NotificationCenter.updateInterfaces, MessagesController.UPDATE_MASK_NAME);
+            getNotificationCenter().postNotificationName(NotificationCenter.contactsDidLoad);
+            Log.e("AAA", "Fake undo");
+        });
+        undoButton.setDelayedAction(() -> {
+            deleteContact(users, false);
+            Log.e("AAA", "Actual delete");
+        });
+        layout.setButton(undoButton);
+        Bulletin bulletin = Bulletin.make(fragment, layout, Bulletin.DURATION_PROLONG);
+        bulletin.show();
     }
 
     public void deleteContact(final ArrayList<TLRPC.User> users, boolean showBulletin) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Adapters/ContactsAdapter.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Adapters/ContactsAdapter.java
@@ -59,7 +59,7 @@ public class ContactsAdapter extends RecyclerListView.SectionsAdapter {
     private int onlyUsers;
     private boolean needPhonebook;
     private LongSparseArray<TLRPC.User> ignoreUsers;
-    private LongSparseArray<?> checkedMap;
+    private LongSparseArray<TLRPC.User> selectedContacts;
     private ArrayList<TLRPC.TL_contact> onlineContacts;
     private boolean scrolling;
     private boolean isAdmin;
@@ -74,11 +74,12 @@ public class ContactsAdapter extends RecyclerListView.SectionsAdapter {
     DialogStoriesCell dialogStoriesCell;
     BaseFragment fragment;
 
-    public ContactsAdapter(Context context, BaseFragment fragment, int onlyUsersType, boolean showPhoneBook, LongSparseArray<TLRPC.User> usersToIgnore, int flags, boolean gps) {
+    public ContactsAdapter(Context context, BaseFragment fragment, int onlyUsersType, boolean showPhoneBook, LongSparseArray<TLRPC.User> usersToIgnore, LongSparseArray<TLRPC.User> selectedContacts, int flags, boolean gps) {
         mContext = context;
         onlyUsers = onlyUsersType;
         needPhonebook = showPhoneBook;
         ignoreUsers = usersToIgnore;
+        this.selectedContacts = selectedContacts;
         isAdmin = flags != 0;
         isChannel = flags == 2;
         hasGps = gps;
@@ -173,10 +174,6 @@ public class ContactsAdapter extends RecyclerListView.SectionsAdapter {
         } catch (Exception e) {
             FileLog.e(e);
         }
-    }
-
-    public void setCheckedMap(LongSparseArray<?> map) {
-        checkedMap = map;
     }
 
     public void setIsScrolling(boolean value) {
@@ -558,9 +555,7 @@ public class ContactsAdapter extends RecyclerListView.SectionsAdapter {
                 }
                 TLRPC.User user = MessagesController.getInstance(currentAccount).getUser(arr.get(position).user_id);
                 userCell.setData(user, null, null, 0);
-                if (checkedMap != null) {
-                    userCell.setChecked(checkedMap.indexOfKey(user.id) >= 0, !scrolling);
-                }
+                userCell.setChecked(selectedContacts.indexOfKey(user.id) >= 0, false);
                 if (ignoreUsers != null) {
                     if (ignoreUsers.indexOfKey(user.id) >= 0) {
                         userCell.setAlpha(0.5f);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Adapters/SearchAdapter.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Adapters/SearchAdapter.java
@@ -50,7 +50,7 @@ public class SearchAdapter extends RecyclerListView.SelectionAdapter {
     private ArrayList<Object> searchResult = new ArrayList<>();
     private ArrayList<CharSequence> searchResultNames = new ArrayList<>();
     private SearchAdapterHelper searchAdapterHelper;
-    private LongSparseArray<?> checkedMap;
+    private LongSparseArray<TLRPC.User> selectedUsers;
     private Timer searchTimer;
     private boolean allowUsernameSearch;
     private boolean useUserCell;
@@ -67,9 +67,10 @@ public class SearchAdapter extends RecyclerListView.SelectionAdapter {
     private ArrayList<ContactsController.Contact> unregistredContacts = new ArrayList<>();
 
 
-    public SearchAdapter(Context context, LongSparseArray<TLRPC.User> arg1, boolean usernameSearch, boolean mutual, boolean chats, boolean bots, boolean self, boolean phones, int searchChannelId) {
+    public SearchAdapter(Context context, LongSparseArray<TLRPC.User> arg1, LongSparseArray<TLRPC.User> selected, boolean usernameSearch, boolean mutual, boolean chats, boolean bots, boolean self, boolean phones, int searchChannelId) {
         mContext = context;
         ignoreUsers = arg1;
+        selectedUsers = selected;
         onlyMutual = mutual;
         allowUsernameSearch = usernameSearch;
         allowChats = chats;
@@ -92,10 +93,6 @@ public class SearchAdapter extends RecyclerListView.SelectionAdapter {
                 return ignoreUsers;
             }
         });
-    }
-
-    public void setCheckedMap(LongSparseArray<?> map) {
-        checkedMap = map;
     }
 
     public void setUseUserCell(boolean value) {
@@ -334,9 +331,6 @@ public class SearchAdapter extends RecyclerListView.SelectionAdapter {
             case 0:
                 if (useUserCell) {
                     view = new UserCell(mContext, 1, 1, false);
-                    if (checkedMap != null) {
-                        ((UserCell) view).setChecked(false, false);
-                    }
                 } else {
                     view = new ProfileSearchCell(mContext);
                 }
@@ -412,9 +406,7 @@ public class SearchAdapter extends RecyclerListView.SelectionAdapter {
                     if (useUserCell) {
                         UserCell userCell = (UserCell) holder.itemView;
                         userCell.setData(object, name, username, 0);
-                        if (checkedMap != null) {
-                            userCell.setChecked(checkedMap.indexOfKey(id) >= 0, false);
-                        }
+                        userCell.setChecked(selectedUsers.indexOfKey(id) >= 0, false);
                     } else {
                         ProfileSearchCell profileSearchCell = (ProfileSearchCell) holder.itemView;
                         if (self) {
@@ -422,6 +414,7 @@ public class SearchAdapter extends RecyclerListView.SelectionAdapter {
                         }
                         profileSearchCell.setData(object, null, name, username, false, self);
                         profileSearchCell.useSeparator = (position != getItemCount() - 1 && position != searchResult.size() - 1);
+                        profileSearchCell.setChecked(selectedUsers.indexOfKey(id) >= 0, false);
                         /*if (ignoreUsers != null) {
                             if (ignoreUsers.containsKey(id)) {
                                 profileSearchCell.drawAlpha = 0.5f;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/InviteUserCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/InviteUserCell.java
@@ -90,7 +90,8 @@ public class InviteUserCell extends FrameLayout {
         }
         String newName = null;
 
-        avatarDrawable.setInfo(currentContact.contact_id, currentContact.first_name, currentContact.last_name);
+        avatarDrawable.setInfo(currentContact.contact_id, currentContact.first_name, currentContact.last_name, null, null, null, true);
+
 
         if (currentName != null) {
             nameTextView.setText(currentName, true);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/UserCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/UserCell.java
@@ -41,7 +41,7 @@ import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.AnimatedEmojiDrawable;
 import org.telegram.ui.Components.AvatarDrawable;
 import org.telegram.ui.Components.BackupImageView;
-import org.telegram.ui.Components.CheckBox;
+import org.telegram.ui.Components.CheckBox2;
 import org.telegram.ui.Components.CheckBoxSquare;
 import org.telegram.ui.Components.LayoutHelper;
 import org.telegram.ui.Components.RecyclerListView;
@@ -56,7 +56,7 @@ public class UserCell extends FrameLayout implements NotificationCenter.Notifica
     protected SimpleTextView nameTextView;
     protected SimpleTextView statusTextView;
     private ImageView imageView;
-    private CheckBox checkBox;
+    private CheckBox2 checkBox;
     private CheckBoxSquare checkBoxBig;
     private TextView adminTextView;
     private TextView addButton;
@@ -187,10 +187,11 @@ public class UserCell extends FrameLayout implements NotificationCenter.Notifica
             checkBoxBig = new CheckBoxSquare(context, false);
             addView(checkBoxBig, LayoutHelper.createFrame(18, 18, (LocaleController.isRTL ? Gravity.LEFT : Gravity.RIGHT) | Gravity.CENTER_VERTICAL, LocaleController.isRTL ? 19 : 0, 0, LocaleController.isRTL ? 0 : 19, 0));
         } else if (checkbox == 1) {
-            checkBox = new CheckBox(context, R.drawable.round_check2);
-            checkBox.setVisibility(INVISIBLE);
-            checkBox.setColor(Theme.getColor(Theme.key_checkbox, resourcesProvider), Theme.getColor(Theme.key_checkboxCheck, resourcesProvider));
-            addView(checkBox, LayoutHelper.createFrame(22, 22, (LocaleController.isRTL ? Gravity.RIGHT : Gravity.LEFT) | Gravity.TOP, LocaleController.isRTL ? 0 : 37 + padding, 40, LocaleController.isRTL ? 37 + padding : 0, 0));
+            checkBox = new CheckBox2(context, 21, resourcesProvider);
+            checkBox.setDrawUnchecked(false);
+            checkBox.setDrawBackgroundAsArc(3);
+            checkBox.setColor(-1, Theme.key_windowBackgroundWhite, Theme.key_checkboxCheck);
+            addView(checkBox, LayoutHelper.createFrame(24, 24, (LocaleController.isRTL ? Gravity.RIGHT : Gravity.LEFT) | Gravity.TOP, LocaleController.isRTL ? 0 : 37 + padding, 36, LocaleController.isRTL ? 37 + padding : 0, 0));
         }
 
         if (admin) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AvatarDrawable.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AvatarDrawable.java
@@ -97,6 +97,20 @@ public class AvatarDrawable extends Drawable {
     public static final int AVATAR_TYPE_ANONYMOUS = 21;
     public static final int AVATAR_TYPE_MY_NOTES = 22;
 
+    /**
+     * Matches {@link org.telegram.ui.Components.AvatarConstructorFragment#defaultColors}
+     * but reordered to preserve color tints.
+     */
+    public static final int[][] advancedGradients = new int[][]{
+            new int[]{0xFFF64884, 0xFFEF5B41, 0xFFF6A730, 0xFFFF7742},
+            new int[]{0xFFF5694E, 0xFFF5772C, 0xFFFFD412, 0xFFFFA743},
+            new int[]{0xFF837CFF, 0xFFB063FF, 0xFFFF72A9, 0xFFE269FF},
+            new int[]{0xFF09D260, 0xFF5EDC40, 0xFFC1E526, 0xFF80DF2B},
+            new int[]{0xFF5EB6FB, 0xFF1FCEEB, 0xFF45F7B7, 0xFF1FF1D9},
+            new int[]{0xFF4D8DFF, 0xFF2BBFFF, 0xFF20E2CD, 0xFF0EE1F1},
+            new int[]{0xFFF94BA0, 0xFFFB5C80, 0xFFFFB23A, 0xFFFE7E62},
+    };
+
     private int alpha = 255;
     private Theme.ResourcesProvider resourcesProvider;
     private boolean invalidateTextLayout;
@@ -376,32 +390,71 @@ public class AvatarDrawable extends Drawable {
     }
 
     public void setInfo(long id, String firstName, String lastName, String custom, Integer customColor, MessagesController.PeerColor profileColor) {
-        hasGradient = true;
-        hasAdvancedGradient = false;
+        setInfo(id, firstName, lastName, custom, customColor, profileColor, false);
+    }
+
+    public void setInfo(long id, String firstName, String lastName, String custom, Integer customColor, MessagesController.PeerColor profileColor, boolean advancedGradient) {
         invalidateTextLayout = true;
+        if (advancedGradient) {
+            hasGradient = false;
+            hasAdvancedGradient = true;
+            if (this.advancedGradient == null) {
+                this.advancedGradient = new GradientTools();
+            }
+        } else {
+            hasGradient = true;
+            hasAdvancedGradient = false;
+        }
+
         if (profileColor != null) {
-            color = profileColor.getAvatarColor1();
-            color2 = profileColor.getAvatarColor2();
+            if (advancedGradient) {
+                int[] gradient = advancedGradients[getPeerColorIndex(profileColor.getAvatarColor1())];
+                this.advancedGradient.setColors(gradient[0], gradient[1], gradient[2], gradient[3]);
+            } else {
+                color = profileColor.getAvatarColor1();
+                color2 = profileColor.getAvatarColor2();
+            }
         } else if (customColor != null) {
             if (customColor >= 14) {
                 MessagesController messagesController = MessagesController.getInstance(UserConfig.selectedAccount);
                 if (messagesController != null && messagesController.peerColors != null && messagesController.peerColors.getColor(customColor) != null) {
                     final int peerColor = messagesController.peerColors.getColor(customColor).getColor1();
-                    color = getThemedColor(Theme.keys_avatar_background[getPeerColorIndex(peerColor)]);
-                    color2 = getThemedColor(Theme.keys_avatar_background2[getPeerColorIndex(peerColor)]);
+                    if (advancedGradient) {
+                        int[] gradient = advancedGradients[getPeerColorIndex(peerColor)];
+                        this.advancedGradient.setColors(gradient[0], gradient[1], gradient[2], gradient[3]);
+                    } else {
+                        color = getThemedColor(Theme.keys_avatar_background[getPeerColorIndex(peerColor)]);
+                        color2 = getThemedColor(Theme.keys_avatar_background2[getPeerColorIndex(peerColor)]);
+                    }
+                } else {
+                    if (advancedGradient) {
+                        int[] gradient = advancedGradients[getColorIndex(customColor)];
+                        this.advancedGradient.setColors(gradient[0], gradient[1], gradient[2], gradient[3]);
+                    } else {
+                        color = getThemedColor(Theme.keys_avatar_background[getColorIndex(customColor)]);
+                        color2 = getThemedColor(Theme.keys_avatar_background2[getColorIndex(customColor)]);
+                    }
+                }
+            } else {
+                if (advancedGradient) {
+                    int[] gradient = advancedGradients[getColorIndex(customColor)];
+                    this.advancedGradient.setColors(gradient[0], gradient[1], gradient[2], gradient[3]);
                 } else {
                     color = getThemedColor(Theme.keys_avatar_background[getColorIndex(customColor)]);
                     color2 = getThemedColor(Theme.keys_avatar_background2[getColorIndex(customColor)]);
                 }
-            } else {
-                color = getThemedColor(Theme.keys_avatar_background[getColorIndex(customColor)]);
-                color2 = getThemedColor(Theme.keys_avatar_background2[getColorIndex(customColor)]);
             }
         } else {
-            color = getThemedColor(Theme.keys_avatar_background[getColorIndex(id)]);
-            color2 = getThemedColor(Theme.keys_avatar_background2[getColorIndex(id)]);
+            if (advancedGradient) {
+                int[] gradient = advancedGradients[getColorIndex(id)];
+                this.advancedGradient.setColors(gradient[0], gradient[1], gradient[2], gradient[3]);
+            } else {
+                color = getThemedColor(Theme.keys_avatar_background[getColorIndex(id)]);
+                color2 = getThemedColor(Theme.keys_avatar_background2[getColorIndex(id)]);
+            }
         }
         needApplyColorAccent = id == 5; // Tinting manually set blue color
+
 
         avatarType = AVATAR_TYPE_NORMAL;
         drawDeleted = false;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Bulletin.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Bulletin.java
@@ -1576,6 +1576,10 @@ public class Bulletin {
         }
 
         public UndoButton(@NonNull Context context, boolean text, Theme.ResourcesProvider resourcesProvider) {
+            this(context, text, !text, resourcesProvider);
+        }
+
+        public UndoButton(@NonNull Context context, boolean text, boolean icon, Theme.ResourcesProvider resourcesProvider) {
             super(context);
             this.resourcesProvider = resourcesProvider;
 
@@ -1583,24 +1587,28 @@ public class Bulletin {
 
             if (text) {
                 undoTextView = new TextView(context);
-                undoTextView.setOnClickListener(v -> undo());
                 undoTextView.setBackground(Theme.createSelectorDrawable((undoCancelColor & 0x00ffffff) | 0x19000000, Theme.RIPPLE_MASK_ROUNDRECT_6DP));
                 undoTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
                 undoTextView.setTypeface(AndroidUtilities.getTypeface("fonts/rmedium.ttf"));
                 undoTextView.setTextColor(undoCancelColor);
                 undoTextView.setText(LocaleController.getString("Undo", R.string.Undo));
                 undoTextView.setGravity(Gravity.CENTER_VERTICAL);
-                ViewHelper.setPaddingRelative(undoTextView, 12, 8, 12, 8);
+                ViewHelper.setPaddingRelative(undoTextView, icon ? 34 : 12, 8, 12, 8);
                 addView(undoTextView, LayoutHelper.createFrameRelatively(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT, Gravity.CENTER_VERTICAL, 8, 0, 8, 0));
-            } else {
+            }
+
+            if (icon) {
                 final ImageView undoImageView = new ImageView(getContext());
-                undoImageView.setOnClickListener(v -> undo());
                 undoImageView.setImageResource(R.drawable.chats_undo);
                 undoImageView.setColorFilter(new PorterDuffColorFilter(undoCancelColor, PorterDuff.Mode.MULTIPLY));
-                undoImageView.setBackground(Theme.createSelectorDrawable((undoCancelColor & 0x00ffffff) | 0x19000000));
+                if (!text) {
+                    undoImageView.setBackground(Theme.createSelectorDrawable((undoCancelColor & 0x00ffffff) | 0x19000000));
+                }
                 ViewHelper.setPaddingRelative(undoImageView, 0, 12, 0, 12);
                 addView(undoImageView, LayoutHelper.createFrameRelatively(56, 48, Gravity.CENTER_VERTICAL));
             }
+
+            setOnClickListener(v -> undo());
         }
 
         public UndoButton setText(CharSequence text) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ContactsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ContactsActivity.java
@@ -972,16 +972,32 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
     }
 
     private void performSelectedContactsDelete() {
-        ArrayList<TLRPC.User> contacts = new ArrayList<>(selectedContacts.size());
-        for (int i = 0; i < selectedContacts.size(); i++) {
-            long key = selectedContacts.keyAt(i);
-            TLRPC.User contact = selectedContacts.get(key);
-            contacts.add(contact);
+        AlertDialog.Builder builder = new AlertDialog.Builder(getContext(), getResourceProvider());
+        if (selectedContacts.size() == 1) {
+            builder.setTitle(LocaleController.getString("DeleteContactTitle", R.string.DeleteContactTitle));
+            builder.setMessage(LocaleController.getString("DeleteContactSubtitle", R.string.DeleteContactSubtitle));
+        } else {
+            builder.setTitle(LocaleController.formatPluralString("DeleteContactsTitle", selectedContacts.size()));
+            builder.setMessage(LocaleController.getString("DeleteContactsSubtitle", R.string.DeleteContactsSubtitle));
         }
+        builder.setPositiveButton(LocaleController.getString("Delete", R.string.Delete), (dialog, which) -> {
+            ArrayList<TLRPC.User> contacts = new ArrayList<>(selectedContacts.size());
+            for (int i = 0; i < selectedContacts.size(); i++) {
+                long key = selectedContacts.keyAt(i);
+                TLRPC.User contact = selectedContacts.get(key);
+                contacts.add(contact);
+            }
 
-        getContactsController().deleteContactsUndoable(getContext(), this, contacts);
+            getContactsController().deleteContactsUndoable(getContext(), ContactsActivity.this, contacts);
 
-        hideActionMode();
+            hideActionMode();
+        });
+        builder.setNegativeButton(LocaleController.getString("Cancel", R.string.Cancel), (dialog, which) -> {
+            dialog.dismiss();
+        });
+        AlertDialog dialog = builder.create();
+        dialog.show();
+        dialog.redPositive();
     }
 
     private void didSelectResult(final TLRPC.User user, boolean useAlert, String param) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ContactsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ContactsActivity.java
@@ -79,6 +79,7 @@ import org.telegram.ui.ActionBar.ActionBar;
 import org.telegram.ui.ActionBar.ActionBarMenu;
 import org.telegram.ui.ActionBar.ActionBarMenuItem;
 import org.telegram.ui.ActionBar.AlertDialog;
+import org.telegram.ui.ActionBar.BackDrawable;
 import org.telegram.ui.ActionBar.BaseFragment;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.ActionBar.ThemeDescription;
@@ -98,6 +99,7 @@ import org.telegram.ui.Components.EditTextBoldCursor;
 import org.telegram.ui.Components.FlickerLoadingView;
 import org.telegram.ui.Components.ItemOptions;
 import org.telegram.ui.Components.LayoutHelper;
+import org.telegram.ui.Components.NumberTextView;
 import org.telegram.ui.Components.RLottieImageView;
 import org.telegram.ui.Components.RecyclerListView;
 import org.telegram.ui.Components.StickerEmptyView;
@@ -152,6 +154,16 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
 
     private boolean disableSections;
 
+    private LongSparseArray<TLRPC.User> selectedContacts = new LongSparseArray<>();
+
+    private NumberTextView selectedContactsCountTextView;
+
+    private ActionBarMenuItem deleteItem;
+
+    private BackDrawable backDrawable;
+
+    private String searchQuery;
+
     private boolean checkPermission = true;
     private long permissionRequestTime;
 
@@ -160,6 +172,8 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
 
     private final static int search_button = 0;
     private final static int sort_button = 1;
+
+    private final static int delete = 100;
 
     public interface ContactsActivityDelegate {
         void didSelectContact(TLRPC.User user, String param, ContactsActivity activity);
@@ -235,7 +249,6 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
         searching = false;
         searchWas = false;
 
-        actionBar.setBackButtonImage(R.drawable.ic_ab_back);
         actionBar.setAllowOverlayTitle(true);
         if (destroyAfterSelect) {
             if (returnAsResult) {
@@ -251,11 +264,32 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
             actionBar.setTitle(LocaleController.getString("Contacts", R.string.Contacts));
         }
 
+        actionBar.setBackButtonDrawable(backDrawable = new BackDrawable(false));
+
+        final ActionBarMenu actionMode = actionBar.createActionMode(false, null);
+        actionMode.setBackgroundColor(Theme.getColor(Theme.key_windowBackgroundWhite));
+        actionMode.drawBlur = false;
+
+        selectedContactsCountTextView = new NumberTextView(actionMode.getContext());
+        selectedContactsCountTextView.setTextSize(18);
+        selectedContactsCountTextView.setTypeface(AndroidUtilities.getTypeface("fonts/rmedium.ttf"));
+        selectedContactsCountTextView.setTextColor(Theme.getColor(Theme.key_actionBarActionModeDefaultIcon));
+        actionMode.addView(selectedContactsCountTextView, LayoutHelper.createLinear(0, LayoutHelper.MATCH_PARENT, 1.0f, 72, 0, 0, 0));
+        selectedContactsCountTextView.setOnTouchListener((v, event) -> true);
+
+        deleteItem = actionMode.addItemWithWidth(delete, R.drawable.msg_delete, AndroidUtilities.dp(54), LocaleController.getString("Delete", R.string.Delete));
+
         actionBar.setActionBarMenuOnItemClick(new ActionBar.ActionBarMenuOnItemClick() {
             @Override
             public void onItemClick(int id) {
                 if (id == -1) {
-                    finishFragment();
+                    if (actionBar.isActionModeShowed()) {
+                        hideActionMode();
+                    } else {
+                        finishFragment();
+                    }
+                } else if (id == delete) {
+                    performSelectedContactsDelete();
                 } else if (id == sort_button) {
                     SharedConfig.toggleSortContactsByName();
                     sortByName = SharedConfig.sortContactsByName;
@@ -307,6 +341,7 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
                     return;
                 }
                 String text = editText.getText().toString();
+                searchQuery = text;
                 if (text.length() != 0) {
                     searchWas = true;
                     if (listView != null) {
@@ -333,7 +368,7 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
             sortItem.setContentDescription(LocaleController.getString("AccDescrContactSorting", R.string.AccDescrContactSorting));
         }
 
-        searchListViewAdapter = new SearchAdapter(context, ignoreUsers, allowUsernameSearch, false, false, allowBots, allowSelf, true, 0) {
+        searchListViewAdapter = new SearchAdapter(context, ignoreUsers, selectedContacts, allowUsernameSearch, false, false, allowBots, allowSelf, true, 0) {
             @Override
             protected void onSearchProgressChanged() {
                 if (!searchInProgress() && getItemCount() == 0) {
@@ -358,7 +393,7 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
         } catch (Throwable e) {
             hasGps = false;
         }
-        listViewAdapter = new ContactsAdapter(context, this, onlyUsers ? 1 : 0, needPhonebook, ignoreUsers, inviteViaLink, hasGps) {
+        listViewAdapter = new ContactsAdapter(context, this, onlyUsers ? 1 : 0, needPhonebook, ignoreUsers, selectedContacts, inviteViaLink, hasGps) {
             @Override
             public void notifyDataSetChanged() {
                 super.notifyDataSetChanged();
@@ -451,6 +486,16 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
         listView.setOnItemClickListener((view, position, x, y) -> {
             if (listView.getAdapter() == searchListViewAdapter) {
                 Object object = searchListViewAdapter.getItem(position);
+
+                if (!selectedContacts.isEmpty() && view instanceof ProfileSearchCell) {
+                    ProfileSearchCell cell = (ProfileSearchCell) view;
+                    if (cell.getUser() != null && cell.getUser().contact) {
+                        showOrUpdateActionMode(cell);
+                    }
+
+                    return;
+                }
+
                 if (object instanceof TLRPC.User) {
                     TLRPC.User user = (TLRPC.User) object;
                     if (searchListViewAdapter.isGlobalSearch(position)) {
@@ -497,6 +542,13 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
                 if (row < 0 || section < 0) {
                     return;
                 }
+
+                if (!selectedContacts.isEmpty() && view instanceof UserCell) {
+                    UserCell userCell = (UserCell) view;
+                    showOrUpdateActionMode(userCell);
+                    return;
+                }
+
                 if (listViewAdapter.hasStories && section == 1) {
                     if (!(view instanceof UserCell)) {
                         return;
@@ -623,52 +675,53 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
         listView.setOnItemLongClickListener(new RecyclerListView.OnItemLongClickListener() {
             @Override
             public boolean onItemClick(View view, int position) {
-                int section = listViewAdapter.getSectionForPosition(position);
-                int row = listViewAdapter.getPositionInSectionForPosition(position);
-                if (Bulletin.getVisibleBulletin() != null) {
-                    Bulletin.getVisibleBulletin().hide();
-                }
-                if (row < 0 || section < 0) {
-                    return false;
-                }
-                if (listViewAdapter.hasStories && section == 1 && view instanceof UserCell) {
-                    UserCell userCell = (UserCell) view;
-                    long dialogId = userCell.getDialogId();
-                    TLRPC.User user = MessagesController.getInstance(currentAccount).getUser(dialogId);
-                    final String key = NotificationsController.getSharedPrefKey(dialogId, 0);
-                    boolean muted = !NotificationsCustomSettingsActivity.areStoriesNotMuted(currentAccount, dialogId);
-                    ItemOptions filterOptions = ItemOptions.makeOptions(ContactsActivity.this, view)
-                            //.setViewAdditionalOffsets(0, AndroidUtilities.dp(8), 0, 0)
-                            .setScrimViewBackground(Theme.createRoundRectDrawable(0, 0, Theme.getColor(Theme.key_windowBackgroundWhite)))
-                            .add(R.drawable.msg_discussion, LocaleController.getString("SendMessage", R.string.SendMessage), () -> {
-                                presentFragment(ChatActivity.of(dialogId));
-                            })
-                            .add(R.drawable.msg_openprofile, LocaleController.getString("OpenProfile", R.string.OpenProfile), () -> {
-                                presentFragment(ProfileActivity.of(dialogId));
-                            })
-                            .addIf(!muted, R.drawable.msg_mute, LocaleController.getString("NotificationsStoryMute", R.string.NotificationsStoryMute), () -> {
-                                MessagesController.getNotificationsSettings(currentAccount).edit().putBoolean("stories_" + key, false).apply();
-                                getNotificationsController().updateServerNotificationsSettings(dialogId, 0);
-                                String name = user == null ? "" : user.first_name.trim();
-                                int index = name.indexOf(" ");
-                                if (index > 0) {
-                                    name = name.substring(0, index);
-                                }
-                                BulletinFactory.of(ContactsActivity.this).createUsersBulletin(Arrays.asList(user), AndroidUtilities.replaceTags(LocaleController.formatString("NotificationsStoryMutedHint", R.string.NotificationsStoryMutedHint, name))).show();
-                            })
-                            .addIf(muted, R.drawable.msg_unmute, LocaleController.getString("NotificationsStoryUnmute", R.string.NotificationsStoryUnmute), () -> {
-                                MessagesController.getNotificationsSettings(currentAccount).edit().putBoolean("stories_" + key, true).apply();
-                                getNotificationsController().updateServerNotificationsSettings(dialogId, 0);
-                                String name = user == null ? "" : user.first_name.trim();
-                                int index = name.indexOf(" ");
-                                if (index > 0) {
-                                    name = name.substring(0, index);
-                                }
-                                BulletinFactory.of(ContactsActivity.this).createUsersBulletin(Arrays.asList(user), AndroidUtilities.replaceTags(LocaleController.formatString("NotificationsStoryUnmutedHint", R.string.NotificationsStoryUnmutedHint, name))).show();
-                            });
-                   // if (user.stories_hidden) {
+                if (listView.getAdapter() == listViewAdapter) {
+                    int section = listViewAdapter.getSectionForPosition(position);
+                    int row = listViewAdapter.getPositionInSectionForPosition(position);
+                    if (Bulletin.getVisibleBulletin() != null) {
+                        Bulletin.getVisibleBulletin().hide();
+                    }
+                    if (row < 0 || section < 0) {
+                        return false;
+                    }
+                    if (listViewAdapter.hasStories && section == 1 && view instanceof UserCell) {
+                        UserCell userCell = (UserCell) view;
+                        long dialogId = userCell.getDialogId();
+                        TLRPC.User user = MessagesController.getInstance(currentAccount).getUser(dialogId);
+                        final String key = NotificationsController.getSharedPrefKey(dialogId, 0);
+                        boolean muted = !NotificationsCustomSettingsActivity.areStoriesNotMuted(currentAccount, dialogId);
+                        ItemOptions filterOptions = ItemOptions.makeOptions(ContactsActivity.this, view)
+                                //.setViewAdditionalOffsets(0, AndroidUtilities.dp(8), 0, 0)
+                                .setScrimViewBackground(Theme.createRoundRectDrawable(0, 0, Theme.getColor(Theme.key_windowBackgroundWhite)))
+                                .add(R.drawable.msg_discussion, LocaleController.getString("SendMessage", R.string.SendMessage), () -> {
+                                    presentFragment(ChatActivity.of(dialogId));
+                                })
+                                .add(R.drawable.msg_openprofile, LocaleController.getString("OpenProfile", R.string.OpenProfile), () -> {
+                                    presentFragment(ProfileActivity.of(dialogId));
+                                })
+                                .addIf(!muted, R.drawable.msg_mute, LocaleController.getString("NotificationsStoryMute", R.string.NotificationsStoryMute), () -> {
+                                    MessagesController.getNotificationsSettings(currentAccount).edit().putBoolean("stories_" + key, false).apply();
+                                    getNotificationsController().updateServerNotificationsSettings(dialogId, 0);
+                                    String name = user == null ? "" : user.first_name.trim();
+                                    int index = name.indexOf(" ");
+                                    if (index > 0) {
+                                        name = name.substring(0, index);
+                                    }
+                                    BulletinFactory.of(ContactsActivity.this).createUsersBulletin(Arrays.asList(user), AndroidUtilities.replaceTags(LocaleController.formatString("NotificationsStoryMutedHint", R.string.NotificationsStoryMutedHint, name))).show();
+                                })
+                                .addIf(muted, R.drawable.msg_unmute, LocaleController.getString("NotificationsStoryUnmute", R.string.NotificationsStoryUnmute), () -> {
+                                    MessagesController.getNotificationsSettings(currentAccount).edit().putBoolean("stories_" + key, true).apply();
+                                    getNotificationsController().updateServerNotificationsSettings(dialogId, 0);
+                                    String name = user == null ? "" : user.first_name.trim();
+                                    int index = name.indexOf(" ");
+                                    if (index > 0) {
+                                        name = name.substring(0, index);
+                                    }
+                                    BulletinFactory.of(ContactsActivity.this).createUsersBulletin(Arrays.asList(user), AndroidUtilities.replaceTags(LocaleController.formatString("NotificationsStoryUnmutedHint", R.string.NotificationsStoryUnmutedHint, name))).show();
+                                });
+                        // if (user.stories_hidden) {
                         filterOptions.add(R.drawable.msg_viewintopic, LocaleController.getString("ShowInChats", R.string.ShowInChats), () -> {
-                           // listViewAdapter.removeStory(dialogId);
+                            // listViewAdapter.removeStory(dialogId);
                             getMessagesController().getStoriesController().toggleHidden(dialogId, false, false, true);
                             BulletinFactory.UndoObject undoObject = new BulletinFactory.UndoObject();
                             undoObject.onUndo = () -> {
@@ -682,7 +735,7 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
                                     AndroidUtilities.replaceTags(LocaleController.formatString("StoriesMovedToDialogs", R.string.StoriesMovedToDialogs, ContactsController.formatName(user.first_name, null, 20))),
                                     null,
                                     undoObject
-                                   ).show();
+                            ).show();
 
                         });
 //                    } else {
@@ -699,8 +752,23 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
 //                        });
 //                    }
 
-                    filterOptions.setGravity(Gravity.RIGHT)
-                            .show();
+                        filterOptions.setGravity(Gravity.RIGHT)
+                                .show();
+                        return true;
+                    }
+                }
+
+                if (!returnAsResult && !createSecretChat && view instanceof UserCell) {
+                    UserCell cell = (UserCell) view;
+                    showOrUpdateActionMode(cell);
+                    return true;
+                }
+
+                if (!returnAsResult && !createSecretChat && view instanceof ProfileSearchCell) {
+                    ProfileSearchCell cell = (ProfileSearchCell) view;
+                    if (cell.getUser() != null && cell.getUser().contact) {
+                        showOrUpdateActionMode(cell);
+                    }
                     return true;
                 }
                 return false;
@@ -823,6 +891,99 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
         return actionBar;
     }
 
+    public boolean addOrRemoveSelectedContact(UserCell cell) {
+        long dialogId = cell.getDialogId();
+        if (selectedContacts.indexOfKey(dialogId) >= 0) {
+            selectedContacts.remove(dialogId);
+            cell.setChecked(false, true);
+            return false;
+        } else {
+            if (cell.getCurrentObject() instanceof TLRPC.User) {
+                selectedContacts.put(dialogId, (TLRPC.User) cell.getCurrentObject());
+                cell.setChecked(true, true);
+                return true;
+            }
+            return false;
+        }
+    }
+
+    public boolean addOrRemoveSelectedContact(ProfileSearchCell cell) {
+        long dialogId = cell.getDialogId();
+        if (selectedContacts.indexOfKey(dialogId) >= 0) {
+            selectedContacts.remove(dialogId);
+            cell.setChecked(false, true);
+            return false;
+        } else {
+            if (cell.getUser() != null) {
+                selectedContacts.put(dialogId, cell.getUser());
+                cell.setChecked(true, true);
+                return true;
+            }
+            return false;
+        }
+    }
+
+    private void showOrUpdateActionMode(Object cell) {
+        boolean checked;
+        if (cell instanceof UserCell) {
+            checked = addOrRemoveSelectedContact((UserCell) cell);
+        } else if (cell instanceof ProfileSearchCell) {
+            checked = addOrRemoveSelectedContact((ProfileSearchCell) cell);
+        } else {
+            return;
+        }
+        boolean updateAnimated = false;
+
+        if (actionBar.isActionModeShowed()) {
+            if (selectedContacts.isEmpty()) {
+                hideActionMode();
+                return;
+            }
+            updateAnimated = true;
+        } else if (checked) {
+            AndroidUtilities.hideKeyboard(fragmentView.findFocus());
+            actionBar.showActionMode();
+
+            backDrawable.setRotation(1, true);
+        }
+
+        selectedContactsCountTextView.setNumber(selectedContacts.size(), updateAnimated);
+    }
+
+    private void hideActionMode() {
+        actionBar.hideActionMode();
+        int count = listView.getChildCount();
+        for (int i = 0; i < count; i++) {
+            View view = listView.getChildAt(i);
+            if (view instanceof UserCell) {
+                UserCell cell = (UserCell) view;
+                if (selectedContacts.indexOfKey(cell.getDialogId()) >= 0) {
+                    cell.setChecked(false, true);
+                }
+            } else if (view instanceof ProfileSearchCell) {
+                ProfileSearchCell cell = (ProfileSearchCell) view;
+                if (selectedContacts.indexOfKey(cell.getDialogId()) >= 0) {
+                    cell.setChecked(false, true);
+                }
+            }
+        }
+        selectedContacts.clear();
+        backDrawable.setRotation(0, true);
+    }
+
+    private void performSelectedContactsDelete() {
+        ArrayList<TLRPC.User> contacts = new ArrayList<>(selectedContacts.size());
+        for (int i = 0; i < selectedContacts.size(); i++) {
+            long key = selectedContacts.keyAt(i);
+            TLRPC.User contact = selectedContacts.get(key);
+            contacts.add(contact);
+        }
+
+        getContactsController().deleteContactsUndoable(getContext(), this, contacts);
+
+        hideActionMode();
+    }
+
     private void didSelectResult(final TLRPC.User user, boolean useAlert, String param) {
         if (useAlert && selectAlertString != null) {
             if (getParentActivity() == null) {
@@ -936,6 +1097,16 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
             if (needFinishFragment) {
                 finishFragment();
             }
+        }
+    }
+
+    @Override
+    public boolean onBackPressed() {
+        if (actionBar.isActionModeShowed()) {
+            hideActionMode();
+            return false;
+        } else {
+            return super.onBackPressed();
         }
     }
 
@@ -1079,6 +1250,9 @@ public class ContactsActivity extends BaseFragment implements NotificationCenter
                     listViewAdapter.setSortType(2, true);
                 }
                 listViewAdapter.notifyDataSetChanged();
+            }
+            if (searchListViewAdapter != null && listView.getAdapter() == searchListViewAdapter) {
+                searchListViewAdapter.searchDialogs(searchQuery);
             }
         } else if (id == NotificationCenter.updateInterfaces) {
             int mask = (Integer) args[0];

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -213,6 +213,14 @@
     <string name="AccAutoDeleteTimer">Auto-delete timer</string>
     <string name="HistoryClearedUndo">History cleared.</string>
     <string name="ChatsDeletedUndo">Chats deleted.</string>
+    <string name="DeleteContactTitle">Delete contact</string>
+    <string name="DeleteContactSubtitle">Are you sure you want to delete this contact?</string>
+    <string name="DeleteContactsTitle_one">Delete %d contact</string>
+    <string name="DeleteContactsTitle_two">Delete %d contacts</string>
+    <string name="DeleteContactsTitle_few">Delete %d contacts</string>
+    <string name="DeleteContactsTitle_many">Delete %d contacts</string>
+    <string name="DeleteContactsTitle_other">Delete %d contacts</string>
+    <string name="DeleteContactsSubtitle">Are you sure you want to delete these contacts?</string>
     <string name="ContactsDeletedUndo_one">%d contact deleted.</string>
     <string name="ContactsDeletedUndo_two">%d contacts deleted.</string>
     <string name="ContactsDeletedUndo_few">%d contacts deleted.</string>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -213,6 +213,11 @@
     <string name="AccAutoDeleteTimer">Auto-delete timer</string>
     <string name="HistoryClearedUndo">History cleared.</string>
     <string name="ChatsDeletedUndo">Chats deleted.</string>
+    <string name="ContactsDeletedUndo_one">%d contact deleted.</string>
+    <string name="ContactsDeletedUndo_two">%d contacts deleted.</string>
+    <string name="ContactsDeletedUndo_few">%d contacts deleted.</string>
+    <string name="ContactsDeletedUndo_many">%d contacts deleted.</string>
+    <string name="ContactsDeletedUndo_other">%d contacts deleted.</string>
     <string name="ChatsMute">Mute</string>
     <string name="ChatsUnmute">Unmute</string>
     <string name="ChatDeletedUndo">Chat deleted</string>


### PR DESCRIPTION
- Add multiselect to the contacts screen to present the ability to delete multiple contacts at once. The user can undo the deletion via the toast button within 5 seconds.
- Freshen up the 'Invite Friends' section by adding gradient background to the cells of contacts who are not yet registered in Telegram. The corresponding gradients were reused from the avatar builder.
- Fix a bug with the layout when searching in the 'Invite Friends' section. Reuse skeletons and stubs from 'Contacts' section.