### PR TITLE
DiffCallback for DrawerLayoutAdapter

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Adapters/diffUtils/DrawerLayoutAdapterDiffCallback.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Adapters/diffUtils/DrawerLayoutAdapterDiffCallback.java
@@ -1,0 +1,54 @@
+package org.telegram.ui.Adapters.diffUtils;
+import androidx.recyclerview.widget.DiffUtil;
+import org.telegram.ui.Adapters.DrawerLayoutAdapter;
+import java.util.ArrayList;
+
+/**
+ * A DiffUtil.Callback implementation for calculating the differences between two lists of
+ * {@link DrawerLayoutAdapter.Item} objects, specifically for updating the DrawerLayoutAdapter
+ * efficiently.
+ */
+public class DrawerLayoutAdapterDiffCallback extends DiffUtil.Callback {
+    private final ArrayList<DrawerLayoutAdapter.Item> oldItems;
+    private final ArrayList<DrawerLayoutAdapter.Item> newItems;
+
+    public DrawerLayoutAdapterDiffCallback(ArrayList<DrawerLayoutAdapter.Item> _oldItems, ArrayList<DrawerLayoutAdapter.Item> _newItems) {
+        oldItems = _oldItems;
+        newItems = _newItems;
+    }
+
+
+    @Override
+    public int getOldListSize() {
+        return oldItems.size();
+    }
+
+    @Override
+    public int getNewListSize() {
+        return newItems.size();
+    }
+
+    @Override
+    public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
+        DrawerLayoutAdapter.Item oldItem = oldItems.get(oldItemPosition);
+        DrawerLayoutAdapter.Item newItem = newItems.get(newItemPosition);
+
+        if (oldItem == null || newItem == null) {
+            return false;
+        }
+
+        return oldItem.id == newItem.id;
+    }
+
+    @Override
+    public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
+        DrawerLayoutAdapter.Item oldItem = oldItems.get(oldItemPosition);
+        DrawerLayoutAdapter.Item newItem = newItems.get(newItemPosition);
+
+        if (oldItem == null || newItem == null) {
+            return false;
+        }
+
+        return oldItem.areContentsTheSame(newItem);
+    }
+}


### PR DESCRIPTION
Why notifyDataSetChanged() is Suboptimal:
Full Redraw: Calling notifyDataSetChanged() triggers a complete redraw of the entire RecyclerView, even if only a single item has changed.
Resource Intensive: This demands significant computational resources, particularly for large lists, as all items must be re-bound and re-drawn.
Undesirable Animations: A full redraw resets any animations associated with list items, leading to a visually jarring user experience.
Why DiffUtil is More Optimal:
Precise Updates: DiffUtil calculates the minimal set of changes (additions, removals, changes, moves) required to transform the old list into the new list.
Targeted Operations: Based on these changes, the adapter uses notifyItemInserted(), notifyItemRemoved(), notifyItemChanged(), and notifyItemMoved() to update only the items that actually need updating.
Improved Performance: This significantly reduces the load on the system, resulting in a smoother and more responsive UI, especially with large lists or frequent data updates.
Preservation of Animations: DiffUtil preserves RecyclerView item animations, providing a more polished visual experience.
In summary, DiffUtil provides granular control over RecyclerView updates, minimizing the amount of work needed to refresh displayed data, in contrast to the all-or-nothing approach of notifyDataSetChanged().