### PR TITLE
Fix crash when a list updates while a screen reader reads an item

### DIFF
--- a/TMessagesProj/src/main/java/androidx/recyclerview/widget/GridLayoutManager.java
+++ b/TMessagesProj/src/main/java/androidx/recyclerview/widget/GridLayoutManager.java
@@ -443,6 +443,12 @@ public class GridLayoutManager extends LinearLayoutManager {
         if (!state.isPreLayout()) {
             return mSpanSizeLookup.getCachedSpanGroupIndex(viewPosition, mSpanCount);
         }
+        if (viewPosition < 0 || viewPosition >= state.getItemCount()) {
+            // the position belongs to a layout that is already gone, as happens when the item is
+            // asked about from a content changed event dispatched while the list is being laid out
+            Log.w(TAG, "Cannot find span size for pre layout position. " + viewPosition);
+            return 0;
+        }
         final int adapterPosition = recycler.convertPreLayoutPositionToPostLayout(viewPosition);
         if (adapterPosition == -1) {
             if (DEBUG) {

--- a/TMessagesProj/src/main/java/androidx/recyclerview/widget/RecyclerViewAccessibilityDelegate.java
+++ b/TMessagesProj/src/main/java/androidx/recyclerview/widget/RecyclerViewAccessibilityDelegate.java
@@ -40,7 +40,13 @@ public class RecyclerViewAccessibilityDelegate extends AccessibilityDelegateComp
     }
 
     boolean shouldIgnore() {
-        return mRecyclerView.hasPendingAdapterUpdates();
+        // item positions are only settled once a layout pass is over: asking the layout manager
+        // about them from inside one, as a content changed event dispatched from layout does,
+        // would read positions that no longer exist and throw. the pre layout check is needed on
+        // its own because that event is dispatched right after the layout counter is cleared
+        return mRecyclerView.hasPendingAdapterUpdates()
+                || mRecyclerView.isComputingLayout()
+                || mRecyclerView.mState.isPreLayout();
     }
 
     @Override


### PR DESCRIPTION
## Summary

With a screen reader running, the app crashes from time to time when a list updates underneath it, most reliably when messages load into an empty chat that was opened from search, from a global search result or from a comment thread, and when scrolling to the end of comments loads more.

```
java.lang.IndexOutOfBoundsException: invalid position 61. State item count is 24
  at RecyclerView$Recycler.convertPreLayoutPositionToPostLayout
  at GridLayoutManager.getSpanGroupIndex
  at GridLayoutManager.onInitializeAccessibilityNodeInfoForItem
  at RecyclerViewAccessibilityDelegate$ItemDelegate.onInitializeAccessibilityNodeInfo
  at ChatMessageCell.onInitializeAccessibilityNodeInfo
  at ViewRootImpl.handleWindowContentChangedEvent
  ...
  at RecyclerView.dispatchContentChangedIfNecessary
  at RecyclerView.onExitLayoutOrScroll
  at RecyclerView.dispatchLayoutStep1
```

The list dispatches a content changed event from inside its layout pass. Because a screen reader holds accessibility focus on an item, the framework builds that item's node info right away, which asks the layout manager for the item position while the ongoing layout has not settled positions yet, and the stale position is out of range for the new state. Without a screen reader the node is never built, which is why it only happens with one running.

The delegate already ignores the layout manager while adapter updates are pending. This extends the same guard to a running layout pass. The node is filled again once the layout is over, so nothing is lost for the screen reader.


## Checking it

With TalkBack on, open a message from search, or scroll through the comments under a channel post, so that messages load underneath while an item is being read.

Before, the app crashed with an IndexOutOfBoundsException from the layout manager. Now it does not.
