### PR TITLE
Fix AV1 videos being uploaded without transcoding, and two AV1 playback defects

### DIFF
--- a/TMessagesProj/jni/gifvideo.cpp
+++ b/TMessagesProj/jni/gifvideo.cpp
@@ -435,7 +435,10 @@ extern "C" JNIEXPORT void JNICALL Java_org_telegram_ui_Components_AnimatedFileNa
                 info->video_stream->codecpar->codec_id == AV_CODEC_ID_MPEG4 ||
                 info->video_stream->codecpar->codec_id == AV_CODEC_ID_VP8 ||
                 info->video_stream->codecpar->codec_id == AV_CODEC_ID_VP9 ||
-                (sdkVersion > 21 && info->video_stream->codecpar->codec_id == AV_CODEC_ID_HEVC);
+                (sdkVersion > 21 && info->video_stream->codecpar->codec_id == AV_CODEC_ID_HEVC) ||
+                // AOSP ships a software AV1 decoder (c2.android.av1-dec) since Android 10 (API 29);
+                // the convert pipeline decodes via platform MediaCodec, not the bundled ffmpeg
+                (sdkVersion >= 29 && info->video_stream->codecpar->codec_id == AV_CODEC_ID_AV1);
 
         if (strstr(info->fmt_ctx->iformat->name, "mov") != 0 && dataArr[PARAM_NUM_SUPPORTED_VIDEO_CODEC]) {
             MOVStreamContext *mov = (MOVStreamContext *) info->video_stream->priv_data;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/VideoPlayer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/VideoPlayer.java
@@ -16,6 +16,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.SurfaceTexture;
 import android.media.AudioManager;
+import android.media.MediaCodec;
 import android.media.MediaCodecInfo;
 import android.media.MediaCodecList;
 import android.media.MediaFormat;
@@ -80,6 +81,7 @@ import com.google.android.exoplayer2.video.VideoSize;
 
 import org.telegram.messenger.AndroidUtilities;
 import org.telegram.messenger.ApplicationLoader;
+import org.telegram.messenger.BuildVars;
 import org.telegram.messenger.DispatchQueue;
 import org.telegram.messenger.FileLoader;
 import org.telegram.messenger.FileLog;
@@ -160,6 +162,7 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
     public boolean allowMultipleInstances;
 
     private boolean triedReinit;
+    private boolean triedAv1CodecFallback;
 
     private Uri currentUri;
 
@@ -870,11 +873,11 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
             final VideoUri q = result.get(i);
             if (q.codec != null) {
                 if (forThumb) {
-                    if (!("avc".equals(q.codec) || "h264".equals(q.codec) || "vp9".equals(q.codec) || "vp8".equals(q.codec) || ("av1".equals(q.codec) || "av01".equals(q.codec)) && supportsHardwareDecoder(q.codec))) {
+                    if (!("avc".equals(q.codec) || "h264".equals(q.codec) || "vp9".equals(q.codec) || "vp8".equals(q.codec) || ("av1".equals(q.codec) || "av01".equals(q.codec)) && supportsDecoder(q.codec, q.width, q.height))) {
                         continue;
                     }
                 } else {
-                    if (("av1".equals(q.codec) || "av01".equals(q.codec) || "hevc".equals(q.codec) || "h265".equals(q.codec) || "vp9".equals(q.codec)) && !supportsHardwareDecoder(q.codec)) {
+                    if (("av1".equals(q.codec) || "av01".equals(q.codec) || "hevc".equals(q.codec) || "h265".equals(q.codec) || "vp9".equals(q.codec)) && !supportsDecoder(q.codec, q.width, q.height)) {
                         continue;
                     }
                 }
@@ -994,6 +997,50 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
     }
 
     private static HashMap<String, Boolean> cachedSupportedCodec;
+    private static HashMap<String, Boolean> cachedSupportedSoftwareCodec;
+
+    // A codec is only treated as unusable after repeated failures, and the verdict expires.
+    // A single transient MediaCodec error (resource exhaustion, low memory, one bad file)
+    // must not disable a codec for the lifetime of the install.
+    private static final int CODEC_FAILURE_THRESHOLD = 3;
+    private static final long CODEC_FAILURE_TTL = 30L * 24 * 60 * 60 * 1000; // 30 days
+
+    private static boolean isCodecBlacklisted(String mime) {
+        final SharedPreferences prefs = MessagesController.getGlobalMainSettings();
+        if (prefs.getInt("unsupport_fails_" + mime, 0) < CODEC_FAILURE_THRESHOLD) {
+            return false;
+        }
+        final long now = System.currentTimeMillis();
+        final long since = prefs.getLong("unsupport_since_" + mime, 0);
+        // A new app build may ship a different decoder or ExoPlayer version, and an old
+        // verdict expires. In both cases reset the counter, so the codec gets a full
+        // fresh failure budget instead of instantly re-tripping on the next failure.
+        final boolean sameBuild = TextUtils.equals(prefs.getString("unsupport_build_" + mime, null), BuildVars.BUILD_VERSION_STRING);
+        final boolean stale = since == 0 || since > now || now - since >= CODEC_FAILURE_TTL;
+        if (!sameBuild || stale) {
+            prefs.edit()
+                    .remove("unsupport_fails_" + mime)
+                    .remove("unsupport_build_" + mime)
+                    .remove("unsupport_since_" + mime)
+                    .apply();
+            return false;
+        }
+        return true;
+    }
+
+    public static void reportCodecFailure(String mime) {
+        final SharedPreferences prefs = MessagesController.getGlobalMainSettings();
+        final int fails = prefs.getInt("unsupport_fails_" + mime, 0) + 1;
+        prefs.edit()
+                .putInt("unsupport_fails_" + mime, fails)
+                .putString("unsupport_build_" + mime, BuildVars.BUILD_VERSION_STRING)
+                .putLong("unsupport_since_" + mime, System.currentTimeMillis())
+                .apply();
+        // both caches gate on the blacklist, so both must be invalidated
+        if (cachedSupportedCodec != null) cachedSupportedCodec.clear();
+        if (cachedSupportedSoftwareCodec != null) cachedSupportedSoftwareCodec.clear();
+    }
+
     public static boolean supportsHardwareDecoder(String codec) {
         try {
             final String mime = toMime(codec);
@@ -1001,7 +1048,7 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
             if (cachedSupportedCodec == null) cachedSupportedCodec = new HashMap<>();
             Boolean cached = cachedSupportedCodec.get(mime);
             if (cached != null) return cached;
-            if (MessagesController.getGlobalMainSettings().getBoolean("unsupport_" + mime, false)) {
+            if (isCodecBlacklisted(mime)) {
                 return false;
             }
             final int count = MediaCodecList.getCodecCount();
@@ -1023,6 +1070,52 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
             FileLog.e(e);
             return false;
         }
+    }
+
+    // Android 10+ guarantees a software AV1 decoder, and the app bundles its own FFmpeg.
+    // Dropping the video track outright when no hardware decoder exists leaves the user
+    // with audio and a black frame, which is strictly worse than decoding in software.
+    private static final long SOFTWARE_DECODE_MAX_PIXELS = 1920L * 1080L;
+
+    public static boolean supportsSoftwareDecoder(String codec) {
+        try {
+            final String mime = toMime(codec);
+            if (mime == null) return false;
+            if (cachedSupportedSoftwareCodec == null) cachedSupportedSoftwareCodec = new HashMap<>();
+            Boolean cached = cachedSupportedSoftwareCodec.get(mime);
+            if (cached != null) return cached;
+            if (isCodecBlacklisted(mime)) {
+                return false;
+            }
+            final int count = MediaCodecList.getCodecCount();
+            for (int i = 0; i < count; i++) {
+                final MediaCodecInfo info = MediaCodecList.getCodecInfoAt(i);
+                if (info.isEncoder()) continue;
+                final String[] supportedTypes = info.getSupportedTypes();
+                for (int j = 0; j < supportedTypes.length; ++j) {
+                    if (supportedTypes[j].equalsIgnoreCase(mime)) {
+                        cachedSupportedSoftwareCodec.put(mime, true);
+                        return true;
+                    }
+                }
+            }
+            cachedSupportedSoftwareCodec.put(mime, false);
+            return false;
+        } catch (Exception e) {
+            FileLog.e(e);
+            return false;
+        }
+    }
+
+    // Use for hard gates that would otherwise discard the video track entirely.
+    // supportsHardwareDecoder() remains the right check for quality-selection heuristics,
+    // where preferring a hardware path is legitimate.
+    public static boolean supportsDecoder(String codec, int width, int height) {
+        if (supportsHardwareDecoder(codec)) return true;
+        // unknown dimensions: allow software decode anyway - a possibly-choppy picture
+        // degrades more gracefully than dropping the video track outright
+        if (width <= 0 || height <= 0) return supportsSoftwareDecoder(codec);
+        return supportsSoftwareDecoder(codec) && (long) width * height <= SOFTWARE_DECODE_MAX_PIXELS;
     }
 
     public Uri makeManifest(ArrayList<Quality> qualities) {
@@ -1124,7 +1217,7 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
                 Quality q = qualities.get(i);
                 for (int j = 0; j < q.uris.size(); ++j) {
                     VideoUri u = q.uris.get(j);
-                    if (!TextUtils.isEmpty(u.codec) && !supportsHardwareDecoder(u.codec)) {
+                    if (!TextUtils.isEmpty(u.codec) && !supportsDecoder(u.codec, u.width, u.height)) {
                         q.uris.remove(j);
                         j--;
                     }
@@ -1343,6 +1436,7 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
 
     public void releasePlayer(boolean async) {
         activePlayers.remove(playerId);
+        triedAv1CodecFallback = false;
         if (player != null) {
             player.release();
             player = null;
@@ -1381,6 +1475,9 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
     public void onRenderedFirstFrame(EventTime eventTime, Object output, long renderTimeMs) {
         fallbackPosition = C.TIME_UNSET;
         fallbackDuration = C.TIME_UNSET;
+        // something is rendering, so any earlier codec fallback is spent - let a later
+        // source on this same instance have its own attempt
+        triedAv1CodecFallback = false;
         if (delegate != null) {
             delegate.onRenderedFirstFrame(eventTime);
         }
@@ -1699,14 +1796,37 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
             if (cause instanceof MediaCodecDecoderException) {
                 if (cause.toString().contains("av1") || cause.toString().contains("av01")) {
                     FileLog.e(error);
-                    FileLog.e("av1 codec failed, we think this codec is not supported");
-                    MessagesController.getGlobalMainSettings().edit().putBoolean("unsupport_video/av01", true).commit();
-                    if (cachedSupportedCodec != null) {
-                        cachedSupportedCodec.clear();
+                    // Do not count transient failures (codec instance exhaustion, low memory)
+                    // against the codec - they say nothing about device capability.
+                    // MediaCodecDecoderException wraps the original MediaCodec.CodecException as its cause.
+                    boolean transientFailure = false;
+                    Throwable c = cause;
+                    while (c != null) {
+                        if (c instanceof MediaCodec.CodecException && ((MediaCodec.CodecException) c).isTransient()) {
+                            transientFailure = true;
+                            break;
+                        }
+                        c = c.getCause();
                     }
-                    videoQualities = Quality.filterByCodec(videoQualities);
-                    if (videoQualities != null) {
-                        preparePlayer(videoQualities, videoQualityToSelect);
+                    if (transientFailure) {
+                        FileLog.e("av1 codec failed transiently, not counting it against the codec");
+                    } else {
+                        FileLog.e("av1 codec failed, recording a failure for this codec");
+                        reportCodecFailure("video/av01");
+                    }
+                    // One fallback attempt per player instance. Below the blacklist threshold
+                    // filterByCodec may strip nothing, and re-preparing the same quality list
+                    // would just hit the same failure again, forever.
+                    if (!triedAv1CodecFallback) {
+                        triedAv1CodecFallback = true;
+                        videoQualities = Quality.filterByCodec(videoQualities);
+                        if (videoQualities != null) {
+                            preparePlayer(videoQualities, videoQualityToSelect);
+                            return;
+                        }
+                    }
+                    if (delegate != null) {
+                        delegate.onError(this, error);
                     }
                     return;
                 }


### PR DESCRIPTION
> **Context on this PR's target.** `DrKLO/Telegram` has issues disabled and has merged 20 PRs in its history, none since November 2021 — it is a periodic source dump rather than a development remote. This is filed as a public reference others can cherry-pick, not with any expectation of a merge. The same change is open against an actively maintained fork at https://github.com/forkgram/TelegramAndroid/pull/488.
Fixes the AV1 send-side defect reported at https://bugs.telegram.org/c/64017, plus two related AV1 playback defects.

> **Not built or device-tested.** I have no Android SDK/NDK set up, and `gifvideo.cpp` needs an NDK rebuild. The diagnosis below is evidence-backed and the change applies cleanly, but **please build and test before merging.** Flagging this up front rather than letting a reviewer discover it.

## 1. AV1 videos are uploaded without transcoding — `gifvideo.cpp`

`nGetVideoInfo` reports `PARAM_NUM_SUPPORTED_VIDEO_CODEC` from a hardcoded allowlist:

```cpp
codec_id == AV_CODEC_ID_H264 || H263 || MPEG4 || VP8 || VP9 ||
(sdkVersion > 21 && codec_id == AV_CODEC_ID_HEVC);
```

`AV_CODEC_ID_AV1` is absent. The consequence chain:

`gifvideo.cpp` returns 0 → `PhotoViewer` sets `videoConvertSupported = false` → the entire compression-setup block is skipped, so `resultWidth`/`compressionsCount`/`selectedCompression` are never populated → `compressItem.setState(videoConvertSupported && compressionsCount > 1, …)` disables the compression UI → no `videoEditedInfo` carrying convert params → the `SendMessagesHelper` gate `videoEditedInfo != null && needConvert()` fails → **the original file is uploaded verbatim**.

It fails *silently* because it isn't an error path — it's a disabled feature. No error, no compression option, no indication the file went out unprocessed.

The fix adds AV1 to the allowlist, gated on API 29 where AOSP ships `c2.android.av1-dec`, mirroring the existing HEVC guard. Note the convert pipeline decodes via platform `MediaCodec`, **not** the bundled FFmpeg — so no `build_ffmpeg.sh` change is required.

### Evidence

Device captures on a Pixel 9 Pro (Telegram 12.9.1, Android 17), logging enabled:

| Source | Res | Route | Converted? | Codecs instantiated | Uploaded from |
|---|---|---|---|---|---|
| AV1 | 4K | share sheet | ❌ | — | `cache/sharing/<original>` |
| HEVC | 1080p | picker | ✅ | `exynos.hevc.decoder` + `exynos.h264.encoder` | generated cache file |
| AV1 | 4K | picker | ❌ | `c2.google.av1.decoder` only — **no encoder** | `/Download/…` **verbatim** |
| HEVC | **4K** | picker | ✅ | `exynos.hevc.decoder` + `exynos.h264.encoder` | generated cache file |

Rows 3 and 4 are the controlled pair — identical resolution, duration, HDR characteristics and route; only the codec differs:

```
begin convert …/TEST_4K_HEVC_control.mp4 rWidth = 1080 rHeight = 1920 oWidth = 2160 oHeight = 3840
compression completed time=27387 needCompress=true w=1080 h=1920 file size=23,8 MB encoder_name=c2.exynos.h264.encoder
```

For AV1, neither line appears, no encoder is created, and upload starts at `file_part=0` straight from the on-disk path. The AV1 file was freshly re-encoded (different SHA256 *and* different decoded-frame MD5), ruling out dedup.

## 2. One transient decoder error permanently disabled AV1 — `VideoPlayer.java`

`onPlayerError` wrote `unsupport_video/av01` on any `MediaCodecDecoderException` mentioning av1, and nothing ever cleared it — no expiry, no retry, no reset on upgrade. `supportsHardwareDecoder()` then returned false for the life of the install, which gates thumbnails, playback, and strips AV1 URIs from the quality list. Codec-instance exhaustion from opening several videos at once is enough to trigger it, after which a device with working hardware AV1 behaves as if it had none. Only recovery was clearing app data.

Replaced with a failure counter (threshold 3) that expires after 30 days and self-resets on app upgrade or when the verdict goes stale, and `CodecException.isTransient()` failures aren't counted at all.

## 3. Software decoders were never considered — `VideoPlayer.java`

`supportsHardwareDecoder()` skipped every non-hardware-accelerated codec. Android 10+ ships a software AV1 decoder, but the method was used as a blanket gate, so on devices without hardware AV1 the video track was dropped entirely while audio kept playing — the widely reported "AV1 plays sound with a black screen". The video wasn't failing to decode; it was never being decoded.

Added `supportsSoftwareDecoder()` and `supportsDecoder(codec, w, h)` (software permitted up to 1080p), used for the three *hard* gates that discarded the track. `supportsHardwareDecoder()` is retained for quality-selection heuristics, where preferring hardware is correct.

## Review notes

Things a reviewer should push on, stated rather than hidden:

- **Retry termination.** The AV1 error path now retries once per player instance (`triedAv1CodecFallback`), reset on first-frame render and in `releasePlayer` — neither is on the retry path. Below the blacklist threshold `filterByCodec` may strip nothing, so an unbounded retry would loop forever.
- **`isCodecBlacklisted()` writes SharedPreferences** from what reads as a predicate (the self-healing reset). Self-limiting: only reached on a cache miss.
- **Two unsynchronized static caches.** Upstream already had one; this adds a second following the same pattern. Synchronizing would change behavior beyond this fix's scope.
- **`reportCodecFailure`'s read-modify-write isn't atomic** — concurrent failures can lose an increment. That only makes blacklisting slower, never wrong.
- **Residual:** three genuinely corrupt AV1 files within 30 days can still blacklist a working codec until the TTL lapses. Wiring a success-path reset needs per-URI codec tracking in `onRenderedFirstFrame`, which felt too invasive here.

Also reported upstream at https://bugs.telegram.org/c/64017 (`DrKLO/Telegram` has issues disabled).
