### PR TITLE
ChatListCell redrawing fix

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatListCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatListCell.java
@@ -45,6 +45,7 @@ public class ChatListCell extends LinearLayout {
                     ListView.this.invalidate();
                 }
             };
+            button.setColor(Theme.getColor(Theme.key_radioBackground), Theme.getColor(Theme.key_radioBackgroundChecked));
             button.setSize(AndroidUtilities.dp(20));
             addView(button, LayoutHelper.createFrame(22, 22, Gravity.RIGHT | Gravity.TOP, 0, 26, 10, 0));
             button.setChecked(isThreeLines && SharedConfig.useThreeLinesLayout || !isThreeLines && !SharedConfig.useThreeLinesLayout, false);
@@ -57,7 +58,11 @@ public class ChatListCell extends LinearLayout {
             int g = Color.green(color);
             int b = Color.blue(color);
 
-            button.setColor(Theme.getColor(Theme.key_radioBackground), Theme.getColor(Theme.key_radioBackgroundChecked));
+            int buttonColor = Theme.getColor(Theme.key_radioBackground);
+            int buttonCheckedColor = Theme.getColor(Theme.key_radioBackgroundChecked);
+            if (button.getColor() != buttonColor || button.getCheckedColor() != buttonCheckedColor) {
+                button.setColor(buttonColor, buttonCheckedColor);
+            }
 
             rect.set(AndroidUtilities.dp(1), AndroidUtilities.dp(1), getMeasuredWidth() - AndroidUtilities.dp(1), AndroidUtilities.dp(73));
             Theme.chat_instantViewRectPaint.setColor(Color.argb((int) (43 * button.getProgress()), r, g, b));

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/RadioButton.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/RadioButton.java
@@ -114,6 +114,10 @@ public class RadioButton extends View {
         invalidate();
     }
 
+    public int getCheckedColor() {
+        return checkedColor;
+    }
+
     public void setCheckedColor(int color2) {
         checkedColor = color2;
         invalidate();


### PR DESCRIPTION
In the **ThemeActivity** in `ChatListCell.ListView#onDraw` method, the color of the button is updated by the method `RadioButton#setColor`, this leads to updating the button itself due to calling `invalidate` method on the button. And the button itself has a overrided `invalidate` method that will lead to the rendering `ChatListCell.ListView` again. Constant unnecessary redrawing occurs. I added a check so that the colors don't update every `onDraw` call.


https://github.com/user-attachments/assets/2309f256-80a0-4e5b-8f98-22de556eba8c

