### PR TITLE
Fix saving files with the same names

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -4369,18 +4369,18 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                                 }
                             }
                             if (path == null || path.length() == 0) {
-                                path = null;
-                                TLRPC.Document document = message.getDocument();
-                                if (!TextUtils.isEmpty(FileLoader.getDocumentFileName(document)) && !(message.messageOwner instanceof TLRPC.TL_message_secret) && FileLoader.canSaveAsFile(message)) {
-                                    String filename = FileLoader.getDocumentFileName(document);
-                                    File newDir = FileLoader.getDirectory(FileLoader.MEDIA_DIR_FILES);
-                                    if (newDir != null) {
-                                        path = new File(newDir, filename).getAbsolutePath();
-                                    }
-                                }
-                                if (path == null) {
+//                                path = null;
+//                                TLRPC.Document document = message.getDocument();
+//                                if (!TextUtils.isEmpty(FileLoader.getDocumentFileName(document)) && !(message.messageOwner instanceof TLRPC.TL_message_secret) && FileLoader.canSaveAsFile(message)) {
+//                                    String filename = FileLoader.getDocumentFileName(document);
+//                                    File newDir = FileLoader.getDirectory(FileLoader.MEDIA_DIR_FILES);
+//                                    if (newDir != null) {
+//                                        path = new File(newDir, filename).getAbsolutePath();
+//                                    }
+//                                }
+//                                if (path == null) {
                                     path = FileLoader.getInstance(currentAccount.getCurrentAccount()).getPathToMessage(message.messageOwner).toString();
-                                }
+//                                }
                             }
                             File sourceFile = new File(path);
                             if (!sourceFile.exists()) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -4369,18 +4369,7 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                                 }
                             }
                             if (path == null || path.length() == 0) {
-//                                path = null;
-//                                TLRPC.Document document = message.getDocument();
-//                                if (!TextUtils.isEmpty(FileLoader.getDocumentFileName(document)) && !(message.messageOwner instanceof TLRPC.TL_message_secret) && FileLoader.canSaveAsFile(message)) {
-//                                    String filename = FileLoader.getDocumentFileName(document);
-//                                    File newDir = FileLoader.getDirectory(FileLoader.MEDIA_DIR_FILES);
-//                                    if (newDir != null) {
-//                                        path = new File(newDir, filename).getAbsolutePath();
-//                                    }
-//                                }
-//                                if (path == null) {
-                                    path = FileLoader.getInstance(currentAccount.getCurrentAccount()).getPathToMessage(message.messageOwner).toString();
-//                                }
+                                path = FileLoader.getInstance(currentAccount.getCurrentAccount()).getPathToMessage(message.messageOwner).toString();
                             }
                             File sourceFile = new File(path);
                             if (!sourceFile.exists()) {


### PR DESCRIPTION
@dkaraush Do you remember or could you help with understanding why do we need this removed code here?
For me it looks like speed boost/optimization because we don't touch FilePathDatabase in this case - is it correct?

Because of the code there is the bug in the app:
https://bugs.telegram.org/c/35162
https://bugs.telegram.org/c/32951
when there is more than one file with the same name we could "save to downloads" only the first of the cached files, because other files are saved internally with suffix " (_number_)" (see [FileLoadOperation](https://github.com/DrKLO/Telegram/blob/master/TMessagesProj/src/main/java/org/telegram/messenger/FileLoadOperation.java#L1584))

So it seems like we **have to** get file path from [FilePathDatabase](https://github.com/DrKLO/Telegram/blob/master/TMessagesProj/src/main/java/org/telegram/messenger/FilePathDatabase.java), where the file path is saved properly ([see putPath](https://github.com/DrKLO/Telegram/blob/master/TMessagesProj/src/main/java/org/telegram/messenger/FilePathDatabase.java#L245)) - is it correct?