### PR TITLE
Fix some bugs and add animations to ProfileMusicView

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AudioPlayerAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AudioPlayerAlert.java
@@ -1675,6 +1675,9 @@ public class AudioPlayerAlert extends BottomSheet implements NotificationCenter.
             saveToProfile(messageObject, false, () -> {
                 if (savedMusicList != null) {
                     savedMusicList.remove(messageObject);
+                }
+            }, () -> {
+                if (savedMusicList != null) {
                     if (savedMusicList.list.isEmpty()) {
                         MediaController.getInstance().cleanup();
                         dismiss();
@@ -2584,6 +2587,10 @@ public class AudioPlayerAlert extends BottomSheet implements NotificationCenter.
     }
 
     private void saveToProfile(MessageObject messageObject, boolean save, Runnable done, boolean triedFileRef) {
+        saveToProfile(messageObject, save, null, done, triedFileRef);
+    }
+
+    private void saveToProfile(MessageObject messageObject, boolean save, Runnable profileUpdater, Runnable done, boolean triedFileRef) {
         final TLRPC.Document document = messageObject.getDocument();
         if (document == null) {
             return;
@@ -2691,8 +2698,13 @@ public class AudioPlayerAlert extends BottomSheet implements NotificationCenter.
                         userInfo.flags2 &=~ TLObject.FLAG_21;
                         userInfo.saved_music = null;
                     }
+                    if (profileUpdater != null) {
+                        profileUpdater.run();
+                    }
                     MessagesStorage.getInstance(currentAccount).updateUserInfo(userInfo, true);
                     NotificationCenter.getInstance(currentAccount).postNotificationName(NotificationCenter.profileMusicUpdated, selfId);
+                } else if (profileUpdater != null) {
+                    profileUpdater.run();
                 }
                 if (done != null) {
                     done.run();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ProfileGalleryBlurView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ProfileGalleryBlurView.java
@@ -667,10 +667,11 @@ public class ProfileGalleryBlurView extends View {
             }
         }
         if (musicView != null) {
+            float dy = -size + dp(22) + (actionSize == 0 ? dp(4) : 0);
             if (avatarImageView != null) {
-                musicView.drawingBlur(actionsBlurNode, avatarImageView, scale / openingScale, -size + dp(22));
+                musicView.drawingBlur(actionsBlurNode, avatarImageView, scale / openingScale, dy);
             } else {
-                musicView.drawingBlur(actionsBlurNode, null, scale, -size + dp(22));
+                musicView.drawingBlur(actionsBlurNode, null, scale, dy);
             }
         }
     }


### PR DESCRIPTION
Hi, This PR fixes several UI issues and enhances animations in the `ProfileMusicView` component. Here's what I've changed:

### Fixes

**Fix: Online text view centering issue** 
Online text view had left padding that prevented proper centering, now it's perfectly centered. _Sorry for that :D_

**Fix: Fix: Rating view positioning**
The new update added a `ratingView`, so now the online text view calculates the `ratingView` size to remain centered while considering the ratingView dimensions.

**Fix: Music replacement logic**
When we have multiple music tracks on profile, from my profile page, deleting the top music from profile causes the music view to disappear completely. It should be replaced with the next music in the playlist instead.

**Fix: Avatar collapse animation glitch**
Based on the `minimizedX` changes (from` dp(42 + 21)` to `dp(42 + 4)`), the new `minimizedX` value now also applies in `setAvatarExpandProgress`. This affects scenarios where users fast scroll up while the avatar is already expanded, which causes a glitch if the new value doesn't apply during the animation.

### Added Animations

**Added: Music switching animation**
Switching the top music in my profile page now includes a smooth translation animation (previous track slides down while the new music data slides in from the top)

**Scenario to test:**
Add multiple music tracks to your profile, then try to move and switch the top music from your profile page, or simply remove the top music from profile. It should smoothly animate to the next music.

**Added: Music removal animation**
Removing music from profile now makes the music player resize smoothly (animates height to zero) during the removal process. Before this PR, there was a minor glitch during this process.

**Scenario to test:**
Go to my profile page, remove the music from your profile and observe the transition.

**Added: Music addition animation**
Adding music to profile now makes the music player resize with animation (height changes from zero to its target height) as it enters. Before this PR, there was a minor glitch during this interaction.

**Scenario to test:**
- Play a music track (don't add it to your profile)
- Open my profile page
- Click on music below tabs
- Add it to your profile
- The musicView should now enter with a smooth animation
