### PR TITLE
fix:The pad is connected to the Bluetooth headset, but sco cannot be …

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPService.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPService.java
@@ -2740,7 +2740,7 @@ public class VoIPService extends Service implements SensorEventListener, AudioMa
 	}
 
 	public void toggleSpeakerphoneOrShowRouteSheet(Context context, boolean fromOverlayWindow, Integer selectedPos) {
-		if (isBluetoothHeadsetConnected() && hasEarpiece()) {
+		if (isBluetoothHeadsetConnected()) {
 			BottomSheet.Builder builder = new BottomSheet.Builder(context)
 					.setTitle(LocaleController.getString("VoipOutputDevices", R.string.VoipOutputDevices), true)
 					.selectedPos(selectedPos)


### PR DESCRIPTION
…established.

Problem description: When the pad device is connected to a Bluetooth headset to initiate a VoIP call, the microphone of the pad device is called instead of the microphone of the Bluetooth headset.

https://github.com/DrKLO/Telegram/blob/master/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPService.java

```
// When the pad is connected to a Bluetooth headset, the hasEarpiece() method returns false, resulting in the sco call being unable to be established. Telegram still uses the pad's microphone, not the Bluetooth headset.
if (isBluetoothHeadsetConnected() && hasEarpiece()) {
						switch (audioRouteToSet) {
							case AUDIO_ROUTE_BLUETOOTH:
								if (!bluetoothScoActive) {
									needSwitchToBluetoothAfterScoActivates = true;
									try {
										am.startBluetoothSco();
									} catch (Throwable e) {
										FileLog.e(e);
									}
```

The iPad device does not have telephony capabilities. To determine whether there is an earpiece, when connected to Bluetooth, the value obtained by bitmaskResult is 128 (AUDIO_DEVICE_OUT_BLUETOOTH_A2DP), so the mask operation will return false.
```
if (((TelephonyManager) getSystemService(TELEPHONY_SERVICE)).getPhoneType() != TelephonyManager.PHONE_TYPE_NONE) {
                        // The mobile device has telephony capability, so it will return true here.
			return true;
		}
		if (mHasEarpiece != null) {
			return mHasEarpiece;
		}

		// not calculated yet, do it now
		try {
			AudioManager am = (AudioManager) getSystemService(AUDIO_SERVICE);
			Method method = AudioManager.class.getMethod("getDevicesForStream", Integer.TYPE);
			Field field = AudioManager.class.getField("DEVICE_OUT_EARPIECE");
			int earpieceFlag = field.getInt(null);
			int bitmaskResult = (int) method.invoke(am, AudioManager.STREAM_VOICE_CALL);

			// check if masked by the earpiece flag
			if ((bitmaskResult & earpieceFlag) == earpieceFlag) {
				mHasEarpiece = Boolean.TRUE;
			} else {
				mHasEarpiece = Boolean.FALSE;
			}
```

There is a problem here with the judgment of whether a Bluetooth headset is connected and whether the Bluetooth headset has the ability to make calls. I hope you can help fix it.
