### PR TITLE
TMA: repeated camera/microphone permission dialog on every WebView PermissionRequest in the same session

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/web/BotWebViewContainer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/web/BotWebViewContainer.java
@@ -682,6 +682,36 @@ public abstract class BotWebViewContainer extends FrameLayout implements Notific
         }
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    private String[] getRequestedAndroidPermissionsForWebResources(String[] resources) {
+        ArrayList<String> permissions = new ArrayList<>();
+        for (String resource : resources) {
+            if (PermissionRequest.RESOURCE_AUDIO_CAPTURE.equals(resource)) {
+                if (!permissions.contains(Manifest.permission.RECORD_AUDIO)) {
+                    permissions.add(Manifest.permission.RECORD_AUDIO);
+                }
+            } else if (PermissionRequest.RESOURCE_VIDEO_CAPTURE.equals(resource)) {
+                if (!permissions.contains(Manifest.permission.CAMERA)) {
+                    permissions.add(Manifest.permission.CAMERA);
+                }
+            }
+        }
+        return permissions.toArray(new String[0]);
+    }
+
+    private boolean canReuseGrantedWebPermissions(String[] permissions) {
+        if (!hasUserPermissions) {
+            return false;
+        }
+        if (permissions.length == 0) {
+            return false;
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return true;
+        }
+        return checkPermissions(permissions);
+    }
+
     public boolean isPageLoaded() {
         return isPageLoaded;
     }
@@ -4405,6 +4435,11 @@ public abstract class BotWebViewContainer extends FrameLayout implements Notific
 
                     final String name = bot ? UserObject.getUserName(botWebViewContainer.botUser) : AndroidUtilities.getHostAuthority(getUrl());
                     String[] resources = request.getResources();
+                    String[] androidPermissions = botWebViewContainer.getRequestedAndroidPermissionsForWebResources(resources);
+                    if (botWebViewContainer.canReuseGrantedWebPermissions(androidPermissions)) {
+                        request.grant(resources);
+                        return;
+                    }
                     if (resources.length == 1) {
                         String resource = resources[0];
 


### PR DESCRIPTION
In Telegram Mini Apps on Android, camera/microphone access inside the WebView may trigger the Telegram permission dialog repeatedly within the same Mini App session.

This is especially visible when a Mini App uses `getUserMedia()` more than once, for example:
- starting camera access again after a previous attempt
- switching `facingMode`
- re-requesting audio/video capture from the same page

### Expected behavior

If the user has already approved camera/microphone access for the current Mini App WebView session, and Android runtime permissions are still granted, repeated `PermissionRequest`s should be granted without showing the Telegram permission dialog again.

### Actual behavior

Telegram shows the WebView permission dialog again for subsequent `PermissionRequest`s, even when:
- the same Mini App session is still active
- the same WebView is used
- Android `CAMERA` / `RECORD_AUDIO` permissions are already granted

This makes camera UX unstable for Mini Apps and may interrupt flows like video recording or camera switching.

### Scope

This is about **Telegram Mini Apps / WebView**, not the native attach menu camera flow.

### Reproduction

1. Open a Telegram Mini App on Android.
2. Let it request camera or camera+microphone access.
3. Approve the Telegram dialog and the Android permission request.
4. Trigger another WebView media permission request in the same page/session
   - for example by switching camera or re-requesting media capture.
5. Observe that Telegram shows its permission dialog again.

### Notes

The issue appears to be in WebView `onPermissionRequest(...)` handling in the Android client. Issue is not present on iOS client

A safe fix is to auto-grant repeated WebView media requests **only inside the same Mini App session**, when:
- the WebView session has already been approved by the user
- and Android runtime permissions are still granted

This should not bypass permission prompts for a fresh page load or a new Mini App session.
