### PR TITLE
Fix self-comparison in DialogsAdapter recent .me URL diff

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Adapters/DialogsAdapter.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Adapters/DialogsAdapter.java
@@ -373,7 +373,7 @@ public class DialogsAdapter extends RecyclerListView.SelectionAdapter implements
                 return dialog != null && itemInternal.dialog != null && dialog.id == itemInternal.dialog.id && dialog.isFolder == itemInternal.dialog.isFolder;
             }
             if (viewType == VIEW_TYPE_ME_URL) {
-                return recentMeUrl != null && itemInternal.recentMeUrl != null && recentMeUrl.url != null && recentMeUrl.url.equals(recentMeUrl.url);
+                return recentMeUrl != null && itemInternal.recentMeUrl != null && recentMeUrl.url != null && recentMeUrl.url.equals(itemInternal.recentMeUrl.url);
             }
             if (viewType == VIEW_TYPE_USER) {
                 return contact != null && itemInternal.contact != null && contact.user_id == itemInternal.contact.user_id;


### PR DESCRIPTION
  ItemInternal.compare() is used as DiffUtil.areItemsTheSame() for the
  chat list. In the VIEW_TYPE_ME_URL branch it compared recentMeUrl.url
  against itself instead of against itemInternal.recentMeUrl.url, so any
  two recent .me URL hint items with non-null URLs were treated as the
  same item. When the hint set changed, RecyclerView wouldn't dispatch
  the right insert/remove and items could render with stale URLs.

  Compare against itemInternal.recentMeUrl.url, matching the pattern used
  by the VIEW_TYPE_DIALOG and VIEW_TYPE_USER branches in the same method.
