### PR TITLE
Announce playback position of voice messages and music

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -4407,6 +4407,22 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
         return currentSavedMusicList;
     }
 
+    // how far the message got, for screen readers, while it is playing or paused
+    public static CharSequence getPlaybackPositionDescription(MessageObject messageObject) {
+        if (messageObject == null || !getInstance().isPlayingMessage(messageObject)) {
+            return null;
+        }
+        final int duration = (int) messageObject.getDuration();
+        // the seconds are counted as it plays, while moving the slider takes it somewhere else
+        // without counting: where the slider stands is what holds in both
+        int position = messageObject.audioProgressSec;
+        if (duration > 0 && messageObject.audioProgress > 0) {
+            position = Math.round(messageObject.audioProgress * duration);
+        }
+        position = Math.max(0, Math.min(duration, position));
+        return LocaleController.formatString(R.string.AccDescrPlayerDuration, LocaleController.formatDuration(position), LocaleController.formatDuration(duration));
+    }
+
     public boolean isPlayingMessage(MessageObject messageObject) {
         if (messageObject != null && messageObject.isRepostPreview) {
             return false;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/AudioPlayerCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/AudioPlayerCell.java
@@ -502,11 +502,17 @@ public class AudioPlayerCell extends FrameLayout implements DownloadController.F
     @Override
     public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
         super.onInitializeAccessibilityNodeInfo(info);
+        CharSequence text;
         if (currentMessageObject.isMusic()) {
-            info.setText(LocaleController.formatString("AccDescrMusicInfo", R.string.AccDescrMusicInfo, currentMessageObject.getMusicAuthor(), currentMessageObject.getMusicTitle()));
+            text = LocaleController.formatString("AccDescrMusicInfo", R.string.AccDescrMusicInfo, currentMessageObject.getMusicAuthor(), currentMessageObject.getMusicTitle());
         } else { // voice message
-            info.setText(titleLayout.getText() + ", " + descriptionLayout.getText());
+            text = titleLayout.getText() + ", " + descriptionLayout.getText();
         }
+        final CharSequence playbackPosition = MediaController.getPlaybackPositionDescription(currentMessageObject);
+        if (playbackPosition != null) {
+            text = playbackPosition + ", " + text;
+        }
+        info.setText(text);
     }
 
     private int getThemedColor(int key) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -6364,6 +6364,10 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
+        accessibilityFocused = false;
+        accessibilityHovered = false;
+        readPlaybackPosition = null;
+
         NotificationCenter.getGlobalInstance().removeObserver(this, NotificationCenter.startSpoilers);
         NotificationCenter.getGlobalInstance().removeObserver(this, NotificationCenter.stopSpoilers);
         NotificationCenter.getGlobalInstance().removeObserver(this, NotificationCenter.emojiLoaded);
@@ -26575,6 +26579,12 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
 
     @Override
     public boolean performAccessibilityAction(int action, Bundle arguments) {
+        if (action == AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS) {
+            accessibilityFocused = true;
+        } else if (action == AccessibilityNodeInfo.ACTION_CLEAR_ACCESSIBILITY_FOCUS) {
+            accessibilityFocused = false;
+            readPlaybackPosition = null;
+        }
         if (delegate != null && delegate.onAccessibilityAction(action, arguments)) {
             return false;
         }
@@ -26624,6 +26634,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         }
         if (currentMessageObject.isVoice() || currentMessageObject.isRoundVideo() || currentMessageObject.isMusic() && MediaController.getInstance().isPlayingMessage(currentMessageObject)) {
             if (seekBarAccessibilityDelegate.performAccessibilityActionInternal(action, arguments)) {
+                announcePlaybackPosition();
                 return true;
             }
         }
@@ -26652,6 +26663,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         int x = (int) getEventX(event);
         int y = (int) getEventY(event);
         if (event.getAction() == MotionEvent.ACTION_HOVER_ENTER || event.getAction() == MotionEvent.ACTION_HOVER_MOVE) {
+            accessibilityHovered = true;
             for (int i = 0; i < accessibilityVirtualViewBounds.size(); i++) {
                 Rect rect = accessibilityVirtualViewBounds.valueAt(i);
                 if (rect.contains(x, y)) {
@@ -26665,8 +26677,57 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             }
         } else if (event.getAction() == MotionEvent.ACTION_HOVER_EXIT) {
             currentFocusedVirtualView = 0;
+            accessibilityHovered = false;
+            readPlaybackPosition = null;
         }
         return super.onHoverEvent(event);
+    }
+
+    private boolean accessibilityFocused;
+    private boolean accessibilityHovered;
+    private CharSequence readPlaybackPosition;
+
+    private boolean isReadByAccessibility() {
+        return accessibilityFocused || accessibilityHovered || isAccessibilityFocused();
+    }
+
+    private Runnable announcePlaybackPositionRunnable;
+
+    // after seeking, only the new position is of use, so report it instead of leaving it to
+    // the screen reader, which would read the whole message again
+    private CharSequence seekBarPositionDescription() {
+        if (currentMessageObject == null) {
+            return null;
+        }
+        final int duration = (int) currentMessageObject.getDuration();
+        if (duration <= 0 || seekBarAccessibilityDelegate == null) {
+            return null;
+        }
+        final float progress = currentMessageObject.isMusic() || currentMessageObject.isVoice() && !useSeekBarWaveform ? seekBar.getProgress() : (useSeekBarWaveform ? seekBarWaveform.getProgress() : currentMessageObject.audioProgress);
+        final int position = Math.max(0, Math.min(duration, Math.round(progress * duration)));
+        return formatString(R.string.AccDescrPlayerDuration, LocaleController.formatDuration(position), LocaleController.formatDuration(duration));
+    }
+
+    private void announcePlaybackPosition() {
+        // the position kept while the message is read is the one before the seek
+        readPlaybackPosition = null;
+        if (announcePlaybackPositionRunnable != null) {
+            removeCallbacks(announcePlaybackPositionRunnable);
+        }
+        announcePlaybackPositionRunnable = () -> {
+            announcePlaybackPositionRunnable = null;
+            readPlaybackPosition = null;
+            CharSequence playbackPosition = MediaController.getPlaybackPositionDescription(currentMessageObject);
+            if (playbackPosition == null) {
+                // a message that was never played is moved by its own slider, and nothing else
+                // knows where it stands
+                playbackPosition = seekBarPositionDescription();
+            }
+            if (playbackPosition != null) {
+                announceForAccessibility(playbackPosition);
+            }
+        };
+        postDelayed(announcePlaybackPositionRunnable, 400);
     }
 
     @Override
@@ -27326,10 +27387,27 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     accessibilityTextFileSize = fileSize;
                 }
 
