### PR TITLE
Fix the bot_id variable type

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -4640,7 +4640,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
             });
             presentFragment(fragment, false, true);
         } else if (auth != null) {
-            final int bot_id = Utilities.parseInt(auth.get("bot_id"));
+            final long bot_id = Utilities.parseLong(auth.get("bot_id"));
             if (bot_id == 0) {
                 return;
             }


### PR DESCRIPTION
Bugfix the `bot_id` variable type, changing it from `int` to `long`, because it should be long instead of int.

int max size in Android: 2147483647

But the IDs of the newly created bots are already larger than int max value.