### PR TITLE
Fix reply keyboard placeholder refresh

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -11370,6 +11370,9 @@ public class ChatActivityEnterView extends FrameLayout implements
                 showPopup = false;
             }
             botKeyboardView.setButtons(botReplyMarkup);
+            if (botKeyboardViewVisible) {
+                updateFieldHint(true);
+            }
             if (showPopup && (messageEditText == null || messageEditText.length() == 0) && !isPopupShowing()) {
                 showPopup(1, POPUP_CONTENT_BOT_KEYBOARD);
             }


### PR DESCRIPTION
## Summary

Refreshes the input field placeholder when an already visible bot reply keyboard is replaced with new markup.

## Problem

ChatActivityEnterView.setButtons() updates the bot message, reply markup, and keyboard rows. The input field hint is normally refreshed by showPopup().

When the bot keyboard is already visible, isPopupShowing() prevents showPopup() from running. The buttons are therefore refreshed while the previous input_field_placeholder can remain visible.

## Fix

Recalculate the field hint after replacing the reply keyboard buttons when the bot keyboard is already visible.

This uses the existing hint priority logic and does not close or reopen the keyboard.

## Test plan

- Reproduced with consecutive ReplyKeyboardMarkup messages using different placeholders while the keyboard remained open.
- Verified that the placeholder updates without keyboard teardown on an Android 15 emulator.
- TMessagesProj_App:assembleAfatDebug completed successfully.
- The APK installed and cold-started successfully.
- git diff --check completed successfully.