### PR TITLE
Fix: XML Parser Allows Dangerous External Content Access in TMessagesProj/src/main/java/org/telegram/messenger/SvgHelper.java

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/SvgHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SvgHelper.java
@@ -440,6 +440,11 @@ public class SvgHelper {
     public static Bitmap getBitmap(int res, int width, int height, int color, float scale) {
         try (InputStream stream = ApplicationLoader.applicationContext.getResources().openRawResource(res)) {
             SAXParserFactory spf = SAXParserFactory.newInstance();
+            try {
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
             SAXParser sp = spf.newSAXParser();
             XMLReader xr = sp.getXMLReader();
             SVGHandler handler = new SVGHandler(width, height, color, false, scale);
@@ -455,6 +460,11 @@ public class SvgHelper {
     public static Bitmap getBitmap(InputStream stream, int width, int height, boolean white) {
         try {
             SAXParserFactory spf = SAXParserFactory.newInstance();
+            try {
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
             SAXParser sp = spf.newSAXParser();
             XMLReader xr = sp.getXMLReader();
             SVGHandler handler = new SVGHandler(width, height, white ? 0xffffffff : null, false, 1f);
@@ -470,6 +480,11 @@ public class SvgHelper {
     public static Bitmap getBitmap(File file, int width, int height, boolean white) {
         try (FileInputStream stream = new FileInputStream(file)) {
             SAXParserFactory spf = SAXParserFactory.newInstance();
+            try {
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
             SAXParser sp = spf.newSAXParser();
             XMLReader xr = sp.getXMLReader();
             SVGHandler handler = new SVGHandler(width, height, white ? 0xffffffff : null, false, 1f);
@@ -488,6 +503,11 @@ public class SvgHelper {
     public static Bitmap getBitmap(String xml, int width, int height, boolean white) {
         try {
             SAXParserFactory spf = SAXParserFactory.newInstance();
+            try {
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
             SAXParser sp = spf.newSAXParser();
             XMLReader xr = sp.getXMLReader();
             SVGHandler handler = new SVGHandler(width, height, white ? 0xffffffff : null, false, 1f);
@@ -503,6 +523,11 @@ public class SvgHelper {
     public static SvgDrawable getDrawable(String xml) {
         try {
             SAXParserFactory spf = SAXParserFactory.newInstance();
+            try {
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
             SAXParser sp = spf.newSAXParser();
             XMLReader xr = sp.getXMLReader();
             SVGHandler handler = new SVGHandler(0, 0, null, true, 1f);
@@ -518,6 +543,11 @@ public class SvgHelper {
     public static SvgDrawable getDrawable(int resId, Integer color) {
         try {
             SAXParserFactory spf = SAXParserFactory.newInstance();
+            try {
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
             SAXParser sp = spf.newSAXParser();
             XMLReader xr = sp.getXMLReader();
             SVGHandler handler = new SVGHandler(0, 0, color, true, 1f);


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** DOCTYPE declarations are enabled for this SAXParserFactory. This is vulnerable to XML external entity attacks. Disable this by setting the feature `http://apache.org/xml/features/disallow-doctype-decl` to true. Alternatively, allow DOCTYPE declarations and only prohibit external entities declarations. This can be done by setting the features `http://xml.org/sax/features/external-general-entities` and `http://xml.org/sax/features/external-parameter-entities` to false. NOTE - The previous links are not meant to be clicked. They are the literal config key values that are supposed to be used to disable these features. For more information, see https://semgrep.dev/docs/cheat-sheets/java-xxe/#3a-documentbuilderfactory.
- **Rule ID:** java.lang.security.audit.xxe.saxparserfactory-disallow-doctype-decl-missing.saxparserfactory-disallow-doctype-decl-missing
- **Severity:** HIGH
- **File:** TMessagesProj/src/main/java/org/telegram/messenger/SvgHelper.java
- **Lines Affected:** 521 - 521

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `TMessagesProj/src/main/java/org/telegram/messenger/SvgHelper.java` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.