### PR TITLE
Allow sending typed messages while bot draft streaming is active

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -7638,6 +7638,7 @@ public class ChatActivityEnterView extends FrameLayout implements
         }
         updateSendButtonPaid();
         final CharSequence message = messageEditText == null ? "" : AndroidUtilities.getTrimmedString(messageEditText.getTextToUse());
+        updateSendButtonBlockedByTypingView(animatorIsBlockedByStreaming.getFloatValue());
         boolean shownSendButton = false;
         if (slowModeTimer > 0 && slowModeTimer != Integer.MAX_VALUE && !isInScheduleMode()) {
             if (slowModeButton.getVisibility() != VISIBLE) {
@@ -7828,7 +7829,7 @@ public class ChatActivityEnterView extends FrameLayout implements
                     }
                 }
             }
-        } else if (message.length() > 0 || forceShowSendButton || audioToSend != null || videoToSendMessageObject != null || slowModeTimer == Integer.MAX_VALUE && !isInScheduleMode() || isLiveComment && getStarsPrice() > 0 || animatorIsBlockedByStreaming.getValue()) {
+        } else if (message.length() > 0 || forceShowSendButton || audioToSend != null || videoToSendMessageObject != null || slowModeTimer == Integer.MAX_VALUE && !isInScheduleMode() || isLiveComment && getStarsPrice() > 0 || shouldBlockSendButtonByStreaming()) {
             shownSendButton = true;
             final String caption = messageEditText == null ? null : messageEditText.getCaption();
             boolean showBotButton = caption != null && (getSendButtonInternal().getVisibility() == VISIBLE || expandStickersButton != null && expandStickersButton.getVisibility() == VISIBLE);
@@ -7846,7 +7847,7 @@ public class ChatActivityEnterView extends FrameLayout implements
                 Theme.setSelectorDrawableColor(sendButton.getBackground(), Color.argb(24, Color.red(color), Color.green(color), Color.blue(color)), true);
             }
 
-            if (audioVideoButtonContainer.getVisibility() == VISIBLE || slowModeButton.getVisibility() == VISIBLE || showBotButton || showSendButton || animatorIsBlockedByStreaming.getValue()) {
+            if (audioVideoButtonContainer.getVisibility() == VISIBLE || slowModeButton.getVisibility() == VISIBLE || showBotButton || showSendButton || shouldBlockSendButtonByStreaming()) {
                 if (animated) {
                     if (runningAnimationType == 1 && caption == null || runningAnimationType == 3 && caption != null) {
                         return;
@@ -14085,8 +14086,27 @@ public class ChatActivityEnterView extends FrameLayout implements
         }
     }
 
+    private boolean hasSendableText() {
+        return messageEditText != null && AndroidUtilities.getTrimmedString(messageEditText.getTextToUse()).length() > 0;
+    }
+
+    private boolean shouldBlockSendButtonByStreaming() {
+        return animatorIsBlockedByStreaming.getValue() && !hasSendableText();
+    }
+
     private boolean isSendButtonEnabled() {
-        return sendButtonEnabled && !animatorIsBlockedByStreaming.getValue();
+        return sendButtonEnabled && !shouldBlockSendButtonByStreaming();
+    }
+
+    private void updateSendButtonBlockedByTypingView(float factor) {
+        if (sendButtonBlockedByTypingView == null) {
+            return;
+        }
+        boolean showBlockedByTyping = factor > 0 && shouldBlockSendButtonByStreaming();
+        sendButtonBlockedByTypingView.setAlpha(showBlockedByTyping ? factor : 0);
+        sendButtonBlockedByTypingView.setScaleX(lerp(0.5f, 1, factor));
+        sendButtonBlockedByTypingView.setScaleY(lerp(0.5f, 1, factor));
+        sendButtonBlockedByTypingView.setVisibility(showBlockedByTyping ? View.VISIBLE : View.INVISIBLE);
     }
 
     private void updateAttachButtonTranslationX() {
@@ -14827,10 +14847,7 @@ public class ChatActivityEnterView extends FrameLayout implements
             checkUi_TopViewVisibility();
         }
         if (id == ANIMATOR_ID_BLOCKED_BY_BOT_TYPING) {
-            sendButtonBlockedByTypingView.setAlpha(factor);
-            sendButtonBlockedByTypingView.setScaleX(lerp(0.5f, 1, factor));
-            sendButtonBlockedByTypingView.setScaleY(lerp(0.5f, 1, factor));
-            sendButtonBlockedByTypingView.setVisibility(factor > 0 ? View.VISIBLE : View.INVISIBLE);
+            updateSendButtonBlockedByTypingView(factor);
         }
         invalidate();
     }


### PR DESCRIPTION
## Summary

This small change keeps the bot draft streaming indicator for an empty composer, but allows the user to send a typed message while the bot draft is active.

Currently, when a bot sends `TL_sendMessageTextDraftAction`, Android shows the `SendButtonBlockedByTypingView` and treats the send button as disabled while the draft exists. This makes sense as a passive “the bot is generating” indicator, but it also prevents explicit user input: if the user types a correction, interruption, or bot command while generation is still in progress, the send button remains blocked.

## Why

For AI/bot chats, users often need to steer or interrupt the bot while it is generating. For example, a user may type a correction or a command such as `/stop` or `/steer ...` after seeing the draft preview go in the wrong direction. On Telegram Desktop, the chat remains usable in this situation; Android currently blocks the send affordance.

This PR keeps the existing blocked-by-streaming UI when the input is empty, but does not let that streaming state disable the send button once the user has typed sendable text.

## Behavior after this change

- Empty composer + bot draft active: the typing/draft indicator can still be shown.
- User types a message while bot draft is active: normal send behavior is restored.
- The change is limited to `ChatActivityEnterView` and does not change draft storage, draft rendering, or server/API behavior.

## Notes

I ran `git diff --check` locally for the patch. I have not run a full Android build in this environment.