### PR TITLE
Fix MiniApp scrolling: when scroll up - the webview is closing

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/BotWebViewMenuContainer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/BotWebViewMenuContainer.java
@@ -144,6 +144,8 @@ public class BotWebViewMenuContainer extends FrameLayout implements Notification
             botMenuItem.addSubItem(R.id.menu_reload_page, R.drawable.msg_retry, LocaleController.getString(R.string.BotWebViewReloadPage));
             settingsItem = botMenuItem.addSubItem(R.id.menu_settings, R.drawable.msg_settings, LocaleController.getString(R.string.BotWebViewSettings));
             settingsItem.setVisibility(View.GONE);
+
+            botMenuItem.addSubItem(R.id.menu_minimize, R.drawable.msg_go_down, LocaleController.getString(R.string.BotWebViewMinimizeView));
         }
     }
 
@@ -558,6 +560,8 @@ public class BotWebViewMenuContainer extends FrameLayout implements Notification
                                 webViewContainer.reload();
                             } else if (id == R.id.menu_settings) {
                                 webViewContainer.onSettingsButtonPressed();
+                            } else if (id == R.id.menu_minimize) {
+                                swipeContainer.stickTo(0);
                             }
                         }
                     });

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/BotWebViewSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/BotWebViewSheet.java
@@ -914,9 +914,12 @@ public class BotWebViewSheet extends Dialog implements NotificationCenter.Notifi
         settingsItem = otherItem.addSubItem(R.id.menu_settings, R.drawable.msg_settings, LocaleController.getString(R.string.BotWebViewSettings));
         settingsItem.setVisibility(View.GONE);
         otherItem.addSubItem(R.id.menu_reload_page, R.drawable.msg_retry, LocaleController.getString(R.string.BotWebViewReloadPage));
+
         if (currentBot != null && (currentBot.show_in_side_menu || currentBot.show_in_attach_menu)) {
             otherItem.addSubItem(R.id.menu_delete_bot, R.drawable.msg_delete, LocaleController.getString(R.string.BotWebViewDeleteBot));
         }
+        otherItem.addSubItem(R.id.menu_minimize, R.drawable.msg_go_down, LocaleController.getString(R.string.BotWebViewMinimizeView));
+
         actionBar.setActionBarMenuOnItemClick(new ActionBar.ActionBarMenuOnItemClick() {
             @Override
             public void onItemClick(int id) {
@@ -948,6 +951,8 @@ public class BotWebViewSheet extends Dialog implements NotificationCenter.Notifi
                     webViewContainer.onSettingsButtonPressed();
                 } else if (id == R.id.menu_delete_bot) {
                     deleteBot(currentAccount, botId, () -> dismiss());
+                } else if (id == R.id.menu_minimize) {
+                    swipeContainer.stickTo(0);
                 }
             }
         });

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertBotWebViewLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertBotWebViewLayout.java
@@ -159,6 +159,8 @@ public class ChatAttachAlertBotWebViewLayout extends ChatAttachAlert.AttachAlert
             }
         } else if (id == R.id.menu_settings) {
             webViewContainer.onSettingsButtonPressed();
+        } else if (id == R.id.menu_minimize) {
+            swipeContainer.stickTo(0);
         }
     }
 
@@ -172,6 +174,7 @@ public class ChatAttachAlertBotWebViewLayout extends ChatAttachAlert.AttachAlert
         settingsItem.setVisibility(View.GONE);
         otherItem.addSubItem(R.id.menu_reload_page, R.drawable.msg_retry, LocaleController.getString(R.string.BotWebViewReloadPage));
         otherItem.addSubItem(R.id.menu_delete_bot, R.drawable.msg_delete, LocaleController.getString(R.string.BotWebViewDeleteBot));
+        otherItem.addSubItem(R.id.menu_minimize, R.drawable.msg_go_down, LocaleController.getString(R.string.BotWebViewMinimizeView));
 
         webViewContainer = new BotWebViewContainer(context, resourcesProvider, getThemedColor(Theme.key_dialogBackground)) {
             @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertBotWebViewLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertBotWebViewLayout.java
@@ -916,10 +916,19 @@ public class ChatAttachAlertBotWebViewLayout extends ChatAttachAlert.AttachAlert
             this.delegate = delegate;
         }
 
+        private boolean isExpanded() {
+            return -offsetY + topActionBarOffsetY == swipeOffsetY;
+        }
+
         @Override
         public boolean dispatchTouchEvent(MotionEvent ev) {
             if (isScrolling && ev.getActionIndex() != 0) {
                 return false;
+            }
+
+            boolean superTouch = super.dispatchTouchEvent(ev);
+            if (isExpanded()) {
+                return superTouch;
             }
 
             MotionEvent rawEvent = MotionEvent.obtain(ev);
@@ -952,7 +961,6 @@ public class ChatAttachAlertBotWebViewLayout extends ChatAttachAlert.AttachAlert
                 }
             }
 
-            boolean superTouch = super.dispatchTouchEvent(ev);
             if (!superTouch && !detector && ev.getAction() == MotionEvent.ACTION_DOWN) {
                 return true;
             }

--- a/TMessagesProj/src/main/res/values/ids.xml
+++ b/TMessagesProj/src/main/res/values/ids.xml
@@ -33,6 +33,7 @@
     <item name="menu_settings" type="id"/>
     <item name="menu_reload_page" type="id"/>
     <item name="menu_delete_bot" type="id"/>
+    <item name="menu_minimize" type="id"/>
 
     <!-- there are required for focusing order customization on the passcode screen -->
     <item name="passcode_btn_1" type="id"/>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -3622,6 +3622,7 @@
     <string name="BotWebViewSettings">Settings</string>
     <string name="BotWebViewOpenBot">Open bot</string>
     <string name="BotWebViewReloadPage">Reload page</string>
+    <string name="BotWebViewMinimizeView">Minimize</string>
     <string name="BotWebViewDeleteBot">Delete bot</string>
     <string name="BotWebViewRequestAllow">Allow</string>
     <string name="BotWebViewRequestDontAllow">Don\'t Allow</string>


### PR DESCRIPTION
## **Fix [bug with scrolling](https://bugs.telegram.org/c/36664) inside the container on android**

### **The bug**
The mini app is minimizing, when user creates these actions:  reversible scrolling, scrolling inside containers, and swiping elements down. The bug is not permenent: it happens often but not always. Additional details [here](https://bugs.telegram.org/c/36664)

### **Reproduce**
1) Open android tg app
2) Open [this tg bot](https://t.me/AndroidScrollIsueBot)
3) Open web app with menu button and expand it
4) Scroll down
5) Scroll up (here it is. Web view is closing)

Here is how code of this app look like: https://stackblitz.com/edit/typescript-gufuwl?file=index.ts

### **Importance**
This problem prevents users with Android devices from working with Mini Apps. Developers are unable to create applications with the full range of advantages of web applications: reversible scrolling, scrolling inside containers, and swiping elements down. Therefore, I propose a solution to avoid all of these issues.

### **TLDR of the commit:**
- ignore swiping the container with web app when it's expanded
- add menu's button "Minimize" to minimize web app

