### PR TITLE
Enable "System Default" Auto Night Mode for all Android versions

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
@@ -4966,7 +4966,7 @@ public class Theme {
                 oldEditorNew.commit();
             }
 
-            selectedAutoNightType = preferences.getInt("selectedAutoNightType", Build.VERSION.SDK_INT >= 29 ? AUTO_NIGHT_TYPE_SYSTEM : AUTO_NIGHT_TYPE_NONE);
+            selectedAutoNightType = preferences.getInt("selectedAutoNightType", AUTO_NIGHT_TYPE_SYSTEM);
             autoNightScheduleByLocation = preferences.getBoolean("autoNightScheduleByLocation", false);
             autoNightBrighnessThreshold = preferences.getFloat("autoNightBrighnessThreshold", 0.25f);
             autoNightDayStartTime = preferences.getInt("autoNightDayStartTime", 22 * 60);

--- a/TMessagesProj/src/main/java/org/telegram/ui/ThemeActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ThemeActivity.java
@@ -696,9 +696,7 @@ public class ThemeActivity extends BaseFragment implements NotificationCenter.No
             nightDisabledRow = rowCount++;
             nightScheduledRow = rowCount++;
             nightAutomaticRow = rowCount++;
-            if (Build.VERSION.SDK_INT >= 29) {
-                nightSystemDefaultRow = rowCount++;
-            }
+            nightSystemDefaultRow = rowCount++;
             nightTypeInfoRow = rowCount++;
             if (Theme.selectedAutoNightType == Theme.AUTO_NIGHT_TYPE_SCHEDULED) {
                 scheduleHeaderRow = rowCount++;


### PR DESCRIPTION
Since [night mode](https://developer.android.com/reference/android/app/UiModeManager#setNightMode(int)) support was introduced as early as API 8, the "System Default" option can function correctly on older Android versions and should not be restricted to Android 10+ devices.

https://github.com/user-attachments/assets/042532bc-d54a-4096-b83c-1a9d3d0b121b