### PR TITLE
Fix incoming-call vibration dropped on Android 13+ when locked (VoIPPreNotificationService USAGE_UNKNOWN)

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPPreNotificationService.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPPreNotificationService.java
@@ -18,6 +18,8 @@ import android.media.MediaPlayer;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
+import android.os.VibrationAttributes;
+import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.provider.Settings;
 import android.text.SpannableString;
@@ -348,7 +350,25 @@ public class VoIPPreNotificationService { // } extends Service implements AudioM
                     } else if (vibrate == 3) {
                         duration *= 2;
                     }
-                    vibrator.vibrate(new long[]{0, duration, 500}, 0);
+                    // Pre-notification rings from a background proc state (no foreground service yet),
+                    // so the vibration must be tagged with a background-allowed usage or Android 13+
+                    // drops it (VibratorManagerService: "is background ... USAGE_UNKNOWN").
+                    if (Build.VERSION.SDK_INT >= 33) {
+                        vibrator.vibrate(
+                            VibrationEffect.createWaveform(new long[]{0, duration, 500}, 0),
+                            new VibrationAttributes.Builder().setUsage(VibrationAttributes.USAGE_RINGTONE).build()
+                        );
+                    } else if (Build.VERSION.SDK_INT >= 26) {
+                        vibrator.vibrate(
+                            VibrationEffect.createWaveform(new long[]{0, duration, 500}, 0),
+                            new AudioAttributes.Builder()
+                                .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+                                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                                .build()
+                        );
+                    } else {
+                        vibrator.vibrate(new long[]{0, duration, 500}, 0);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes incoming-call vibration being silently dropped on **Android 13+** when the phone is **locked** and the ringer is in **vibrate** mode. Addresses https://bugs.telegram.org/c/43817.

On Android 13+, `MessagesController` routes an incoming call through `VoIPPreNotificationService.show()`. Despite the name this is a static helper, **not** a foreground service, so its `startRinging()` runs (inside the async `receivedCall` callback) while the process is still in a **background** proc state. The call-ring vibration is issued with the legacy `Vibrator.vibrate(long[], int)` API, which carries no `VibrationAttributes` and is therefore treated as `USAGE_UNKNOWN`. Android's `VibratorManagerService` drops vibrations from background processes whose usage is not in `BACKGROUND_PROCESS_USAGE_ALLOWLIST`, so the incoming-call vibration never plays. The single short buzz the user still feels is the system-played notification-channel vibration, not the call ring.

## Root cause (logcat — Pixel 9 Pro, Android 16 / SDK 36)

```
VibratorManagerService: Ignoring incoming vibration as process with uid=10428 is background, attrs=VibrationAttributes{mUsage=UNKNOWN, mAudioUsage=USAGE_UNKNOWN, mFlags=0}
```

AOSP `VibrationSettings`:

```java
if (!mUidObserver.isUidForeground(callerInfo.uid)
        && !BACKGROUND_PROCESS_USAGE_ALLOWLIST.contains(usage)) {
    return Status.IGNORED_BACKGROUND;
}
```

- `USAGE_UNKNOWN` is **not** in `BACKGROUND_PROCESS_USAGE_ALLOWLIST` → dropped while backgrounded.
- `USAGE_RINGTONE` **is** in that allowlist → allowed from the background.

This matches the observed behaviour: the call vibrates when the app is open/foreground (proc state passes the gate) and fails when locked/backgrounded. It reproduces **deterministically on both Wi‑Fi and mobile data** (not network/latency dependent).

## Environment

- Device: Pixel 9 Pro, Android 16 (SDK 36)
- Telegram 12.8.3 (`versionCode=69222`)
- Ringer mode: vibrate-only, screen locked

## Fix

`TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPPreNotificationService.java` — tag the vibration with a background-allowed usage on SDK 33+:

```java
if (Build.VERSION.SDK_INT >= 33) {
    vibrator.vibrate(
        VibrationEffect.createWaveform(new long[]{0, duration, 500}, 0),
        new VibrationAttributes.Builder().setUsage(VibrationAttributes.USAGE_RINGTONE).build()
    );
} else if (Build.VERSION.SDK_INT >= 26) {
    vibrator.vibrate(
        VibrationEffect.createWaveform(new long[]{0, duration, 500}, 0),
        new AudioAttributes.Builder()
            .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
            .build()
    );
} else {
    vibrator.vibrate(new long[]{0, duration, 500}, 0);
}
```

The legacy `vibrate(long[], int)` call is kept as the pre-API-26 fallback. Note the same legacy call also exists in `VoIPService.startRingtoneAndVibration(...)`; that path runs after `startForeground(...)`, so it is not affected by the background gate, but it could be aligned for consistency.

## Notes

Related: PR #1854 targets the same bug but references `VibrationAttributes.USAGE_NOTIFICATION_RINGTONE`, which is an `AudioAttributes` constant and is not a member of `VibrationAttributes` (the ringtone usage there is `USAGE_RINGTONE`). This PR is the minimal, compilable form of the same fix.
