### PR TITLE
Fix: evdns: fix searching empty hostnames

### DIFF
--- a/TMessagesProj/jni/voip/webrtc/base/third_party/libevent/evdns.c
+++ b/TMessagesProj/jni/voip/webrtc/base/third_party/libevent/evdns.c
@@ -2496,8 +2496,11 @@ search_set_from_hostname(void) {
 static char *
 search_make_new(const struct search_state *const state, int n, const char *const base_name) {
 	const int base_len = strlen(base_name);
-	const char need_to_append_dot = base_name[base_len - 1] == '.' ? 0 : 1;
+	char need_to_append_dot;
 	struct search_domain *dom;
+
+	if (!base_len) return NULL;
+ 	need_to_append_dot = base_name[base_len - 1] == '.' ? 0 : 1;
 
 	for (dom = state->head; dom; dom = dom->next) {
 		if (!n--) {


### PR DESCRIPTION
This PR helps update the evdns third-party dependency to address an issue originally reported here:
https://github.com/libevent/libevent/commit/ec65c42 & https://github.com/libevent/libevent/issues/332

The search_make_new function in evdns.c in libevent before 2.1.6-beta allows attackers to cause a denial of service (out-of-bounds read) via an empty hostname.



