### PR TITLE
Fix MarkAllAsRead for archived forums

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
@@ -2183,6 +2183,9 @@ public class MessagesStorage extends BaseController {
                     for (int a = 0; a < dialogs.size(); a++) {
                         long did = dialogs.keyAt(a);
                         ReadDialog dialog = dialogs.valueAt(a);
+                        if (getMessagesController().isForum(did)) {
+                            getMessagesController().markAllTopicsAsRead(did);
+                        }
                         getMessagesController().markDialogAsRead(did, dialog.lastMid, dialog.lastMid, dialog.date, false, 0, dialog.unreadCount, true, 0);
                     }
                 });


### PR DESCRIPTION
Issue repro steps

1. Archive forum (group with topics)
2. Receive a message in any of the topics
3. Long press "Archived Chats"
4. Press "Mark all as read"
5. Observe that the forum still has unread messages

I added the same logic that is already being used in
```java
// DialogsActivity.java
private void markAsRead(long did) {
  // ...
  if (getMessagesController().isForum(did)) {
    getMessagesController().markAllTopicsAsRead(did);
  }
  // ...
}
```