### PR TITLE
Set AudioAttributes contentType to fix AudioPlaybackCapture on Samsung devices

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/VideoPlayer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/VideoPlayer.java
@@ -275,6 +275,14 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
             }
             player = builder.build();
 
+            // Default to MEDIA/MOVIE so AudioPolicyManager (Samsung in particular) routes the
+            // track to the AudioPlaybackCapture submix. UNKNOWN contentType is silently dropped
+            // from the submix on some HALs. Overridden by setStreamType() for earpiece routing.
+            player.setAudioAttributes(new AudioAttributes.Builder()
+                .setUsage(C.USAGE_MEDIA)
+                .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+                .build(), handleAudioFocus);
+
             player.addAnalyticsListener(this);
             player.addListener(this);
             player.addVideoListener(this);
@@ -293,6 +301,10 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
                 audioPlayer = new ExoPlayer.Builder(ApplicationLoader.applicationContext)
                         .setTrackSelector(trackSelector)
                         .setLoadControl(loadControl).buildSimpleExoPlayer();
+                audioPlayer.setAudioAttributes(new AudioAttributes.Builder()
+                    .setUsage(C.USAGE_MEDIA)
+                    .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+                    .build(), true);
                 audioPlayer.addListener(new Player.Listener() {
 
                     @Override
@@ -1639,11 +1651,13 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
         if (player != null) {
             player.setAudioAttributes(new AudioAttributes.Builder()
                 .setUsage(type == AudioManager.STREAM_VOICE_CALL ? C.USAGE_VOICE_COMMUNICATION : C.USAGE_MEDIA)
+                .setContentType(type == AudioManager.STREAM_VOICE_CALL ? C.AUDIO_CONTENT_TYPE_SPEECH : C.AUDIO_CONTENT_TYPE_MOVIE)
                 .build(), handleAudioFocus);
         }
         if (audioPlayer != null) {
             audioPlayer.setAudioAttributes(new AudioAttributes.Builder()
                 .setUsage(type == AudioManager.STREAM_VOICE_CALL ? C.USAGE_VOICE_COMMUNICATION : C.USAGE_MEDIA)
+                .setContentType(type == AudioManager.STREAM_VOICE_CALL ? C.AUDIO_CONTENT_TYPE_SPEECH : C.AUDIO_CONTENT_TYPE_MUSIC)
                 .build(), true);
         }
     }


### PR DESCRIPTION
# `AudioPlaybackCapture` silently ignores Telegram media playback on devices whose AudioPolicyManager filters by `AudioAttributes.contentType`

## Summary

On Samsung Galaxy Z Fold 4 (One UI / Snapdragon 8+ Gen 1), third-party apps using Android's `AudioPlaybackCapture` API (e.g. AudioRelay) capture audio from YouTube, Samsung Gallery, and Telegram X correctly, but receive **silence** when capturing video, voice, or music playback from official Telegram for Android — even though Telegram's manifest correctly declares `android:allowAudioPlaybackCapture="true"`.

The same Telegram APK works fine on a Galaxy S10+ on the same Android version. So this is not an Android version mismatch and not a manifest issue.

Root cause: Telegram constructs ExoPlayer `AudioAttributes` with only `usage` set, leaving `contentType = AUDIO_CONTENT_TYPE_UNKNOWN`. Some OEM AudioPolicyManager implementations (Samsung's, confirmed on Z Fold 4) treat `MEDIA / UNKNOWN` tracks as ineligible for the `REMOTE_SUBMIX` virtual output used by `AudioPlaybackCapture`, and silently exclude the track from the submix routing patch. Setting a real `contentType` (`AUDIO_CONTENT_TYPE_MOVIE` for video, `AUDIO_CONTENT_TYPE_MUSIC` for audio) fixes routing without affecting playback.

## Affected playback paths

All three of these go silent under `AudioPlaybackCapture` on Z Fold 4:

- Video messages played fullscreen (`PhotoViewer` → `VideoPlayer`)
- Audio file messages and voice messages (`MediaController.audioPlayer` → `VideoPlayer`)
- Round/video-note messages (`MediaController.videoPlayer` → `VideoPlayer`)

## Reproduction

1. Z Fold 4 (Android 13+, One UI 5+).
2. Install AudioRelay (or any app using `MediaProjection` + `AudioPlaybackCaptureConfiguration.addMatchingUsage(USAGE_MEDIA)`).
3. Grant projection. Start capture.
4. Play any video message in Telegram.
5. Capture is silent. Switch to YouTube/Gallery — capture works.

## Evidence: `dumpsys media.audio_flinger`

A `REMOTE_SUBMIX` output thread (`AudioOut_AB5`, output device `0x8000 = AUDIO_DEVICE_OUT_REMOTE_SUBMIX`) is created when AudioRelay starts capture. AudioFlinger places a "patch track" (id 8373, owned by audioserver uid 1525) on this thread to receive routed copies of matching app audio.

While **YouTube** is playing (speaker thread `AudioOut_15`):

```
Tracks:
  Type     Id Active Client Session Port Id S  Flags   Format Chn mask SRate ST Usg CT ...
       --   8371    yes  30101   47337    8870 A  0x000 00000001 00000003 48000  3   1  2 ...
                                                                  ^MEDIA  ^MUSIC
Submix patch:
  P   8373    yes   1525       0       0 A  0x400 ...    <-- ACTIVE: audio flowing to capture
```

While **Telegram** is playing (same speaker thread):

```
Tracks:
  Type     Id Active Client Session Port Id S  Flags   Format Chn mask SRate ST Usg CT ...
       --   8402    yes  29092   47473    8887 A  0x000 00000001 00000003 44100  3   1  0 ...
                                                                  ^MEDIA  ^UNKNOWN
Submix patch:
  P   8373     no   1525       0       0 P  0x400 ...    <-- PAUSED: no audio reaches capture
```

Identical thread, identical flags (`0x000`), identical PCM format (`0x1` = `PCM_16_BIT`), identical usage (`1` = `USAGE_MEDIA`). The only difference is `CT` (content type): YouTube=`2` (`MUSIC`), Telegram=`0` (`UNKNOWN`). The submix patch goes active for the former and stays paused for the latter, despite both using `USAGE_MEDIA`.

So `usage=MEDIA, contentType=UNKNOWN` is being treated by this device's AudioPolicyManager as "not eligible for capture-submix routing." Fixing the contentType is sufficient.

## Where the bug is

`TMessagesProj/src/main/java/org/telegram/ui/Components/VideoPlayer.java`:

- `setStreamType(int type)` (around L1638) calls `setUsage()` but never `setContentType()`.
- The `preparePlayer()` flow that builds the `ExoPlayer` (around L276 and L301) doesn't set audio attributes at all, so callers that never invoke `setStreamType` — most notably `PhotoViewer`, which is the fullscreen video player most users see — get ExoPlayer's default `AudioAttributes`, where `contentType = AUDIO_CONTENT_TYPE_UNKNOWN`.

## Fix

```diff
@@ VideoPlayer.preparePlayer @@
             player = builder.build();
 
+            // Default to MEDIA/MOVIE so AudioPolicyManager (Samsung in particular) routes the
+            // track to the AudioPlaybackCapture submix. UNKNOWN contentType is silently dropped
+            // from the submix on some HALs. Overridden by setStreamType() for earpiece routing.
+            player.setAudioAttributes(new AudioAttributes.Builder()
+                .setUsage(C.USAGE_MEDIA)
+                .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+                .build(), handleAudioFocus);
+
             player.addAnalyticsListener(this);
 ...
                 audioPlayer = new ExoPlayer.Builder(ApplicationLoader.applicationContext)
                         .setTrackSelector(trackSelector)
                         .setLoadControl(loadControl).buildSimpleExoPlayer();
+                audioPlayer.setAudioAttributes(new AudioAttributes.Builder()
+                    .setUsage(C.USAGE_MEDIA)
+                    .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+                    .build(), true);
                 audioPlayer.addListener(new Player.Listener() {

@@ VideoPlayer.setStreamType @@
         if (player != null) {
             player.setAudioAttributes(new AudioAttributes.Builder()
                 .setUsage(type == AudioManager.STREAM_VOICE_CALL ? C.USAGE_VOICE_COMMUNICATION : C.USAGE_MEDIA)
+                .setContentType(type == AudioManager.STREAM_VOICE_CALL ? C.AUDIO_CONTENT_TYPE_SPEECH : C.AUDIO_CONTENT_TYPE_MOVIE)
                 .build(), handleAudioFocus);
         }
         if (audioPlayer != null) {
             audioPlayer.setAudioAttributes(new AudioAttributes.Builder()
                 .setUsage(type == AudioManager.STREAM_VOICE_CALL ? C.USAGE_VOICE_COMMUNICATION : C.USAGE_MEDIA)
+                .setContentType(type == AudioManager.STREAM_VOICE_CALL ? C.AUDIO_CONTENT_TYPE_SPEECH : C.AUDIO_CONTENT_TYPE_MUSIC)
                 .build(), true);
         }
```

14 lines added, no other changes.

## Why this is safe

- `contentType` is metadata hinting at *what kind of audio* the track contains. It doesn't change routing on devices without the OEM-specific submix filter — those continue to behave exactly as before.
- The values chosen (`MOVIE` for the main player, `MUSIC` for the audio-only player, `SPEECH` when stream is `STREAM_VOICE_CALL`) match what the player is actually playing in each case and match what well-behaved Android media apps (YouTube, Google Play Music, ExoPlayer demo app) already declare.
- ExoPlayer's `setAudioAttributes(attrs, handleAudioFocus)` is called the same way Telegram already calls it for the `setUsage`-only variant; only the builder argument changes.
- No change to manifest, permissions, or playback behavior. The audio that reaches the speaker is identical bytes.

## Tested

Built from Telegram 12.7.3 (build 6750) with the patch applied, installed alongside the official client, retested on Galaxy Z Fold 4. AudioRelay now captures Telegram media playback correctly.

`dumpsys media.audio_flinger` after the fix shows the predicted behavior:

```
Speaker thread (AudioOut_15), active Telegram track:
  8459  yes  6020  48017  8946 A  0x000 PCM_16  stereo  44100  ST=3  Usg=1  CT=3 (MOVIE)
                                                                              ^^^^^^^^^
Submix thread (AudioOut_AB5):
  P  8461  yes  1525  ...  A  0x000 PCM_16  stereo  44100  ...     <-- ACTIVE, audio flowing
```

AudioFlinger creates a new patch track on the `REMOTE_SUBMIX` output for Telegram's playback (`Server`/`FrmRdy` counters advancing in sync with the speaker track), exactly as it does for YouTube. The only change in the speaker track between buggy and fixed runs is the `CT` column (`0` → `3`); everything else is byte-identical. Capture works.

- Z Fold 4 (One UI 6.x, Snapdragon 8+ Gen 1) — **confirmed fixed**.
- Galaxy S10+ — unaffected before and after (older HAL didn't filter on contentType).

## Related Android docs

- `AudioPlaybackCaptureConfiguration`: https://developer.android.com/reference/android/media/AudioPlaybackCaptureConfiguration
- `AudioAttributes.setContentType()`: https://developer.android.com/reference/android/media/AudioAttributes.Builder#setContentType(int)
