### PR TITLE
[Fix] Audio / Video desync in Camera 2 API round videos (circles)

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/InstantCameraView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/InstantCameraView.java
@@ -2493,12 +2493,12 @@ public class InstantCameraView extends FrameLayout implements NotificationCenter
                         for (int a = input.lastWroteBuffer; a <= input.results; a++) {
                             if (a < input.results) {
                                 long totalTime = input.offset[a] - audioStartTime;
-                                if (!running && (input.offset[a] >= videoLast - desyncTime || totalTime >= 60_000000)) {
+                                if (!running && (input.offset[a] >= videoLast / 1000 - desyncTime || totalTime >= 60_000000)) {
                                     if (BuildVars.LOGS_ENABLED) {
                                         if (totalTime >= 60_000000) {
                                             FileLog.d("InstantCamera stop audio encoding because recorded time more than 60s");
                                         } else {
-                                            FileLog.d("InstantCamera stop audio encoding because of stoped video recording at " + input.offset[a] + " last video " + videoLast);
+                                            FileLog.d("InstantCamera stop audio encoding because of stoped video recording at " + input.offset[a] + " last video " + (videoLast / 1000));
                                         }
 
                                     }
@@ -2586,7 +2586,17 @@ public class InstantCameraView extends FrameLayout implements NotificationCenter
                 }
                 lastTimestamp = timestampNanos;
             } else {
-                alphaDt = dt = (timestampNanos - lastTimestamp);
+                long dtTimestamps = (timestampNanos - lastTimestamp);
+                long dtReal = (System.currentTimeMillis() - lastCommitedFrameTime) * 1000000;
+                if (dtTimestamps < 0 || Math.abs(dtReal - dtTimestamps) > 100_000_000) {
+                    dt = dtReal;
+                } else {
+                    dt = dtTimestamps;
+                }
+                if (dt < 0) {
+                    dt = 0;
+                }
+                alphaDt = dtTimestamps;
                 lastTimestamp = timestampNanos;
             }
             firstVideoFrameSincePause = false;


### PR DESCRIPTION
OG Bug: https://bugs.telegram.org/c/58703

When "Use Camera 2 API" is enabled, round video messages drift out of sync: the video track speeds up and freezes in the final seconds while audio plays at normal speed

With "Camera 2 API" off (legacy Camera 1 API), sync is correct but fps is capped (~24 - 30) and quality is lower

The trigger is variable frame rate (VFR). Phone cameras lower fps in dim light and raise it (toward 60) in bright light
So the desync appears the moment fps ramps up mid-recording

The encode/mux path already drives video PTS from the real camera timestamp (`SurfaceTexture.getTimestamp()`) and `MP4Builder` / `Track` already write real per-sample timestamps. The desync comes from two time-base bugs that only surface under Camera2's high/variable fps:

1. Per-frame video PTS was unguarded
2. Audio / Video end-alignment mixed units (nanoseconds (ns) vs microseconds (us))

Just added `InstantCameraView.java` changes only - scoped to the round-video recording path