### PR TITLE
Fix: video player respects system auto-rotation lock setting

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
@@ -2983,6 +2983,13 @@ public class AndroidUtilities {
         return isTabletInternal() && !SharedConfig.forceDisableTabletMode;
     }
 
+    public static boolean isAutoRotationEnabled(Context context) {
+        return android.provider.Settings.System.getInt(
+            context.getContentResolver(),
+            android.provider.Settings.System.ACCELEROMETER_ROTATION, 0
+        ) == 1;
+    }
+
     public static boolean isSmallScreen() {
         if (isSmallScreen == null) {
             isSmallScreen = (Math.max(displaySize.x, displaySize.y) - statusBarHeight - navigationBarHeight) / density <= 650;

--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
@@ -10502,17 +10502,23 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
                             if (orientation >= 270 - 30 && orientation <= 270 + 30) {
                                 wasRotated = true;
                             } else if (wasRotated && orientation > 0 && (orientation >= 330 || orientation <= 30)) {
-                                parentActivity.setRequestedOrientation(prevOrientation);
-                                fullscreenedByButton = 0;
-                                wasRotated = false;
-                            }
+                                
+                                if (AndroidUtilities.isAutoRotationEnabled(parentActivity)) {
+                                    parentActivity.setRequestedOrientation(prevOrientation);
+                                    fullscreenedByButton = 0;
+                                    wasRotated = false;
+                                }
+                            }    
                         } else {
                             if (orientation > 0 && (orientation >= 330 || orientation <= 30)) {
                                 wasRotated = true;
                             } else if (wasRotated && orientation >= 270 - 30 && orientation <= 270 + 30) {
-                                parentActivity.setRequestedOrientation(prevOrientation);
-                                fullscreenedByButton = 0;
-                                wasRotated = false;
+                                
+                                if (AndroidUtilities.isAutoRotationEnabled(parentActivity)) {
+                                    parentActivity.setRequestedOrientation(prevOrientation);
+                                    fullscreenedByButton = 0;
+                                    wasRotated = false;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
When auto-rotation is disabled in system settings, the video player 
still exits fullscreen mode when the phone is physically rotated back.

Fix: added a check for system auto-rotation setting before resetting screen orientation in PhotoViewer.java (OrientationEventListener).

Files changed:
- AndroidUtilities.java — added isAutoRotationEnabled() helper
- PhotoViewer.java — wrapped setRequestedOrientation() calls with the check