### PR TITLE
Fix Chromecast Media Playback Crash

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/VideoPlayer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/VideoPlayer.java
@@ -1450,9 +1450,11 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
     }
 
     public void setPlaybackSpeed(float speed) {
-        if (player != null) {
-            player.setPlaybackParameters(new PlaybackParameters(speed, speed > 1.0f ? 0.98f : 1.0f));
-        }
+        try {
+            if (player != null) {
+                player.setPlaybackParameters(new PlaybackParameters(speed, speed > 1.0f ? 0.98f : 1.0f));
+            }
+        } catch (Exception ignore) {}
     }
 
     public float getPlaybackSpeed() {


### PR DESCRIPTION
Without these changes, some Chromecast devices' media applications may induce an exception crash in the Android Telegram client by causing the `CastSync` facility to forward a zero-value playback speed parameter into ExoPlayer. Here is an example of one such stack trace...
```
 2025-04-08 18:15:36.865 26021-26021 AndroidRuntime          pid-26021                            E  FATAL EXCEPTION: main
                                                                                                     Process: org.telegram.messenger, PID: 26021
                                                                                                     java.lang.IllegalArgumentException
                                                                                                         at com.google.android.exoplayer2.util.Assertions.checkArgument(SourceFile:0)
                                                                                                         at com.google.android.exoplayer2.PlaybackParameters.<init>(SourceFile:0)
                                                                                                         at org.telegram.ui.Components.VideoPlayer.setPlaybackSpeed(Unknown Source:15)
                                                                                                         at org.telegram.ui.PhotoViewer$54.setPlaybackSpeed(Unknown Source:0)
                                                                                                         at org.telegram.ui.PhotoViewer.chooseSpeed(Unknown Source:132)
                                                                                                         at org.telegram.ui.PhotoViewer.syncCastedPlayer(Unknown Source:170)
                                                                                                         at org.telegram.ui.CastSync.syncInterface(Unknown Source:8)
                                                                                                         at org.telegram.ui.CastSync$1$1.onStatusUpdated(Unknown Source:5)
                                                                                                         at com.google.android.gms.cast.framework.media.zzbn.zzm(Unknown Source:46)
                                                                                                         at com.google.android.gms.cast.internal.zzaq.zzY(Unknown Source:4)
                                                                                                         at com.google.android.gms.cast.internal.zzaq.zzO(Unknown Source:644)
                                                                                                         at com.google.android.gms.cast.framework.media.RemoteMediaClient.onMessageReceived(Unknown Source:2)
                                                                                                         at com.google.android.gms.cast.zzbp.run(Unknown Source:30)
                                                                                                         at android.os.Handler.handleCallback(Handler.java:938)
                                                                                                         at android.os.Handler.dispatchMessage(Handler.java:99)
                                                                                                         at android.os.Looper.loopOnce(Looper.java:226)
                                                                                                         at android.os.Looper.loop(Looper.java:313)
                                                                                                         at android.app.ActivityThread.main(ActivityThread.java:8663)
                                                                                                         at java.lang.reflect.Method.invoke(Native Method)
                                                                                                         at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:567)
                                                                                                         at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
 2025-04-08 18:15:36.889  1104-4453  ActivityManager         system_server                        W  crash : org.telegram.messenger,10294
```