### PR TITLE
Support TalkBack granular text navigation in chat message cells

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -6364,6 +6364,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
+        accessibilityFocused = false;
+        accessibilityHovered = false;
+
         NotificationCenter.getGlobalInstance().removeObserver(this, NotificationCenter.startSpoilers);
         NotificationCenter.getGlobalInstance().removeObserver(this, NotificationCenter.stopSpoilers);
         NotificationCenter.getGlobalInstance().removeObserver(this, NotificationCenter.emojiLoaded);
@@ -26575,6 +26578,12 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
 
     @Override
     public boolean performAccessibilityAction(int action, Bundle arguments) {
+        if (action == AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS) {
+            accessibilityFocused = true;
+        } else if (action == AccessibilityNodeInfo.ACTION_CLEAR_ACCESSIBILITY_FOCUS) {
+            accessibilityFocused = false;
+            updateAccessibilityTraversalText();
+        }
         if (delegate != null && delegate.onAccessibilityAction(action, arguments)) {
             return false;
         }
@@ -26652,6 +26661,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         int x = (int) getEventX(event);
         int y = (int) getEventY(event);
         if (event.getAction() == MotionEvent.ACTION_HOVER_ENTER || event.getAction() == MotionEvent.ACTION_HOVER_MOVE) {
+            accessibilityHovered = true;
             for (int i = 0; i < accessibilityVirtualViewBounds.size(); i++) {
                 Rect rect = accessibilityVirtualViewBounds.valueAt(i);
                 if (rect.contains(x, y)) {
@@ -26665,8 +26675,26 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             }
         } else if (event.getAction() == MotionEvent.ACTION_HOVER_EXIT) {
             currentFocusedVirtualView = 0;
+            accessibilityHovered = false;
+            updateAccessibilityTraversalText();
         }
         return super.onHoverEvent(event);
+    }
+
+    private boolean accessibilityFocused;
+    private boolean accessibilityHovered;
+
+    private boolean isReadByAccessibility() {
+        return accessibilityFocused || accessibilityHovered || isAccessibilityFocused();
+    }
+
+    // the framework's granular traversal iterates over the host view's content description, and
+    // changing it reports the message as changed, which has screen readers read it again: so it
+    // is only brought up to date once the message is no longer being read
+    private void updateAccessibilityTraversalText() {
+        if (accessibilityText != null && !TextUtils.equals(getContentDescription(), accessibilityText)) {
+            setContentDescription(accessibilityText);
+        }
     }
 
     @Override
@@ -27330,7 +27358,20 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     info.setContentDescription(accessibilityText.toString());
                 } else {
                     info.setText(accessibilityText);
+                    // links are only exposed to screen readers through the node text, so keep
+                    // the content description off the node to not shadow it
+                    info.setContentDescription(null);
                 }
+                if (!isReadByAccessibility()) {
+                    updateAccessibilityTraversalText();
+                }
+                info.setMovementGranularities(
+                    AccessibilityNodeInfo.MOVEMENT_GRANULARITY_CHARACTER |
+                    AccessibilityNodeInfo.MOVEMENT_GRANULARITY_WORD |
+                    AccessibilityNodeInfo.MOVEMENT_GRANULARITY_PARAGRAPH
+                );
+                info.addAction(AccessibilityNodeInfo.ACTION_NEXT_AT_MOVEMENT_GRANULARITY);
+                info.addAction(AccessibilityNodeInfo.ACTION_PREVIOUS_AT_MOVEMENT_GRANULARITY);
 
                 info.setEnabled(true);
                 AccessibilityNodeInfo.CollectionItemInfo itemInfo = info.getCollectionItemInfo();


### PR DESCRIPTION
## Summary

TalkBack users cannot move through message text by character, word or paragraph. The message cell exposes its text through an accessibility node provider, but the node never declares movement granularities and the host view has no text for the framework to traverse, so granular navigation has nothing to work with.

This change:

- Declares character, word and paragraph movement granularities on the message accessibility node, along with the standard traversal actions.
- Keeps the host view's content description in sync with the message accessibility text, which is what the framework's granular traversal iterates over. Changing it reports the message as changed, so it is brought up to date once the message is no longer being touched or focused, rather than while it is being read.
- Clears the content description on the node itself, so screen readers keep reading the node text, which is the version that carries the link spans.

Cursor movement and traversal events are handled entirely by the framework. The spoken text, the links exposed to the TalkBack links menu, and the click and long click actions are unchanged.


## Checking it

With TalkBack on, swipe onto a message with more than a line of text, set the reading control to characters, words or lines, and swipe up or down.

Before, there was nothing to move through: the message was read as one piece and the granularities were not offered at all. Now it moves through the text a character, a word, a line or a paragraph at a time.
