### PR TITLE
Fix bounds check in name_parse function

### DIFF
--- a/TMessagesProj/jni/voip/webrtc/base/third_party/libevent/evdns.c
+++ b/TMessagesProj/jni/voip/webrtc/base/third_party/libevent/evdns.c
@@ -804,6 +804,7 @@ name_parse(u8 *packet, int length, int *idx, char *name_out, int name_out_len) {
 			*cp++ = '.';
 		}
 		if (cp + label_len >= end) return -1;
+		if (j + label_len > length) return -1;
 		memcpy(cp, packet + j, label_len);
 		cp += label_len;
 		j += label_len;


### PR DESCRIPTION
**Description**
Added a bounds check before memcpy operation in name_parse() function to improve security. This ensures that label_len bytes can be safely read from the packet buffer before copying memory. The fix prevents potential out-of-bounds reads when processing malformed DNS packets.

**The fix adds:**
if (j + label_len > length) return -1;

**References:**
Original fix: libevent/libevent@96f64a0
CVE-2016-10195: https://nvd.nist.gov/vuln/detail/CVE-2016-10195