+                CharSequence spokenText = accessibilityText;
+                CharSequence playbackPosition = MediaController.getPlaybackPositionDescription(currentMessageObject);
+                if (playbackPosition != null) {
+                    // while the message is being read, keep reporting the position it was reached
+                    // at: a position that moves on every request looks like the message itself
+                    // changed and has screen readers read all of it again
+                    if (isReadByAccessibility() && !MediaController.getInstance().isMessagePaused()) {
+                        if (readPlaybackPosition == null) {
+                            readPlaybackPosition = playbackPosition;
+                        }
+                        playbackPosition = readPlaybackPosition;
+                    } else {
+                        readPlaybackPosition = null;
+                    }
+                    spokenText = TextUtils.concat(playbackPosition, ", ", accessibilityText);
+                }
+
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-                    info.setContentDescription(accessibilityText.toString());
+                    info.setContentDescription(spokenText.toString());
                 } else {
-                    info.setText(accessibilityText);
+                    info.setText(spokenText);
                 }
 
                 info.setEnabled(true);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ContextLinkCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ContextLinkCell.java
@@ -1091,7 +1091,8 @@ public class ContextLinkCell extends FrameLayout implements DownloadController.F
                 sbuf.append(descriptionLayout.getText());
             }
         }
-        info.setText(sbuf);
+        final CharSequence playbackPosition = MediaController.getPlaybackPositionDescription(currentMessageObject);
+        info.setText(playbackPosition != null ? playbackPosition + ", " + sbuf : sbuf);
         if (checkBox != null && checkBox.isChecked()) {
             info.setCheckable(true);
             info.setChecked(true);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/SharedAudioCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/SharedAudioCell.java
@@ -609,10 +609,18 @@ public class SharedAudioCell extends FrameLayout implements DownloadController.F
     public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
         super.onInitializeAccessibilityNodeInfo(info);
         info.setEnabled(true);
+        CharSequence text = null;
         if (currentMessageObject.isMusic()) {
-            info.setText(LocaleController.formatString("AccDescrMusicInfo", R.string.AccDescrMusicInfo, currentMessageObject.getMusicAuthor(), currentMessageObject.getMusicTitle()));
+            text = LocaleController.formatString("AccDescrMusicInfo", R.string.AccDescrMusicInfo, currentMessageObject.getMusicAuthor(), currentMessageObject.getMusicTitle());
         } else if (titleLayout != null && descriptionLayout != null) {
-            info.setText(titleLayout.getText() + ", " + descriptionLayout.getText());
+            text = titleLayout.getText() + ", " + descriptionLayout.getText();
+        }
+        if (text != null) {
+            final CharSequence playbackPosition = MediaController.getPlaybackPositionDescription(currentMessageObject);
+            if (playbackPosition != null) {
+                text = playbackPosition + ", " + text;
+            }
+            info.setText(text);
         }
         if (checkBox.isChecked()) {
             info.setCheckable(true);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/FragmentContextView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/FragmentContextView.java
@@ -433,6 +433,22 @@ public class FragmentContextView extends FrameLayout implements NotificationCent
             @Override
             protected TextView createTextView() {
                 TextView textView = new TextView(context);
+                // the switcher only holds the text views, so the position has to be told
+                // by the view a screen reader actually lands on
+                textView.setAccessibilityDelegate(new View.AccessibilityDelegate() {
+                    @Override
+                    public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfo info) {
+                        super.onInitializeAccessibilityNodeInfo(host, info);
+                        if (currentStyle != STYLE_AUDIO_PLAYER) {
+                            return;
+                        }
+                        final CharSequence text = ((TextView) host).getText();
+                        final CharSequence playbackPosition = MediaController.getPlaybackPositionDescription(MediaController.getInstance().getPlayingMessageObject());
+                        if (playbackPosition != null && !TextUtils.isEmpty(text)) {
+                            info.setText(playbackPosition + ", " + text);
+                        }
+                    }
+                });
                 textView.setMaxLines(1);
                 textView.setLines(1);
                 textView.setSingleLine(true);


### PR DESCRIPTION
## Summary

Voice messages, round videos and music only announce their total length, so screen reader users have no way to tell how far playback has got without opening the full player.

This change announces the elapsed time of the total length, in the same wording the full player already uses, in front of the rest of the description so the position is heard first. It is reported in the chat, in shared media, in the playlist of the music player, in inline bot results and in the player bar above the chat.

Where playback stands is taken from the seek bar rather than from the seconds counted as it plays, so moving it reports where it was moved to, whether or not it is playing at the time. The position stays put while a message is being read and playing, so that a position moving on every request does not look like the message changed and have all of it read again, and seeking reports the new position on its own.

Messages that are not currently in the player keep announcing their length exactly as before, and nothing changes visually.


## Checking it

With TalkBack on, play a voice message, a round video or a piece of music, and swipe onto it while it plays or is paused.

Before, only the total length was said, so there was no way to tell how far it had got. Now the elapsed time is said first, of the total.

The same holds wherever such a message can be played: in the chat, in shared media, in the playlist, in inline results and on the player bar.
