### PR TITLE
Fix vibration for SDK >= 33

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPPreNotificationService.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPPreNotificationService.java
@@ -18,6 +18,8 @@ import android.media.MediaPlayer;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
+import android.os.VibrationAttributes;
+import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.provider.Settings;
 import android.text.SpannableString;
@@ -357,7 +359,16 @@ public class VoIPPreNotificationService { // } extends Service implements AudioM
                     } else if (vibrate == 3) {
                         duration *= 2;
                     }
-                    vibrator.vibrate(new long[]{0, duration, 500}, 0);
+                    long[] pattern = new long[]{0, duration, 500};
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        vibrator.vibrate(
+                            VibrationEffect.createWaveform(pattern, 0),
+                            new VibrationAttributes.Builder()
+                                .setUsage(VibrationAttributes.USAGE_RINGTONE) // required for background apps
+                                .build());
+                    } else {
+                        vibrator.vibrate(pattern, 0);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Vibration doesn't work on Android 14 for incoming calls on Xiaomi (HyperOS) devices. It was tested on POCO X6 PRO,  Xiaomi 14T. Incoming call is visible on screen, ringtone works fine, but vibration doesn't work at all in all modes.

After further investigation using debugger, I found that "vibrator.vibrate" method doesn't work. I added fork to handle Android 13+ (>= SDK 33) differently using recommended method from Android documentation. 

I realize the deprecated method should work fine, but looks like not all vendors support it correctly. By my pull request I propose to improve the current vibration logic by using recommended method and, as the result, fix the bug on wide range of devices.

- Old "vibrate" method is deprecated since SDK 26: https://developer.android.com/reference/android/os/Vibrator#vibrate(long[],%20int)
- New recommended method with background apps support since SDK 33:  https://developer.android.com/reference/android/os/Vibrator#vibrate(android.os.VibrationEffect,%20android.os.VibrationAttributes)



Also found very similar, if not same, bug for other phone owners in this bug report topic:
https://bugs.telegram.org/c/2569