### PR TITLE
Raise Attention of A Rogue Feature in Poisioned Telegram Android Source (Create .RogueFeatureIssueReport02102024)

### DIFF
--- a/.RogueFeatureIssueReport02102024
+++ b/.RogueFeatureIssueReport02102024
@@ -1,0 +1,16 @@
+Issue Report — Rogue Feature Discovered on Telegram Android Source Affecting Many Client Apps
+=============================================================================================
+
+DESCRIPTION:
+
+It has been observed that a rogue feature which automatically adds the token that automatically logs the user into the Telegram Web application, is believed to be designed within the Telegram Android client. Because no user notices are given prior to starting this behaviour, this is a rogue feature.
+
+HOW TO REPRODUCE:
+
+1. Send a message in Telegram containing the link to the official Telegram Web application: https://web.telegram.org .
+
+2. Click on the link in the message, the rogue behaviour will start. Not actually the URL sent but with tokens to the signed-in user is appended, which results in unsoliticited data sharing.
+
+ADVICE:
+
+This rogue feature should be removed.


### PR DESCRIPTION
A rogue feature which automatically adds the sign-in token when opening the Telegram Web application's link has been discovered. This pull request should not be merged; instead this is in response as Telegram intentionally disallows GitHub Issues being used as a platform handling user reports, security vulnerabilities and feedbacks. The aim is to keep track of the source documenting this rogue behaviour to give cautions to the Internet community, as pull requests cannot be deleted by-design.

Key point: By clicking on the link https://web.telegram.org on the Telegram Android app, not the link itself but with some extra parameters are added and opened by the browser.

Please note that this is not an actual open source contribution. Please do not merge this pull request.