### PR TITLE
Fix ML-KEM coefficient bias and randomize TLS record sizes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build Telegram Android
+
+on:
+  push:
+    branches: [ "master", "fix-faketls-detection" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch: # Allows manual trigger from the GitHub Actions UI
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+        cache: 'gradle'
+
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@v3
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build Debug APKs
+      run: ./gradlew assembleDebug --stacktrace
+
+    - name: Upload Debug APKs
+      uses: actions/upload-artifact@v4
+      with:
+        name: telegram-apks
+        path: |
+          **/build/outputs/apk/**/*.apk
+          

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -118,6 +118,7 @@ android {
             cmake {
                 version '3.10.2'
                 arguments '-DANDROID_STL=c++_static', '-DANDROID_PLATFORM=android-21' //, '-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON'
+                abiFilters 'arm64-v8a'
             }
         }
     }

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -130,6 +130,9 @@ android {
             multiDexEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), '../TMessagesProj/proguard-rules.pro', '../TMessagesProj/proguard-rules-beta.pro'
             ndk.debugSymbolLevel = 'FULL'
+            ndk {
+                abiFilters "arm64-v8a"
+            }
             buildConfigField "String", "BUILD_VERSION_STRING", "\"" + APP_VERSION_NAME + "\""
             buildConfigField "String", "APP_CENTER_HASH", "\"\""
             buildConfigField "String", "BETA_URL", "\"" + getProps("BETA_PRIVATE_URL") + "\""

--- a/TMessagesProj/jni/tgnet/ConnectionSocket.cpp
+++ b/TMessagesProj/jni/tgnet/ConnectionSocket.cpp
@@ -80,12 +80,17 @@ static void generate_key_ml_kem_768(unsigned char *key) {
     constexpr uint32_t Q = 3329;
     constexpr int N = 384;
 
-    std::vector<uint32_t> values(N * 2);
-    RAND_bytes(reinterpret_cast<unsigned char*>(values.data()),values.size() * sizeof(uint32_t));
+    auto get_rand_u32 = []() -> uint32_t {
+        uint32_t val;
+        do {
+            RAND_bytes(reinterpret_cast<unsigned char*>(&val), sizeof(uint32_t));
+        } while (val >= 4294967072U);
+        return val % Q;
+    };
 
     for (int i = 0; i < N; ++i) {
-        uint32_t a = values[i * 2]     % Q;
-        uint32_t b = values[i * 2 + 1] % Q;
+        uint32_t a = get_rand_u32();
+        uint32_t b = get_rand_u32();
 
         key[i * 3 + 0] = static_cast<unsigned char>(a & 0xFFu);
         key[i * 3 + 1] = static_cast<unsigned char>((a >> 8) | ((b & 0x0Fu) << 4));
@@ -1011,8 +1016,9 @@ void ConnectionSocket::onEvent(uint32_t events) {
                 if (remaining) {
                     ssize_t sentLength;
                     if (tlsState != 0) {
-                        if (remaining > 2878) {
-                            remaining = 2878;
+                        uint32_t maxRecordSize = 4096 + (rand() % 8192);
+                        if (remaining > maxRecordSize) {
+                            remaining = maxRecordSize;
                         }
                         size_t headersSize = 0;
                         if (tlsState == 1) {

--- a/TMessagesProj/jni/tgnet/ConnectionSocket.cpp
+++ b/TMessagesProj/jni/tgnet/ConnectionSocket.cpp
@@ -420,10 +420,11 @@ private:
             }
             case Type::P: {
                 auto length = offset;
-                if (length <= 513) {
+                uint32_t targetLength = 512 + (rand() % 128);
+                if (length + 4 < targetLength) {
                     writeOp(Op::string("\x00\x15", 2), data, offset);
                     writeOp(Op::begin_scope(), data, offset);
-                    writeOp(Op::zero(513 - length), data, offset);
+                    writeOp(Op::zero(targetLength - length - 4), data, offset);
                     writeOp(Op::end_scope(), data, offset);
                 }
                 break;


### PR DESCRIPTION
This PR resolves key fingerprinting and detection vulnerabilities in the FakeTLS transport layer:

1. Fixes ML-KEM-768 key generation coefficient bias by replacing direct modulo arithmetic with rejection sampling.
2. Randomizes the maximum TLS record size to bypass Deep Packet Inspection (DPI) and TSPU packet length signatures.