### PR TITLE
Feat(UI): overhaul liquid glass effect

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/CallLogActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/CallLogActivity.java
@@ -828,6 +828,10 @@ public class CallLogActivity extends BaseFragment implements NotificationCenter.
 
 
 		iBlur3Capture = new ViewGroupPartRenderer(listView, contentView, listView::drawChild);
+		listView.setForceInternalRenderNodeBlurCapture(
+			Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+				LiteMode.isEnabled(LiteMode.FLAG_LIQUID_GLASS)
+		);
 		listView.addEdgeEffectListener(() -> listView.postOnAnimation(() -> {
 			checkUi_listClip();
 			blur3_InvalidateBlur();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/RecyclerListView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/RecyclerListView.java
@@ -3129,12 +3129,17 @@ public class RecyclerListView extends RecyclerView implements IBlur3Capture {
     /* Blur3 */
 
     private Matrix selfTransformationsMatrix;
+    private boolean forceInternalRenderNodeBlurCapture;
+
+    public void setForceInternalRenderNodeBlurCapture(boolean force) {
+        forceInternalRenderNodeBlurCapture = force;
+    }
 
     @Override
     public void capture(Canvas canvas, RectF position) {
         final long drawingTime = SystemClock.uptimeMillis();
 
-        if (hasActiveEdgeEffects() && getOverScrollMode() != OVER_SCROLL_NEVER) {
+        if (forceInternalRenderNodeBlurCapture || hasActiveEdgeEffects() && getOverScrollMode() != OVER_SCROLL_NEVER) {
             if (selfTransformationsMatrix == null) {
                 selfTransformationsMatrix = new Matrix();
             }
@@ -3196,7 +3201,7 @@ public class RecyclerListView extends RecyclerView implements IBlur3Capture {
             return;
         }
 
-        if (hasActiveEdgeEffects() && getOverScrollMode() != OVER_SCROLL_NEVER) {
+        if (forceInternalRenderNodeBlurCapture || hasActiveEdgeEffects() && getOverScrollMode() != OVER_SCROLL_NEVER) {
             builder.unsupported();
             return;
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/LiquidGlassEffect.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/LiquidGlassEffect.java
@@ -1,9 +1,11 @@
 package org.telegram.ui.Components.blur3;
 
-import android.graphics.Color;
+import android.graphics.ColorMatrix;
+import android.graphics.ColorMatrixColorFilter;
 import android.graphics.RenderEffect;
 import android.graphics.RenderNode;
 import android.graphics.RuntimeShader;
+import android.graphics.Shader;
 
 import androidx.annotation.RequiresApi;
 
@@ -15,88 +17,114 @@ public class LiquidGlassEffect {
 
     private final RenderNode node;
     private final RuntimeShader shader;
-    private RenderEffect effect;
 
-    public LiquidGlassEffect(RenderNode node) {
-        this.node = node;
-        final String code = AndroidUtilities.readRes(R.raw.liquid_glass_shader);
-        shader = new RuntimeShader(code);
-        node.setRenderEffect(effect = RenderEffect.createRuntimeShaderEffect(shader, "img"));
-    }
-
-    private float resolutionX, resolutionY;
-    private float centerX, centerY;
-    private float sizeX, sizeY;
+    private float width;
+    private float height;
     private float radiusLeftTop;
     private float radiusRightTop;
     private float radiusRightBottom;
     private float radiusLeftBottom;
-    private float thickness;
-    private float intensity;
-    private float index;
-    private int foregroundColor;
+    private float refractionHeight;
+    private float refractionAmount;
+    private float depthEffect;
+    private float chromaticAberration;
+    private float blurRadius;
+    private float saturation;
 
-    public void update(
-        float left, float top, float right, float bottom,
-        float radiusLeftTop, float radiusRightTop, float radiusRightBottom, float radiusLeftBottom,
-
-        float thickness,
-        float intensity,
-        float index,
-        int foregroundColor
-    ) {
-        float resolutionX = node.getWidth();
-        float resolutionY = node.getHeight();
-        float centerX = (left + right) / 2;
-        float centerY = (top + bottom) / 2;
-        float width = right - left, height = bottom - top;
-        float sizeX = width / 2;
-        float sizeY = height / 2;
-
-        if (radiusLeftTop + radiusLeftBottom > height) {
-            float a = radiusLeftTop / (radiusLeftTop + radiusLeftBottom);
-            radiusLeftTop = height * a;
-            radiusLeftBottom = height * (1.0f - a);
-        }
-        if (radiusRightTop + radiusRightBottom > height) {
-            float a = radiusRightTop / (radiusRightTop + radiusRightBottom);
-            radiusRightTop = height * a;
-            radiusRightBottom = height * (1.0f - a);
-        }
-
-        if (
-            Math.abs(this.resolutionX - resolutionX) > 0.1f ||
-            Math.abs(this.resolutionY - resolutionY) > 0.1f ||
-            Math.abs(this.centerX - centerX) > 0.1f ||
-            Math.abs(this.centerY - centerY) > 0.1f ||
-            Math.abs(this.sizeX - sizeX) > 0.1f ||
-            Math.abs(this.sizeY - sizeY) > 0.1f ||
-            Math.abs(this.radiusLeftTop - radiusLeftTop) > 0.1f ||
-            Math.abs(this.radiusRightTop - radiusRightTop) > 0.1f ||
-            Math.abs(this.radiusRightBottom - radiusRightBottom) > 0.1f ||
-            Math.abs(this.radiusLeftBottom - radiusLeftBottom) > 0.1f ||
-            Math.abs(this.thickness - thickness) > 0.1f ||
-            Math.abs(this.intensity - intensity) > 0.1f ||
-            Math.abs(this.index - index) > 0.1f ||
-            this.foregroundColor != foregroundColor
-        ) {
-            this.foregroundColor = foregroundColor;
-
-            final float a = Color.alpha(foregroundColor) / 255f;
-            final float r = Color.red(foregroundColor) / 255f * a;
-            final float g = Color.green(foregroundColor) / 255f * a;
-            final float b = Color.blue(foregroundColor) / 255f * a;
-
-            shader.setFloatUniform("resolution", this.resolutionX = resolutionX, this.resolutionY = resolutionY);
-            shader.setFloatUniform("center", this.centerX = centerX, this.centerY = centerY);
-            shader.setFloatUniform("size", this.sizeX = sizeX, this.sizeY = sizeY);
-            shader.setFloatUniform("radius", this.radiusRightBottom = radiusRightBottom, this.radiusRightTop = radiusRightTop, this.radiusLeftBottom = radiusLeftBottom, this.radiusLeftTop = radiusLeftTop);
-            shader.setFloatUniform("thickness", this.thickness = thickness);
-            shader.setFloatUniform("refract_intensity", this.intensity = intensity);
-            shader.setFloatUniform("refract_index", this.index = index);
-            shader.setFloatUniform("foreground_color_premultiplied", r, g, b, a);
-            node.setRenderEffect(effect = RenderEffect.createRuntimeShaderEffect(shader, "img"));
-        }
+    public LiquidGlassEffect(RenderNode node) {
+        this.node = node;
+        shader = new RuntimeShader(AndroidUtilities.readRes(R.raw.liquid_glass_shader));
     }
 
+    public void update(
+        float width,
+        float height,
+        float radiusLeftTop,
+        float radiusRightTop,
+        float radiusRightBottom,
+        float radiusLeftBottom,
+        float refractionHeight,
+        float refractionAmount,
+        boolean depthEffect,
+        boolean chromaticAberration,
+        float blurRadius,
+        float saturation
+    ) {
+        final float maxRadius = Math.min(width, height) * 0.5f;
+        radiusLeftTop = Math.min(radiusLeftTop, maxRadius);
+        radiusRightTop = Math.min(radiusRightTop, maxRadius);
+        radiusRightBottom = Math.min(radiusRightBottom, maxRadius);
+        radiusLeftBottom = Math.min(radiusLeftBottom, maxRadius);
+        refractionHeight = Math.max(refractionHeight, 0.001f);
+
+        final float depth = depthEffect ? 1f : 0f;
+        final float dispersion = chromaticAberration ? 1f : 0f;
+
+        if (
+            Math.abs(this.width - width) <= 0.1f &&
+            Math.abs(this.height - height) <= 0.1f &&
+            Math.abs(this.radiusLeftTop - radiusLeftTop) <= 0.1f &&
+            Math.abs(this.radiusRightTop - radiusRightTop) <= 0.1f &&
+            Math.abs(this.radiusRightBottom - radiusRightBottom) <= 0.1f &&
+            Math.abs(this.radiusLeftBottom - radiusLeftBottom) <= 0.1f &&
+            Math.abs(this.refractionHeight - refractionHeight) <= 0.1f &&
+            Math.abs(this.refractionAmount - refractionAmount) <= 0.1f &&
+            Math.abs(this.depthEffect - depth) <= 0.001f &&
+            Math.abs(this.chromaticAberration - dispersion) <= 0.001f &&
+            Math.abs(this.blurRadius - blurRadius) <= 0.1f &&
+            Math.abs(this.saturation - saturation) <= 0.001f
+        ) {
+            return;
+        }
+
+        this.width = width;
+        this.height = height;
+        this.radiusLeftTop = radiusLeftTop;
+        this.radiusRightTop = radiusRightTop;
+        this.radiusRightBottom = radiusRightBottom;
+        this.radiusLeftBottom = radiusLeftBottom;
+        this.refractionHeight = refractionHeight;
+        this.refractionAmount = refractionAmount;
+        this.depthEffect = depth;
+        this.chromaticAberration = dispersion;
+        this.blurRadius = blurRadius;
+        this.saturation = saturation;
+
+        shader.setFloatUniform("size", width, height);
+        shader.setFloatUniform("offset", 0f, 0f);
+        shader.setFloatUniform(
+            "cornerRadii",
+            radiusLeftTop,
+            radiusRightTop,
+            radiusRightBottom,
+            radiusLeftBottom
+        );
+        shader.setFloatUniform("refractionHeight", refractionHeight);
+        shader.setFloatUniform("refractionAmount", -refractionAmount);
+        shader.setFloatUniform("depthEffect", depth);
+        shader.setFloatUniform("chromaticAberration", dispersion);
+
+        RenderEffect input = null;
+        if (Math.abs(saturation - 1f) > 0.001f) {
+            final float invSat = 1f - saturation;
+            final float r = 0.213f * invSat;
+            final float g = 0.715f * invSat;
+            final float b = 0.072f * invSat;
+            final ColorMatrix matrix = new ColorMatrix(new float[] {
+                r + saturation, g, b, 0f, 0f,
+                r, g + saturation, b, 0f, 0f,
+                r, g, b + saturation, 0f, 0f,
+                0f, 0f, 0f, 1f, 0f
+            });
+            input = RenderEffect.createColorFilterEffect(new ColorMatrixColorFilter(matrix));
+        }
+        if (blurRadius > 0f) {
+            input = input == null
+                ? RenderEffect.createBlurEffect(blurRadius, blurRadius, Shader.TileMode.CLAMP)
+                : RenderEffect.createBlurEffect(blurRadius, blurRadius, input, Shader.TileMode.CLAMP);
+        }
+
+        final RenderEffect lens = RenderEffect.createRuntimeShaderEffect(shader, "content");
+        node.setRenderEffect(input == null ? lens : RenderEffect.createChainEffect(lens, input));
+    }
 }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/drawable/BlurredBackgroundDrawable.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/drawable/BlurredBackgroundDrawable.java
@@ -141,6 +141,55 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
         onBoundPropsChanged();
     }
 
+    public BlurredBackgroundDrawable setOpticalDisplacement(float amount) {
+        boundProps.opticalDisplacement = amount;
+        onBoundPropsChanged();
+        return this;
+    }
+
+    public BlurredBackgroundDrawable setDepthShadingEnabled(boolean enabled) {
+        boundProps.depthShadingEnabled = enabled;
+        onBoundPropsChanged();
+        return this;
+    }
+
+    public BlurredBackgroundDrawable setSpectralSeparationEnabled(boolean enabled) {
+        boundProps.spectralSeparationEnabled = enabled;
+        onBoundPropsChanged();
+        return this;
+    }
+
+    public BlurredBackgroundDrawable setSurfaceBlurRadius(float radius) {
+        boundProps.opticalBlurRadius = radius;
+        onBoundPropsChanged();
+        return this;
+    }
+
+    public BlurredBackgroundDrawable setBackdropSaturation(float saturation) {
+        boundProps.backdropSaturation = saturation;
+        onBoundPropsChanged();
+        return this;
+    }
+
+    public BlurredBackgroundDrawable setEdgeLightingStrength(float strength) {
+        boundProps.edgeLightingStrength = strength;
+        onBoundPropsChanged();
+        return this;
+    }
+
+    public BlurredBackgroundDrawable setSurfaceTintColor(int color) {
+        boundProps.surfaceTintColor = color;
+        onBoundPropsChanged();
+        return this;
+    }
+
+    public BlurredBackgroundDrawable setInsetShadow(float radius, float alpha) {
+        boundProps.insetShadowRadius = radius;
+        boundProps.insetShadowAlpha = alpha;
+        onBoundPropsChanged();
+        return this;
+    }
+
     public Rect getPaddedBounds() {
         return boundProps.boundsWithPadding;
     }
@@ -222,7 +271,15 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
         public boolean hasPadding;
         public int liquidThickness;
         public float liquidIntensity = 0.75f;
-        public float liquidIndex = 1.5f;
+        public float opticalDisplacement = Float.NaN;
+        public float opticalBlurRadius;
+        public float backdropSaturation = 1.5f;
+        public float edgeLightingStrength = 1f;
+        public float insetShadowRadius;
+        public float insetShadowAlpha;
+        public int surfaceTintColor;
+        public boolean depthShadingEnabled;
+        public boolean spectralSeparationEnabled;
 
         public float strokeWidthTop;
         public float strokeWidthBottom;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/drawable/BlurredBackgroundDrawableRenderNode.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/drawable/BlurredBackgroundDrawableRenderNode.java
@@ -4,11 +4,15 @@ import static org.telegram.messenger.AndroidUtilities.dp;
 
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.BlendMode;
 import android.graphics.Outline;
 import android.graphics.Paint;
+import android.graphics.Path;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.graphics.RenderEffect;
 import android.graphics.RenderNode;
+import android.graphics.Shader;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
@@ -16,6 +20,7 @@ import androidx.annotation.RequiresApi;
 
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.blur3.LiquidGlassEffect;
+import org.telegram.ui.Components.blur3.render.SurfaceEdgeLighting;
 import org.telegram.ui.Components.blur3.source.BlurredBackgroundSource;
 
 @RequiresApi(api = Build.VERSION_CODES.Q)
@@ -26,24 +31,34 @@ public class BlurredBackgroundDrawableRenderNode extends BlurredBackgroundDrawab
 
     private final RenderNode renderNode;
     private final RenderNode renderNodeFill;
+    private final RenderNode renderNodeInnerShadow;
 
     private final Paint paintShadow = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final Paint paintStrokeTop = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final Paint paintStrokeBottom = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint paintInnerShadow = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint paintInnerShadowMask = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Path innerShadowPath = new Path();
+    private final float[] innerShadowRadii = new float[8];
+    private RenderEffect innerShadowBlurEffect;
+    private float innerShadowBlurRadius = Float.NaN;
 
     private boolean renderNodeInvalidated;
 
     public BlurredBackgroundDrawableRenderNode(BlurredBackgroundSource source) {
         this.renderNode = new RenderNode("BlurredNode");
         this.renderNodeFill = new RenderNode("BlurredFill");
+        this.renderNodeInnerShadow = new RenderNode("LiquidInnerShadow");
         this.renderNode.setClipToOutline(true);
         this.renderNode.setClipToBounds(true);
+        this.renderNodeInnerShadow.setUseCompositingLayer(true, null);
 
         this.source = source;
 
         this.paintShadow.setColor(0);
         this.paintStrokeTop.setStyle(Paint.Style.STROKE);
         this.paintStrokeBottom.setStyle(Paint.Style.STROKE);
+        this.paintInnerShadowMask.setBlendMode(BlendMode.CLEAR);
     }
 
     @Override
@@ -53,10 +68,12 @@ public class BlurredBackgroundDrawableRenderNode extends BlurredBackgroundDrawab
     }
 
     private LiquidGlassEffect liquidGlassEffect;
+    private SurfaceEdgeLighting surfaceEdgeLighting;
 
     @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
     public void setLiquidGlassEffectAllowed() {
         liquidGlassEffect = new LiquidGlassEffect(renderNodeFill);
+        surfaceEdgeLighting = new SurfaceEdgeLighting();
     }
 
 
@@ -82,6 +99,7 @@ public class BlurredBackgroundDrawableRenderNode extends BlurredBackgroundDrawab
         if (!boundProps.boundsWithPadding.isEmpty()) {
             renderNodeFill.setPosition(0, 0, boundProps.boundsWithPadding.width(), boundProps.boundsWithPadding.height());
             renderNode.setPosition(0, 0, boundProps.boundsWithPadding.width(), boundProps.boundsWithPadding.height());
+            renderNodeInnerShadow.setPosition(0, 0, boundProps.boundsWithPadding.width(), boundProps.boundsWithPadding.height());
             renderNode.setOutline(outline);
 
             renderNodeInvalidated = true;
@@ -113,21 +131,28 @@ public class BlurredBackgroundDrawableRenderNode extends BlurredBackgroundDrawab
         c.save();
         c.translate(-sL, -sT);
         if (liquidGlassEffect != null && Build.VERSION.SDK_INT >= 33) {
-            final int thickness = Math.max(Math.min(
-                boundProps.liquidThickness <= 0 ? dp(11) : boundProps.liquidThickness,
-                Math.min(boundProps.boundsWithPadding.width(), boundProps.boundsWithPadding.height()) / 5), 1);
+            final float refractionHeight = Math.max(
+                boundProps.liquidThickness <= 0 ? dp(12) : boundProps.liquidThickness,
+                1f
+            );
+            final float refractionAmount = !Float.isNaN(boundProps.opticalDisplacement)
+                ? boundProps.opticalDisplacement
+                : dp(24) * boundProps.liquidIntensity;
 
             liquidGlassEffect.update(
-                0, 0, boundProps.boundsWithPadding.width(), boundProps.boundsWithPadding.height(),
+                boundProps.boundsWithPadding.width(),
+                boundProps.boundsWithPadding.height(),
                 boundProps.shaderRadii[0], boundProps.shaderRadii[2], boundProps.shaderRadii[4], boundProps.shaderRadii[6],
-                thickness,
-                boundProps.liquidIntensity,
-                boundProps.liquidIndex,
-                backgroundColor
+                refractionHeight,
+                refractionAmount,
+                boundProps.depthShadingEnabled,
+                boundProps.spectralSeparationEnabled,
+                boundProps.opticalBlurRadius,
+                boundProps.backdropSaturation
             );
         }
         source.draw(c, sL, sT, sR, sB);
-        c.save();
+        c.restore();
         renderNodeFill.endRecording();
 
 
@@ -136,10 +161,14 @@ public class BlurredBackgroundDrawableRenderNode extends BlurredBackgroundDrawab
             c.drawColor(backgroundColor);
         } else {
             c.drawRenderNode(renderNodeFill);
-            if (liquidGlassEffect == null && Color.alpha(backgroundColor) != 0) {
+            if (Color.alpha(backgroundColor) != 0) {
                 c.drawColor(backgroundColor);
             }
+            if (Color.alpha(boundProps.surfaceTintColor) != 0) {
+                c.drawColor(boundProps.surfaceTintColor);
+            }
         }
+        drawInnerShadow(c);
         if (strokeColorTop != 0) {
             drawStroke(c, 0, 0, boundProps.boundsWithPadding.width(),
                     boundProps.boundsWithPadding.height(), boundProps.radii,
@@ -150,7 +179,70 @@ public class BlurredBackgroundDrawableRenderNode extends BlurredBackgroundDrawab
                     boundProps.boundsWithPadding.height(), boundProps.radii,
                     boundProps.strokeWidthBottom, false, paintStrokeBottom);
         }
+        if (surfaceEdgeLighting != null && Build.VERSION.SDK_INT >= 33) {
+            surfaceEdgeLighting.render(
+                c,
+                boundProps.boundsWithPadding.width(),
+                boundProps.boundsWithPadding.height(),
+                boundProps.shaderRadii[0],
+                boundProps.shaderRadii[2],
+                boundProps.shaderRadii[4],
+                boundProps.shaderRadii[6],
+                boundProps.edgeLightingStrength
+            );
+        }
         renderNode.endRecording();
+    }
+
+    private void drawInnerShadow(Canvas canvas) {
+        final float radius = boundProps.insetShadowRadius;
+        final float alpha = boundProps.insetShadowAlpha;
+        if (radius <= 0f || alpha <= 0f || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return;
+        }
+
+        final float width = boundProps.boundsWithPadding.width();
+        final float height = boundProps.boundsWithPadding.height();
+        System.arraycopy(
+            boundProps.shaderRadii,
+            0,
+            innerShadowRadii,
+            0,
+            innerShadowRadii.length
+        );
+
+        innerShadowPath.rewind();
+        innerShadowPath.addRoundRect(
+            0f,
+            0f,
+            width,
+            height,
+            innerShadowRadii,
+            Path.Direction.CW
+        );
+        innerShadowPath.close();
+
+        paintInnerShadow.setColor(Theme.multAlpha(Color.BLACK, 0.15f * alpha));
+        if (innerShadowBlurEffect == null || Math.abs(innerShadowBlurRadius - radius) > 0.1f) {
+            innerShadowBlurRadius = radius;
+            innerShadowBlurEffect =
+                RenderEffect.createBlurEffect(radius, radius, Shader.TileMode.DECAL);
+            renderNodeInnerShadow.setRenderEffect(innerShadowBlurEffect);
+        }
+
+        final Canvas shadowCanvas = renderNodeInnerShadow.beginRecording();
+        shadowCanvas.save();
+        shadowCanvas.clipPath(innerShadowPath);
+        shadowCanvas.drawPath(innerShadowPath, paintInnerShadow);
+        shadowCanvas.translate(0f, radius);
+        shadowCanvas.drawPath(innerShadowPath, paintInnerShadowMask);
+        shadowCanvas.restore();
+        renderNodeInnerShadow.endRecording();
+
+        canvas.save();
+        canvas.clipPath(innerShadowPath);
+        canvas.drawRenderNode(renderNodeInnerShadow);
+        canvas.restore();
     }
 
     @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/drawable/color/impl/BlurredBackgroundProviderImpl.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/drawable/color/impl/BlurredBackgroundProviderImpl.java
@@ -3,6 +3,7 @@ package org.telegram.ui.Components.blur3.drawable.color.impl;
 import static org.telegram.messenger.AndroidUtilities.dpf2;
 
 import android.graphics.Color;
+import android.os.Build;
 
 import androidx.core.graphics.ColorUtils;
 import androidx.core.math.MathUtils;
@@ -17,12 +18,26 @@ import org.telegram.ui.Components.blur3.drawable.color.BlurredBackgroundProvider
 
 public class BlurredBackgroundProviderImpl {
     public static BlurredBackgroundProvider mainTabs(Theme.ResourcesProvider resourcesProvider) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            LiteMode.isEnabled(LiteMode.FLAG_LIQUID_GLASS)) {
+            return new BlurredBackgroundProviderBuilder(resourcesProvider)
+                .setBackgroundColor((r, isDark) -> {
+                    final int colorBg = Theme.getColor(Theme.key_windowBackgroundWhite, r);
+                    final int colorTarget = Theme.getColor(Theme.key_glass_targetMainTabs, r);
+                    return solveSrcColor(colorBg, colorTarget, 0.4f);
+                })
+                .setStrokeColorTop(0, 0)
+                .setStrokeColorBottom(0, 0)
+                .setShadowColor(0x1A000000, 0x1A000000)
+                .setShadowLayer(dpf2(24f), 0, dpf2(4f))
+                .setStrokeWidth(0, 0)
+                .build();
+        }
         return new BlurredBackgroundProviderBuilder(resourcesProvider)
             .setBackgroundColor((r, isDark) -> {
-                final float alpha = LiteMode.isEnabled(LiteMode.FLAG_LIQUID_GLASS) ? 0.85f : 0.76f;
                 final int colorBg = Theme.getColor(Theme.key_windowBackgroundWhite, r);
                 final int colorTarget = Theme.getColor(Theme.key_glass_targetMainTabs, r);
-                return solveSrcColor(colorBg, colorTarget, alpha);
+                return solveSrcColor(colorBg, colorTarget, 0.76f);
             })
             .setStrokeColorTop(0x11000000, 0x06FFFFFF)
             .setStrokeColorBottom(0x20000000, 0x11FFFFFF)

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/liquid_glass/LICENSE.txt
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/liquid_glass/LICENSE.txt
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 Kyant
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/liquid_glass/NOTICE.txt
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/liquid_glass/NOTICE.txt
@@ -1,0 +1,26 @@
+Liquid Glass rendering
+
+Portions of the optical rendering implementation are derived from
+AndroidLiquidGlass / Backdrop by Kyant.
+
+Copyright 2025 Kyant
+Original project: https://github.com/Kyant0/AndroidLiquidGlass
+Licensed under the Apache License, Version 2.0.
+
+Derived portions are present in:
+
+- res/raw/liquid_glass_shader.agsl
+  Lens refraction, signed-distance shape calculations and chromatic dispersion.
+
+- res/raw/glass_surface_edge_shader.agsl
+  Directional edge-lighting calculations.
+
+- java/org/telegram/ui/Components/blur3/LiquidGlassEffect.java
+  Android RuntimeShader configuration and optical-effect composition.
+
+The Telegram render-node integration, background capture pipeline,
+bottom-tab layout, gesture handling, animations, theming, selected-state
+rendering and application-specific behavior were implemented separately
+for this project.
+
+The complete Apache License 2.0 text is included in LICENSE.txt.

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/render/SurfaceEdgeLighting.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/render/SurfaceEdgeLighting.java
@@ -1,0 +1,87 @@
+package org.telegram.ui.Components.blur3.render;
+
+import static org.telegram.messenger.AndroidUtilities.dpf2;
+
+import android.graphics.BlendMode;
+import android.graphics.BlurMaskFilter;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.RuntimeShader;
+
+import androidx.annotation.RequiresApi;
+
+import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.R;
+
+@RequiresApi(api = 33)
+public class SurfaceEdgeLighting {
+
+    private final RuntimeShader shader;
+    private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Path path = new Path();
+
+    public SurfaceEdgeLighting() {
+        shader = new RuntimeShader(AndroidUtilities.readRes(R.raw.glass_surface_edge_shader));
+        paint.setStyle(Paint.Style.STROKE);
+        paint.setStrokeWidth((float) Math.ceil(dpf2(0.5f)) * 2f);
+        paint.setMaskFilter(new BlurMaskFilter(dpf2(0.25f), BlurMaskFilter.Blur.NORMAL));
+        paint.setBlendMode(BlendMode.PLUS);
+        paint.setShader(shader);
+        paint.setAlpha(128);
+    }
+
+    public void render(
+        Canvas canvas,
+        float width,
+        float height,
+        float radiusLeftTop,
+        float radiusRightTop,
+        float radiusRightBottom,
+        float radiusLeftBottom,
+        float alpha
+    ) {
+        if (width <= 0f || height <= 0f || alpha <= 0f) {
+            return;
+        }
+
+        final float maxRadius = Math.min(width, height) * 0.5f;
+        radiusLeftTop = Math.min(radiusLeftTop, maxRadius);
+        radiusRightTop = Math.min(radiusRightTop, maxRadius);
+        radiusRightBottom = Math.min(radiusRightBottom, maxRadius);
+        radiusLeftBottom = Math.min(radiusLeftBottom, maxRadius);
+
+        shader.setFloatUniform("size", width, height);
+        shader.setFloatUniform(
+            "cornerRadii",
+            radiusLeftTop,
+            radiusRightTop,
+            radiusRightBottom,
+            radiusLeftBottom
+        );
+        shader.setFloatUniform("angle", (float) (Math.PI * 0.25));
+        shader.setFloatUniform("falloff", 1f);
+        paint.setAlpha(Math.round(128f * alpha));
+
+        path.rewind();
+        path.addRoundRect(
+            0f,
+            0f,
+            width,
+            height,
+            new float[] {
+                radiusLeftTop, radiusLeftTop,
+                radiusRightTop, radiusRightTop,
+                radiusRightBottom, radiusRightBottom,
+                radiusLeftBottom, radiusLeftBottom
+            },
+            Path.Direction.CW
+        );
+        path.close();
+
+        canvas.save();
+        canvas.clipPath(path);
+        canvas.drawPath(path, paint);
+        canvas.restore();
+    }
+}

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/render/SurfaceTouchLighting.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/render/SurfaceTouchLighting.java
@@ -1,0 +1,56 @@
+package org.telegram.ui.Components.blur3.render;
+
+import android.graphics.BlendMode;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.RectF;
+import android.graphics.RuntimeShader;
+
+import androidx.annotation.RequiresApi;
+
+import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.R;
+
+@RequiresApi(api = 33)
+public class SurfaceTouchLighting {
+
+    private final RuntimeShader shader;
+    private final Paint basePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint radialPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Path path = new Path();
+
+    public SurfaceTouchLighting() {
+        shader = new RuntimeShader(AndroidUtilities.readRes(R.raw.glass_surface_touch_shader));
+        basePaint.setBlendMode(BlendMode.PLUS);
+        radialPaint.setBlendMode(BlendMode.PLUS);
+        radialPaint.setShader(shader);
+    }
+
+    public void render(Canvas canvas, RectF bounds, float positionX, float positionY, float progress) {
+        if (bounds.isEmpty() || progress <= 0f) {
+            return;
+        }
+
+        path.rewind();
+        path.addRoundRect(bounds, bounds.height() * 0.5f, bounds.height() * 0.5f, Path.Direction.CW);
+        path.close();
+
+        basePaint.setColor(Color.WHITE);
+        basePaint.setAlpha(Math.round(255f * 0.03f * progress));
+        shader.setFloatUniform("radius", bounds.height() * 1.5f);
+        shader.setFloatUniform(
+            "position",
+            Math.max(bounds.left, Math.min(bounds.right, positionX)),
+            Math.max(bounds.top, Math.min(bounds.bottom, positionY))
+        );
+        radialPaint.setAlpha(Math.round(255f * 0.1125f * progress));
+
+        canvas.save();
+        canvas.clipPath(path);
+        canvas.drawRect(bounds, basePaint);
+        canvas.drawRect(bounds, radialPaint);
+        canvas.restore();
+    }
+}

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/source/LayeredCaptureSource.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/source/LayeredCaptureSource.java
@@ -1,0 +1,52 @@
+package org.telegram.ui.Components.blur3.source;
+
+import android.graphics.Canvas;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
+import org.telegram.ui.Components.blur3.drawable.BlurredBackgroundDrawable;
+import org.telegram.ui.Components.blur3.drawable.BlurredBackgroundDrawableRenderNode;
+
+import me.vkryl.core.reference.ReferenceList;
+
+@RequiresApi(api = Build.VERSION_CODES.Q)
+public class LayeredCaptureSource implements BlurredBackgroundSource {
+
+    public interface OverlayRenderer {
+        void renderOverlay(Canvas canvas);
+    }
+
+    private final BlurredBackgroundSource source;
+    private final OverlayRenderer overlayRenderer;
+    private final ReferenceList<BlurredBackgroundDrawableRenderNode> drawables = new ReferenceList<>();
+
+    public LayeredCaptureSource(BlurredBackgroundSource source, OverlayRenderer overlayRenderer) {
+        this.source = source;
+        this.overlayRenderer = overlayRenderer;
+    }
+
+    @Override
+    public void draw(Canvas canvas, float left, float top, float right, float bottom) {
+        source.draw(canvas, left, top, right, bottom);
+        overlayRenderer.renderOverlay(canvas);
+    }
+
+    @Override
+    public void dispatchOnDrawablesRelativePositionChange() {
+        source.dispatchOnDrawablesRelativePositionChange();
+    }
+
+    public void invalidateConsumers() {
+        for (BlurredBackgroundDrawableRenderNode drawable : drawables) {
+            drawable.invalidateDisplayList();
+        }
+    }
+
+    @Override
+    public BlurredBackgroundDrawable createDrawable() {
+        final BlurredBackgroundDrawableRenderNode drawable = new BlurredBackgroundDrawableRenderNode(this);
+        drawables.add(drawable);
+        return drawable;
+    }
+}

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/glass/GlassTabView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/glass/GlassTabView.java
@@ -5,6 +5,8 @@ import static org.telegram.messenger.AndroidUtilities.dpf2;
 import static org.telegram.messenger.AndroidUtilities.lerp;
 
 import android.content.Context;
+import android.graphics.BlendMode;
+import android.graphics.BlendModeColorFilter;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -16,6 +18,7 @@ import android.text.TextPaint;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
+import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
@@ -54,11 +57,18 @@ import me.vkryl.android.animator.FactorAnimator;
 
 public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, FactorAnimator.Target {
     private final TextView textView;
+    private final TextView liquidSelectedTextView;
     private final RLottieImageView imageView;
     private BackupImageView backupImageView;
     private Theme.ResourcesProvider resourcesProvider;
     private final Paint paintCounterBackground = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint liquidSelectedTintPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final AnimatedTextView.AnimatedTextDrawable counter;
+    private PorterDuffColorFilter liquidInactiveColorFilter;
+    private PorterDuffColorFilter liquidSelectedColorFilter;
+    private BlendModeColorFilter liquidSelectedLayerColorFilter;
+    private int liquidInactiveFilterColor;
+    private int liquidSelectedFilterColor;
 
     private static final int ANIMATOR_ID_IS_SELECTED = 0;
     private static final int ANIMATOR_ID_COUNTER_VISIBLE = 1;
@@ -95,6 +105,18 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
         defaultTextPaint = new TextPaint(textView.getPaint());
         addView(textView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, Gravity.CENTER_HORIZONTAL | Gravity.TOP, 0, 28.33f, 0, 0));
 
+        liquidSelectedTextView = new TextView(context);
+        liquidSelectedTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 12f);
+        liquidSelectedTextView.setSingleLine();
+        liquidSelectedTextView.setLines(1);
+        liquidSelectedTextView.setEllipsize(TextUtils.TruncateAt.END);
+        liquidSelectedTextView.setTypeface(
+            AndroidUtilities.getTypeface(AndroidUtilities.TYPEFACE_ROBOTO_EXTRA_BOLD)
+        );
+        liquidSelectedTextView.setGravity(Gravity.CENTER);
+        liquidSelectedTextView.setTextColor(Color.WHITE);
+        addView(liquidSelectedTextView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, Gravity.CENTER_HORIZONTAL | Gravity.TOP, 0, 28.33f, 0, 0));
+
         counter = new AnimatedTextView.AnimatedTextDrawable();
         counter.setTypeface(AndroidUtilities.bold());
         counter.setCallback(this);
@@ -125,6 +147,7 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
             final float offset = (visualWidth - getMeasuredWidth()) / 2f;
             imageView.setTranslationX(offset);
             textView.setTranslationX(offset);
+            liquidSelectedTextView.setTranslationX(offset);
         }
     }
 
@@ -133,6 +156,10 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
     private boolean hasGestureSelectedOverride;
     private float gestureSelectedOverride;
     private boolean skipDrawSelector;
+    private boolean liquidGlassLayersEnabled;
+    private boolean liquidSelectedLayerDraw;
+    private Drawable liquidInactiveIconDrawable;
+    private Drawable liquidSelectedIconDrawable;
 
     public void setGestureSelectedOverride(float gestureSelectedOverride, boolean allow) {
         this.gestureSelectedOverride = gestureSelectedOverride;
@@ -149,6 +176,10 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
 
     @Override
     protected void dispatchDraw(@NonNull Canvas canvas) {
+        dispatchDrawContent(canvas);
+    }
+
+    private void dispatchDrawContent(Canvas canvas) {
         final float viewWidth = hasVisualWidth ? visualWidth : getWidth();
         final float selectedFactor = hasGestureSelectedOverride ? gestureSelectedOverride : isSelectedAnimator.getFloatValue();
         if (selectedFactor > 0 && !skipDrawSelector) {
@@ -171,6 +202,12 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
         }
 
         super.dispatchDraw(canvas);
+
+        if (liquidGlassLayersEnabled && !liquidSelectedLayerDraw && liquidInactiveIconDrawable != null) {
+            ensureLiquidInactiveColorFilter();
+            liquidInactiveIconDrawable.setColorFilter(liquidInactiveColorFilter);
+            drawLiquidIcon(canvas, liquidInactiveIconDrawable);
+        }
 
         if (hasCounter > 0) {
             canvas.save();
@@ -218,6 +255,176 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
         }
     }
 
+    @Override
+    protected boolean drawChild(Canvas canvas, View child, long drawingTime) {
+        if (liquidGlassLayersEnabled && child == imageView) {
+            return true;
+        }
+        if (child == liquidSelectedTextView && (!liquidGlassLayersEnabled || !liquidSelectedLayerDraw)) {
+            return true;
+        }
+        if (liquidSelectedLayerDraw && (child == textView || child == backupImageView)) {
+            return true;
+        }
+        return super.drawChild(canvas, child, drawingTime);
+    }
+
+    public void setSplitSelectionRendering(boolean enabled) {
+        if (liquidGlassLayersEnabled == enabled) {
+            return;
+        }
+        liquidGlassLayersEnabled = enabled;
+        if (enabled) {
+            rebuildLiquidSelectedIcon();
+            imageView.clearAnimationDrawable();
+            applyUnselectedPresentation();
+        } else {
+            clearLiquidIcons();
+            lastIconAnimationRaw = 0;
+            checkPlayAnimation(false);
+            textView.setTypeface(isSelectedAnimator.getValue()
+                ? AndroidUtilities.getTypeface(AndroidUtilities.TYPEFACE_ROBOTO_EXTRA_BOLD)
+                : AndroidUtilities.bold());
+            updateColors();
+        }
+        invalidate();
+    }
+
+    private void applyUnselectedPresentation() {
+        textView.setTypeface(AndroidUtilities.bold());
+        updateColors();
+    }
+
+    private void rebuildLiquidSelectedIcon() {
+        clearLiquidIcons();
+        if (tabAnimation == null) {
+            return;
+        }
+        if (tabAnimation.iconStatic != -1) {
+            liquidInactiveIconDrawable = getContext().getResources()
+                .getDrawable(tabAnimation.iconStatic)
+                .mutate();
+            liquidInactiveIconDrawable.setCallback(this);
+            liquidSelectedIconDrawable = getContext().getResources()
+                .getDrawable(tabAnimation.iconStatic)
+                .mutate();
+            liquidSelectedIconDrawable.setCallback(this);
+            return;
+        }
+        if (tabAnimation.iconToFilled == -1 || tabAnimation.iconToOutline == -1) {
+            return;
+        }
+        final RLottieDrawable inactiveDrawable = new RLottieDrawable(
+            tabAnimation.iconToOutline,
+            "liquid_inactive_" + tabAnimation.iconToOutline,
+            dp(24),
+            dp(24)
+        );
+        inactiveDrawable.setMasterParent(this);
+        inactiveDrawable.setCurrentFrame(0, false);
+        liquidInactiveIconDrawable = inactiveDrawable;
+        final RLottieDrawable drawable = new RLottieDrawable(
+            tabAnimation.iconToFilled,
+            "liquid_selected_" + tabAnimation.iconToFilled,
+            dp(24),
+            dp(24)
+        );
+        drawable.setMasterParent(this);
+        final int selectedFrame = tabAnimation.endFrameMid >= 0
+            ? tabAnimation.endFrameMid
+            : Math.max(0, drawable.getFramesCount() - 1);
+        drawable.setCurrentFrame(selectedFrame, false);
+        liquidSelectedIconDrawable = drawable;
+    }
+
+    private void clearLiquidIcons() {
+        recycleLiquidIcon(liquidInactiveIconDrawable);
+        recycleLiquidIcon(liquidSelectedIconDrawable);
+        liquidInactiveIconDrawable = null;
+        liquidSelectedIconDrawable = null;
+    }
+
+    private void recycleLiquidIcon(Drawable drawable) {
+        if (drawable == null) {
+            return;
+        }
+        drawable.setCallback(null);
+        if (drawable instanceof RLottieDrawable) {
+            final RLottieDrawable lottieDrawable = (RLottieDrawable) drawable;
+            lottieDrawable.setMasterParent(null);
+            lottieDrawable.recycle(true);
+        }
+    }
+
+    private void ensureLiquidInactiveColorFilter() {
+        if (liquidInactiveColorFilter == null || liquidInactiveFilterColor != colorDefault) {
+            liquidInactiveFilterColor = colorDefault;
+            liquidInactiveColorFilter = new PorterDuffColorFilter(colorDefault, PorterDuff.Mode.SRC_IN);
+        }
+    }
+
+    private void ensureLiquidSelectedColorFilters(int accentColor) {
+        if (liquidSelectedColorFilter == null || liquidSelectedFilterColor != accentColor) {
+            liquidSelectedFilterColor = accentColor;
+            liquidSelectedColorFilter = new PorterDuffColorFilter(accentColor, PorterDuff.Mode.SRC_IN);
+            liquidSelectedLayerColorFilter = new BlendModeColorFilter(accentColor, BlendMode.SRC_IN);
+        }
+    }
+
+    public void renderSelectedPresentation(Canvas canvas, int accentColor) {
+        ensureLiquidSelectedColorFilters(accentColor);
+        liquidSelectedTintPaint.setColorFilter(liquidSelectedLayerColorFilter);
+        final int layer = canvas.saveLayer(
+            0f,
+            0f,
+            getWidth(),
+            getHeight(),
+            liquidSelectedTintPaint
+        );
+        liquidSelectedLayerDraw = true;
+        try {
+            dispatchDrawContent(canvas);
+        } finally {
+            liquidSelectedLayerDraw = false;
+        }
+        canvas.restoreToCount(layer);
+
+        if (liquidSelectedIconDrawable != null) {
+            liquidSelectedIconDrawable.setColorFilter(liquidSelectedColorFilter);
+            final int left = Math.round(imageView.getLeft() + imageView.getTranslationX());
+            final int top = Math.round(imageView.getTop() + imageView.getTranslationY());
+            liquidSelectedIconDrawable.setBounds(
+                left,
+                top,
+                left + imageView.getWidth(),
+                top + imageView.getHeight()
+            );
+            liquidSelectedIconDrawable.draw(canvas);
+        }
+
+        if (backupImageView != null) {
+            canvas.save();
+            canvas.translate(
+                backupImageView.getLeft() + backupImageView.getTranslationX(),
+                backupImageView.getTop() + backupImageView.getTranslationY()
+            );
+            backupImageView.draw(canvas);
+            canvas.restore();
+        }
+    }
+
+    private void drawLiquidIcon(Canvas canvas, Drawable drawable) {
+        final int left = Math.round(imageView.getLeft() + imageView.getTranslationX());
+        final int top = Math.round(imageView.getTop() + imageView.getTranslationY());
+        drawable.setBounds(
+            left,
+            top,
+            left + imageView.getWidth(),
+            top + imageView.getHeight()
+        );
+        drawable.draw(canvas);
+    }
+
     private Drawable premiumStarDrawable;
 
     public void setCounter(String text, boolean isError, boolean animated) {
@@ -231,10 +438,14 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
     }
 
     public void setSelected(boolean selected, boolean animated) {
-        isSelectedAnimator.setValue(selected, animated);
-        checkPlayAnimation(animated);
-
-        textView.setTypeface(selected ? AndroidUtilities.getTypeface(AndroidUtilities.TYPEFACE_ROBOTO_EXTRA_BOLD) : AndroidUtilities.bold());
+        if (liquidGlassLayersEnabled) {
+            isSelectedAnimator.setValue(selected, false);
+            applyUnselectedPresentation();
+        } else {
+            isSelectedAnimator.setValue(selected, animated);
+            checkPlayAnimation(animated);
+            textView.setTypeface(selected ? AndroidUtilities.getTypeface(AndroidUtilities.TYPEFACE_ROBOTO_EXTRA_BOLD) : AndroidUtilities.bold());
+        }
     }
 
     public boolean isTabSelected() {
@@ -252,8 +463,9 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
     private boolean needUpdateBackupViewColor;
 
     private void updateColors() {
-        final int color = ColorUtils.blendARGB(colorDefault, colorSelected, isSelectedAnimator.getFloatValue());
-        final int colorText = ColorUtils.blendARGB(colorDefault, colorSelectedText, isSelectedAnimator.getFloatValue());
+        final float selected = liquidGlassLayersEnabled ? 0f : isSelectedAnimator.getFloatValue();
+        final int color = ColorUtils.blendARGB(colorDefault, colorSelected, selected);
+        final int colorText = ColorUtils.blendARGB(colorDefault, colorSelectedText, selected);
 
         final PorterDuffColorFilter filter = new PorterDuffColorFilter(color, PorterDuff.Mode.SRC_IN);
         if (backupImageView != null && needUpdateBackupViewColor) {
@@ -401,7 +613,7 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
         GlassTabView tab = new GlassTabView(context);
         tab.resourcesProvider = resourcesProvider;
         tab.tabAnimation = tabAnimation;
-        tab.textView.setText(LocaleController.getString(stringRes));
+        tab.setText(LocaleController.getString(stringRes));
         tab.checkPlayAnimation(false);
         tab.imageView.setLayoutParams(LayoutHelper.createFrame(24, 24, Gravity.CENTER_HORIZONTAL | Gravity.TOP, 0, 4, 0, 0));
         tab.colorDefault = Theme.getColor(Theme.key_glass_tabUnselected, resourcesProvider);
@@ -413,7 +625,7 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
 
     public static GlassTabView createAvatar(Context context, Theme.ResourcesProvider resourcesProvider, int currentAccount, @StringRes int stringRes) {
         GlassTabView tab = new GlassTabView(context);
-        tab.textView.setText(LocaleController.getString(stringRes));
+        tab.setText(LocaleController.getString(stringRes));
         tab.imageView.setVisibility(GONE);
 
         TLRPC.User user = MessagesController.getInstance(currentAccount).getUser(UserConfig.getInstance(currentAccount).getClientUserId());
@@ -492,6 +704,8 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
     public void setAttachScale(float scale) {
         textView.setScaleX(scale);
         textView.setScaleY(scale);
+        liquidSelectedTextView.setScaleX(scale);
+        liquidSelectedTextView.setScaleY(scale);
         imageView.setScaleX(scale);
         imageView.setScaleY(scale);
         if (backupImageView != null) {
@@ -533,6 +747,7 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
         final float px = dp(textSizeDp);
         if (textView.getTextSize() != px) {
             textView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, textSizeDp);
+            liquidSelectedTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, textSizeDp);
             defaultTextPaint.setTextSize(px);
         }
     }
@@ -618,11 +833,17 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
         lastIconAnimationRaw = 0;
         lastBotIconId = 0;
         imageView.clearAnimationDrawable();
-        checkPlayAnimation(false);
+        if (liquidGlassLayersEnabled) {
+            rebuildLiquidSelectedIcon();
+            applyUnselectedPresentation();
+        } else {
+            checkPlayAnimation(false);
+        }
     }
 
     public void setText(CharSequence text) {
         textView.setText(text);
+        liquidSelectedTextView.setText(text);
     }
 
 
@@ -636,7 +857,7 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
         tabAnimationBot = bot;
         lastIconAnimationRaw = 0;
         lastBotIconId = 0;
-        textView.setText(bot.short_name);
+        setText(bot.short_name);
 
         backupImageView.setRoundRadius(0);
         backupImageView.setSize(dp(24), dp(24));
@@ -656,7 +877,7 @@ public class GlassTabView extends FrameLayout implements MainTabsLayout.Tab, Fac
         lastIconAnimationRaw = 0;
         lastBotIconId = 0;
 
-        textView.setText(ContactsController.formatName(user.first_name, user.last_name));
+        setText(ContactsController.formatName(user.first_name, user.last_name));
         if (avatarDrawable == null) {
             avatarDrawable = new AvatarDrawable();
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/MainTabsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/MainTabsActivity.java
@@ -52,10 +52,10 @@ import org.telegram.ui.ActionBar.ActionBarMenuSubItem;
 import org.telegram.ui.ActionBar.BaseFragment;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.ActionBar.ThemeDescription;
+import org.telegram.ui.Components.Bulletin;
 import org.telegram.ui.Components.AnimatedEmojiDrawable;
 import org.telegram.ui.Components.AvatarDrawable;
 import org.telegram.ui.Components.BackupImageView;
-import org.telegram.ui.Components.Bulletin;
 import org.telegram.ui.Components.CubicBezierInterpolator;
 import org.telegram.ui.Components.FolderDrawable;
 import org.telegram.ui.Components.HintsController;
@@ -70,6 +70,7 @@ import org.telegram.ui.Components.blur3.drawable.BlurredBackgroundDrawable;
 import org.telegram.ui.Components.blur3.drawable.color.impl.BlurredBackgroundProviderImpl;
 import org.telegram.ui.Components.blur3.source.BlurredBackgroundSourceColor;
 import org.telegram.ui.Components.blur3.source.BlurredBackgroundSourceRenderNode;
+import org.telegram.ui.Components.blur3.source.LayeredCaptureSource;
 import org.telegram.ui.Components.chat.ViewPositionWatcher;
 import org.telegram.ui.Components.glass.GlassTabView;
 import org.telegram.ui.Stories.recorder.HintView2;
@@ -281,6 +282,9 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
     public View createView(Context context) {
         super.createView(context);
         tabletLayout = false;
+        final boolean liquidGlassTabsEnabled =
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                LiteMode.isEnabled(LiteMode.FLAG_LIQUID_GLASS);
 
         tabsView = new MainTabsLayout(context, resourceProvider);
         tabsView.setClipChildren(false);
@@ -293,16 +297,16 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
         tabs[INDEX_SETTINGS] = GlassTabView.createMainTab(context, resourceProvider, GlassTabView.TabAnimation.SETTINGS, R.string.Settings);
         tabs[INDEX_CALLS] = GlassTabView.createMainTab(context, resourceProvider, GlassTabView.TabAnimation.CALLS, R.string.MainTabsCalls);
         tabs[INDEX_PROFILE] = GlassTabView.createAvatar(context, resourceProvider, currentAccount, R.string.MainTabsProfile);
-        tabs[INDEX_CHATS].setOnLongClickListener(this::openFoldersSelector);
-        tabs[INDEX_CONTACTS].setOnLongClickListener(this::openContactsSelector);
-        tabs[INDEX_CALLS].setOnLongClickListener(this::openCallsSelector);
-        tabs[INDEX_PROFILE].setOnLongClickListener(this::openAccountSelector);
-
-        tabsView.addTabToIgnoreClick(tabs[INDEX_CHATS]);
-        tabsView.addTabToIgnoreClick(tabs[INDEX_CONTACTS]);
-        tabsView.addTabToIgnoreClick(tabs[INDEX_PROFILE]);
-        tabsView.addTabToIgnoreClick(tabs[INDEX_CALLS]);
-
+        if (!liquidGlassTabsEnabled) {
+            tabs[INDEX_CHATS].setOnLongClickListener(this::openFoldersSelector);
+            tabs[INDEX_CONTACTS].setOnLongClickListener(this::openContactsSelector);
+            tabs[INDEX_CALLS].setOnLongClickListener(this::openCallsSelector);
+            tabs[INDEX_PROFILE].setOnLongClickListener(this::openAccountSelector);
+            tabsView.addTabToIgnoreClick(tabs[INDEX_CHATS]);
+            tabsView.addTabToIgnoreClick(tabs[INDEX_CONTACTS]);
+            tabsView.addTabToIgnoreClick(tabs[INDEX_PROFILE]);
+            tabsView.addTabToIgnoreClick(tabs[INDEX_CALLS]);
+        }
         for (int index = 0; index < tabs.length; index++) {
             final GlassTabView view = tabs[index];
 
@@ -337,12 +341,47 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
 
         BlurredBackgroundDrawableViewFactory iBlur3FactoryGlass = new BlurredBackgroundDrawableViewFactory(iBlur3SourceTabGlass != null ? iBlur3SourceTabGlass : iBlur3SourceColor);
         iBlur3FactoryGlass.setSourceRootView(viewPositionWatcher, contentView);
-        iBlur3FactoryGlass.setLiquidGlassEffectAllowed(LiteMode.isEnabled(LiteMode.FLAG_LIQUID_GLASS));
+        iBlur3FactoryGlass.setLiquidGlassEffectAllowed(liquidGlassTabsEnabled);
 
         tabsViewBackground = iBlur3FactoryGlass.create(tabsView, BlurredBackgroundProviderImpl.mainTabs(resourceProvider));
         tabsViewBackground.setRadius(dp(DialogsActivity.MAIN_TABS_HEIGHT / 2f));
         tabsViewBackground.setPadding(dp(DialogsActivity.MAIN_TABS_MARGIN - 0.334f));
+        if (liquidGlassTabsEnabled) {
+            tabsViewBackground
+                .setThickness(dp(24))
+                .setOpticalDisplacement(dp(24))
+                .setSurfaceBlurRadius(dp(8))
+                .setBackdropSaturation(1.5f);
+        }
         tabsView.setBackground(tabsViewBackground);
+
+        if (liquidGlassTabsEnabled) {
+            final LayeredCaptureSource selectorSource = new LayeredCaptureSource(
+                iBlur3SourceTabGlass != null ? iBlur3SourceTabGlass : iBlur3SourceColor,
+                tabsView::renderSelectionCapture
+            );
+            final BlurredBackgroundDrawableViewFactory selectorFactory = new BlurredBackgroundDrawableViewFactory(selectorSource);
+            selectorFactory.setSourceRootView(viewPositionWatcher, contentView);
+            selectorFactory.setLiquidGlassEffectAllowed(true);
+            final BlurredBackgroundDrawable hiddenTabsBackground = iBlur3FactoryGlass.create(
+                null,
+                BlurredBackgroundProviderImpl.mainTabs(resourceProvider)
+            );
+            hiddenTabsBackground
+                .setRadius(dp(DialogsActivity.MAIN_TABS_HEIGHT / 2f))
+                .setThickness(1)
+                .setOpticalDisplacement(0f)
+                .setSurfaceBlurRadius(dp(8))
+                .setBackdropSaturation(1.5f)
+                .setEdgeLightingStrength(0f);
+            hiddenTabsBackground.setShadowAlpha(0f);
+            tabsView.installGlassSelectionRenderer(
+                selectorFactory,
+                tabsViewBackground,
+                hiddenTabsBackground,
+                selectorSource
+            );
+        }
 
         BlurredBackgroundDrawableViewFactory iBlur3FactoryFade = new BlurredBackgroundDrawableViewFactory(iBlur3SourceColor);
         iBlur3FactoryFade.setSourceRootView(viewPositionWatcher, contentView);
@@ -355,6 +394,9 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
         contentView.addView(fadeView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 0, Gravity.BOTTOM));
 
         tabsViewWrapper = new FrameLayout(context);
+        if (liquidGlassTabsEnabled) {
+            tabsViewWrapper.setClipChildren(false);
+        }
         tabsViewWrapper.setOnClickListener(v -> {});
         tabsViewWrapper.addView(tabsView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, DialogsActivity.MAIN_TABS_HEIGHT_WITH_MARGINS, Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL));
         tabsViewWrapper.setClipToPadding(false);
@@ -389,48 +431,70 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
 
     public boolean openContactsSelector(View anchor) {
         if (getContext() == null || getParentActivity() == null) return false;
-        final ItemOptions o = ItemOptions.makeOptions(this, anchor);
-        o.add(R.drawable.msg_contact_add, getString(R.string.NewContact), () -> {
+        final ItemOptions options = ItemOptions.makeOptions(this, anchor);
+        options.add(R.drawable.msg_contact_add, getString(R.string.NewContact), () -> {
             new NewContactBottomSheet(this, getContext()).show();
         });
-        o.add(R.drawable.msg_calls, getString(R.string.VoipChatRecentCalls), () -> {
+        options.add(R.drawable.msg_calls, getString(R.string.VoipChatRecentCalls), () -> {
             Bundle args = new Bundle();
             args.putBoolean("needFinishFragment", false);
             presentFragment(new CallLogActivity(args));
         });
-        o.setBlur(true);
-        o.translate(0, -dp(4));
-        o.setGravity(Gravity.LEFT);
-        final ShapeDrawable bg = Theme.createRoundRectDrawable(dp(28), getThemedColor(Theme.key_windowBackgroundWhite));
-        bg.getPaint().setShadowLayer(dp(6), 0, dp(1), Theme.multAlpha(0xFF000000, 0.15f));
-        o.setScrimViewBackground(bg);
-        o.show();
+        options.setBlur(true);
+        options.translate(0, -dp(4));
+        options.setGravity(Gravity.LEFT);
+        final ShapeDrawable background =
+            Theme.createRoundRectDrawable(dp(28), getThemedColor(Theme.key_windowBackgroundWhite));
+        background.getPaint().setShadowLayer(
+            dp(6),
+            0,
+            dp(1),
+            Theme.multAlpha(0xFF000000, 0.15f)
+        );
+        options.setScrimViewBackground(background);
+        options.show();
         return true;
     }
 
     public boolean openCallsSelector(View anchor) {
         if (getContext() == null || getParentActivity() == null) return false;
-        final ItemOptions o = ItemOptions.makeOptions(this, anchor);
-        o.add(R.drawable.menu_call_create, getString(R.string.GroupCallCreate2), () -> CallLogActivity.openCreateCall(this));
+        final ItemOptions options = ItemOptions.makeOptions(this, anchor);
+        options.add(
+            R.drawable.menu_call_create,
+            getString(R.string.GroupCallCreate2),
+            () -> CallLogActivity.openCreateCall(this)
+        );
         if (getUserConfig().showCallsTab) {
-            o.add(R.drawable.msg_archive_hide, getString(R.string.HideCallTab), () -> {
+            options.add(R.drawable.msg_archive_hide, getString(R.string.HideCallTab), () -> {
                 getUserConfig().setShowCallsTab(false);
                 checkUi_callTabVisible(false, true);
-                NotificationCenter.getInstance(currentAccount).postNotificationName(NotificationCenter.callTabsVisibleToggled);
+                NotificationCenter.getInstance(currentAccount)
+                    .postNotificationName(NotificationCenter.callTabsVisibleToggled);
             });
         } else {
-            o.add(R.drawable.menu_add_tab_24, getString(R.string.GroupCallShowInMainTabs), () -> {
-                getUserConfig().setShowCallsTab(true);
-                checkUi_callTabVisible(true, true);
-                NotificationCenter.getInstance(currentAccount).postNotificationName(NotificationCenter.callTabsVisibleToggled);
-            });
+            options.add(
+                R.drawable.menu_add_tab_24,
+                getString(R.string.GroupCallShowInMainTabs),
+                () -> {
+                    getUserConfig().setShowCallsTab(true);
+                    checkUi_callTabVisible(true, true);
+                    NotificationCenter.getInstance(currentAccount)
+                        .postNotificationName(NotificationCenter.callTabsVisibleToggled);
+                }
+            );
         }
-        o.setBlur(true);
-        o.translate(0, -dp(4));
-        final ShapeDrawable bg = Theme.createRoundRectDrawable(dp(28), getThemedColor(Theme.key_windowBackgroundWhite));
-        bg.getPaint().setShadowLayer(dp(6), 0, dp(1), Theme.multAlpha(0xFF000000, 0.15f));
-        o.setScrimViewBackground(bg);
-        o.show();
+        options.setBlur(true);
+        options.translate(0, -dp(4));
+        final ShapeDrawable background =
+            Theme.createRoundRectDrawable(dp(28), getThemedColor(Theme.key_windowBackgroundWhite));
+        background.getPaint().setShadowLayer(
+            dp(6),
+            0,
+            dp(1),
+            Theme.multAlpha(0xFF000000, 0.15f)
+        );
+        options.setScrimViewBackground(background);
+        options.show();
         return true;
     }
 
@@ -438,39 +502,72 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
 
     private boolean openFoldersSelector(View anchor) {
         if (getContext() == null || getParentActivity() == null) return false;
-        final ArrayList<MessagesController.DialogFilter> filters = getMessagesController().getDialogFilters();
+        final ArrayList<MessagesController.DialogFilter> filters =
+            getMessagesController().getDialogFilters();
         if (filters == null || filters.size() <= 1) return false;
 
-        final ItemOptions o = ItemOptions.makeOptions(this, anchor);
+        final ItemOptions options = ItemOptions.makeOptions(this, anchor);
         for (int i = 0; i < filters.size(); i++) {
             final MessagesController.DialogFilter folder = filters.get(i);
-            final ActionBarMenuSubItem folderItem = new ActionBarMenuSubItem(getParentActivity(), 2, false, false, getResourceProvider());
+            final ActionBarMenuSubItem folderItem = new ActionBarMenuSubItem(
+                getParentActivity(),
+                2,
+                false,
+                false,
+                getResourceProvider()
+            );
             folderItem.setPadding(dp(18), 0, dp(18), 0);
-            CharSequence title = folder.isDefault() ? getString(R.string.FilterAllChats) : folder.name;
-            title = Emoji.replaceEmoji(title, folderItem.getTextView().getPaint().getFontMetricsInt(), false);
+            CharSequence title =
+                folder.isDefault() ? getString(R.string.FilterAllChats) : folder.name;
+            title = Emoji.replaceEmoji(
+                title,
+                folderItem.getTextView().getPaint().getFontMetricsInt(),
+                false
+            );
             if (!folder.isDefault()) {
-                title = MessageObject.replaceAnimatedEmoji(title, folder.entities, folderItem.getTextView().getPaint().getFontMetricsInt());
+                title = MessageObject.replaceAnimatedEmoji(
+                    title,
+                    folder.entities,
+                    folderItem.getTextView().getPaint().getFontMetricsInt()
+                );
             }
-            folderItem.setEmojiCacheType(folder.title_noanimate ? AnimatedEmojiDrawable.CACHE_TYPE_NOANIMATE_FOLDER : AnimatedEmojiDrawable.CACHE_TYPE_MESSAGES);
+            folderItem.setEmojiCacheType(
+                folder.title_noanimate
+                    ? AnimatedEmojiDrawable.CACHE_TYPE_NOANIMATE_FOLDER
+                    : AnimatedEmojiDrawable.CACHE_TYPE_MESSAGES
+            );
             final int color = getMessagesController().folderTags ? folder.color : -1;
-            folderItem.setTextAndIcon(title, 0, new FolderDrawable(getContext(), R.drawable.msg_folders, color));
-            folderItem.getTextView().setEmojiColor(getThemedColor(Theme.key_featuredStickers_addButton));
+            folderItem.setTextAndIcon(
+                title,
+                0,
+                new FolderDrawable(getContext(), R.drawable.msg_folders, color)
+            );
+            folderItem.getTextView().setEmojiColor(
+                getThemedColor(Theme.key_featuredStickers_addButton)
+            );
             folderItem.setMinimumWidth(160);
-            folderItem.setOnClickListener(e -> {
-                o.dismiss();
+            folderItem.setOnClickListener(view -> {
+                options.dismiss();
                 openFolder(folder.id);
             });
-            o.addView(folderItem, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT));
+            options.addView(
+                folderItem,
+                LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT)
+            );
         }
-//        o.setBlur(true);
-        o.translate(-dp(8), -dp(4));
-        o.setMaxHeight(dp(400));
-        final ShapeDrawable bg = Theme.createRoundRectDrawable(dp(28), getThemedColor(Theme.key_windowBackgroundWhite));
-        bg.getPaint().setShadowLayer(dp(6), 0, dp(1), Theme.multAlpha(0xFF000000, 0.15f));
-        o.setScrimViewBackground(bg);
-        o.setGravity(Gravity.LEFT);
-        o.show();
-
+        options.translate(-dp(8), -dp(4));
+        options.setMaxHeight(dp(400));
+        final ShapeDrawable background =
+            Theme.createRoundRectDrawable(dp(28), getThemedColor(Theme.key_windowBackgroundWhite));
+        background.getPaint().setShadowLayer(
+            dp(6),
+            0,
+            dp(1),
+            Theme.multAlpha(0xFF000000, 0.15f)
+        );
+        options.setScrimViewBackground(background);
+        options.setGravity(Gravity.LEFT);
+        options.show();
         return true;
     }
 
@@ -489,104 +586,127 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
 
     public boolean openAccountSelector(View button) {
         final ArrayList<Integer> accountNumbers = new ArrayList<>();
-
-        accountNumbers.clear();
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
-            if (UserConfig.getInstance(a).isClientActivated()) {
-                accountNumbers.add(a);
+        for (int account = 0; account < UserConfig.MAX_ACCOUNT_COUNT; account++) {
+            if (UserConfig.getInstance(account).isClientActivated()) {
+                accountNumbers.add(account);
             }
         }
-        Collections.sort(accountNumbers, (o1, o2) -> {
-            long l1 = UserConfig.getInstance(o1).loginTime;
-            long l2 = UserConfig.getInstance(o2).loginTime;
-            if (l1 > l2) {
-                return 1;
-            } else if (l1 < l2) {
-                return -1;
-            }
-            return 0;
+        Collections.sort(accountNumbers, (first, second) -> {
+            final long firstLoginTime = UserConfig.getInstance(first).loginTime;
+            final long secondLoginTime = UserConfig.getInstance(second).loginTime;
+            return Long.compare(firstLoginTime, secondLoginTime);
         });
 
-        ItemOptions o = ItemOptions.makeOptions(this, button);
+        final ItemOptions options = ItemOptions.makeOptions(this, button);
         if (UserConfig.getActivatedAccountsCount() < UserConfig.MAX_ACCOUNT_COUNT) {
-            o.add(R.drawable.msg_addbot, getString(R.string.AddAccount), () -> {
+            options.add(R.drawable.msg_addbot, getString(R.string.AddAccount), () -> {
                 int freeAccounts = 0;
                 Integer availableAccount = null;
-                for (int a = UserConfig.MAX_ACCOUNT_COUNT - 1; a >= 0; a--) {
-                    if (!UserConfig.getInstance(a).isClientActivated()) {
+                for (int account = UserConfig.MAX_ACCOUNT_COUNT - 1; account >= 0; account--) {
+                    if (!UserConfig.getInstance(account).isClientActivated()) {
                         freeAccounts++;
                         if (availableAccount == null) {
-                            availableAccount = a;
+                            availableAccount = account;
                         }
                     }
                 }
                 if (!UserConfig.hasPremiumOnAccounts()) {
-                    freeAccounts -= (UserConfig.MAX_ACCOUNT_COUNT - UserConfig.MAX_ACCOUNT_DEFAULT_COUNT);
+                    freeAccounts -=
+                        UserConfig.MAX_ACCOUNT_COUNT - UserConfig.MAX_ACCOUNT_DEFAULT_COUNT;
                 }
                 if (freeAccounts > 0 && availableAccount != null) {
                     presentFragment(new LoginActivity(availableAccount));
                 } else if (!UserConfig.hasPremiumOnAccounts()) {
-                    showDialog(new LimitReachedBottomSheet(this, getContext(), TYPE_ACCOUNTS, currentAccount, null));
+                    showDialog(
+                        new LimitReachedBottomSheet(
+                            this,
+                            getContext(),
+                            TYPE_ACCOUNTS,
+                            currentAccount,
+                            null
+                        )
+                    );
                 }
             });
         }
 
         if (BuildConfig.DEBUG_PRIVATE_VERSION) {
-            o.add(R.drawable.menu_download_round, "Dump Canvas", () -> AndroidUtilities.runOnUIThread(this::dumpCanvas, 1000));
+            options.add(
+                R.drawable.menu_download_round,
+                "Dump Canvas",
+                () -> AndroidUtilities.runOnUIThread(this::dumpCanvas, 1000)
+            );
         }
 
-        if (accountNumbers.size() > 0) {
-            if (o.getItemsCount() > 0) o.addGap();
-            for (int acc : accountNumbers) {
-                final int account = acc;
-                final View btn = accountView(acc, currentAccount == acc);
-                btn.setOnClickListener(v -> {
+        if (!accountNumbers.isEmpty()) {
+            if (options.getItemsCount() > 0) {
+                options.addGap();
+            }
+            for (int account : accountNumbers) {
+                final View accountButton = accountView(account, currentAccount == account);
+                accountButton.setOnClickListener(view -> {
                     if (currentAccount == account) return;
-                    o.dismiss();
+                    options.dismiss();
                     if (LaunchActivity.instance != null) {
                         LaunchActivity.instance.switchToAccount(account, true);
                     }
                 });
-                o.addView(btn, LayoutHelper.createLinear(230, 48));
+                options.addView(accountButton, LayoutHelper.createLinear(230, 48));
             }
         }
 
-        o.setBlur(true);
-        o.translate(0, -dp(4));
-        final ShapeDrawable bg = Theme.createRoundRectDrawable(dp(28), getThemedColor(Theme.key_windowBackgroundWhite));
-        bg.getPaint().setShadowLayer(dp(6), 0, dp(1), Theme.multAlpha(0xFF000000, 0.15f));
-        o.setScrimViewBackground(bg);
-        o.show();
-
+        options.setBlur(true);
+        options.translate(0, -dp(4));
+        final ShapeDrawable background =
+            Theme.createRoundRectDrawable(dp(28), getThemedColor(Theme.key_windowBackgroundWhite));
+        background.getPaint().setShadowLayer(
+            dp(6),
+            0,
+            dp(1),
+            Theme.multAlpha(0xFF000000, 0.15f)
+        );
+        options.setScrimViewBackground(background);
+        options.show();
         HintsController.Hint.AccountSwitchHint.doNotShowAgain();
-
         return true;
     }
 
     public LinearLayout accountView(int account, boolean selected) {
-        final LinearLayout btn = new LinearLayout(getContext());
-        btn.setOrientation(LinearLayout.HORIZONTAL);
-        btn.setBackground(Theme.createRadSelectorDrawable(getThemedColor(Theme.key_listSelector), 0, 0));
+        final LinearLayout button = new LinearLayout(getContext());
+        button.setOrientation(LinearLayout.HORIZONTAL);
+        button.setBackground(
+            Theme.createRadSelectorDrawable(getThemedColor(Theme.key_listSelector), 0, 0)
+        );
 
         final TLRPC.User user = UserConfig.getInstance(account).getCurrentUser();
-
         final AvatarDrawable avatarDrawable = new AvatarDrawable();
         avatarDrawable.setInfo(user);
 
         final FrameLayout avatarContainer = new FrameLayout(getContext()) {
             private final Paint selectedPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+
             @Override
             protected void dispatchDraw(@NonNull Canvas canvas) {
                 if (selected) {
                     selectedPaint.setStyle(Paint.Style.STROKE);
                     selectedPaint.setStrokeWidth(dp(1.33f));
-                    selectedPaint.setColor(getThemedColor(Theme.key_featuredStickers_addButton));
-                    canvas.drawCircle(getWidth() / 2.0f, getHeight() / 2.0f, dp(16), selectedPaint);
+                    selectedPaint.setColor(
+                        getThemedColor(Theme.key_featuredStickers_addButton)
+                    );
+                    canvas.drawCircle(
+                        getWidth() / 2.0f,
+                        getHeight() / 2.0f,
+                        dp(16),
+                        selectedPaint
+                    );
                 }
                 super.dispatchDraw(canvas);
             }
         };
-        btn.addView(avatarContainer, LayoutHelper.createLinear(34, 34, Gravity.CENTER_VERTICAL, 12, 0, 0, 0));
+        button.addView(
+            avatarContainer,
+            LayoutHelper.createLinear(34, 34, Gravity.CENTER_VERTICAL, 12, 0, 0, 0)
+        );
 
         final BackupImageView avatarView = new BackupImageView(getContext());
         if (selected) {
@@ -596,7 +716,10 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
         avatarView.setRoundRadius(dp(16));
         avatarView.getImageReceiver().setCurrentAccount(account);
         avatarView.setForUserOrChat(user, avatarDrawable);
-        avatarContainer.addView(avatarView, LayoutHelper.createLinear(32, 32, Gravity.CENTER, 1, 1, 1, 1));
+        avatarContainer.addView(
+            avatarView,
+            LayoutHelper.createLinear(32, 32, Gravity.CENTER, 1, 1, 1, 1)
+        );
 
         final TextView textView = new TextView(getContext());
         textView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 16);
@@ -604,9 +727,20 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
         textView.setText(UserObject.getUserName(user));
         textView.setMaxLines(2);
         textView.setEllipsize(TextUtils.TruncateAt.END);
-        btn.addView(textView, LayoutHelper.createLinear(0, LayoutHelper.WRAP_CONTENT, 1f, Gravity.CENTER_VERTICAL, 13, 0, 14, 0));
-
-        return btn;
+        button.addView(
+            textView,
+            LayoutHelper.createLinear(
+                0,
+                LayoutHelper.WRAP_CONTENT,
+                1f,
+                Gravity.CENTER_VERTICAL,
+                13,
+                0,
+                14,
+                0
+            )
+        );
+        return button;
     }
 
     @Override
@@ -626,7 +760,9 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
             if (currentPosition != POSITION_PROFILE) {
                 dropFragmentAtPosition(POSITION_PROFILE);
             }
-            if (pendingFolderId != null && currentPosition == POSITION_CHATS && dialogsActivity != null) {
+            if (pendingFolderId != null &&
+                currentPosition == POSITION_CHATS &&
+                dialogsActivity != null) {
                 dialogsActivity.scrollToFolder(pendingFolderId);
                 pendingFolderId = null;
             }
@@ -734,9 +870,20 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
     public GlassTabView[] tabs;
 
     public void selectTab(int position, boolean animated) {
+        GlassTabView selectedTab = null;
         for (int a = 0; a < tabs.length; a++) {
             GlassTabView tab = tabs[a];
-            tab.setSelected(indexToPosition(a) == position, animated);
+            if (indexToPosition(a) == position && (tabsView == null || tabsView.isViewVisible(tab))) {
+                selectedTab = tab;
+                break;
+            }
+        }
+        if (tabsView != null) {
+            tabsView.setTabSelected(selectedTab, animated);
+        } else {
+            for (int a = 0; a < tabs.length; a++) {
+                tabs[a].setSelected(tabs[a] == selectedTab, animated);
+            }
         }
     }
 
@@ -1097,7 +1244,7 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
             fadeView.invalidate();
         }
         if (tabsView != null) {
-            tabsView.invalidate();
+            tabsView.syncGlassSelectionPalette();
         }
         if (tabs != null) {
             for (GlassTabView tabView : tabs) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/MainTabsLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/MainTabsLayout.java
@@ -5,11 +5,18 @@ import static org.telegram.messenger.AndroidUtilities.lerp;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.graphics.BlendMode;
+import android.graphics.BlendModeColorFilter;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.RectF;
+import android.view.HapticFeedbackConstants;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewConfiguration;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -18,12 +25,15 @@ import androidx.dynamicanimation.animation.FloatPropertyCompat;
 import androidx.dynamicanimation.animation.SpringAnimation;
 import androidx.dynamicanimation.animation.SpringForce;
 
-import android.util.Log;
-
 import org.telegram.messenger.AndroidUtilities;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.AnimatedLinearLayout;
 import org.telegram.ui.Components.CubicBezierInterpolator;
+import org.telegram.ui.Components.blur3.BlurredBackgroundDrawableViewFactory;
+import org.telegram.ui.Components.blur3.render.SurfaceTouchLighting;
+import org.telegram.ui.Components.blur3.drawable.BlurredBackgroundDrawable;
+import org.telegram.ui.Components.blur3.drawable.color.BlurredBackgroundColorProvider;
+import org.telegram.ui.Components.blur3.source.LayeredCaptureSource;
 import org.telegram.ui.Components.glass.GlassTabView;
 
 import java.util.HashSet;
@@ -43,8 +53,147 @@ public class MainTabsLayout extends AnimatedLinearLayout {
         this.resourcesProvider = resourcesProvider;
     }
 
+    private BlurredBackgroundDrawable liquidSelectorDrawable;
+    private BlurredBackgroundDrawable liquidTabsBackground;
+    private BlurredBackgroundDrawable liquidHiddenTabsBackground;
+    private LayeredCaptureSource layeredCaptureSource;
+    private final Paint liquidTintPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Path liquidSelectorPath = new Path();
+    private final RectF liquidSelectorRect = new RectF();
+    private final RectF liquidPanelBounds = new RectF();
+    private BlendModeColorFilter liquidTintColorFilter;
+    private int liquidTintColor;
+    private float liquidPressProgress;
+    private float liquidSelectorScaleX = 1f;
+    private float liquidSelectorScaleY = 1f;
+    private float liquidSelectorCenterX;
+    private float liquidSelectorVelocity;
+    private long liquidSelectorPositionTime;
+    private float liquidInteractiveProgress;
+    private float liquidSelectorRadius = Float.NaN;
+    private boolean liquidReleasePending;
+    private float liquidReleaseTargetX;
+    private float liquidPanelDragOffset;
+    private float liquidPanelOffsetX;
+    private float liquidAppliedPanelOffsetX;
+    private float liquidLastTouchX;
+    private SurfaceTouchLighting surfaceTouchLighting;
+    private boolean liquidTracking;
+    private View liquidTargetTab;
+    private View liquidDownTab;
+    private float liquidDownX;
+    private float liquidDownY;
+    private float liquidLastTouchY;
+    private long liquidDownTime;
+    private int liquidPointerId = MotionEvent.INVALID_POINTER_ID;
+    private LiquidGestureState liquidGestureState = LiquidGestureState.IDLE;
+    private final Runnable liquidLongPressRunnable = this::startPendingLiquidLongPress;
+
+    private enum LiquidGestureState {
+        IDLE,
+        PENDING_LONG_PRESS,
+        TRACKING
+    }
+
+    public void installGlassSelectionRenderer(
+        BlurredBackgroundDrawableViewFactory factory,
+        BlurredBackgroundDrawable tabsBackground,
+        BlurredBackgroundDrawable hiddenTabsBackground,
+        LayeredCaptureSource captureSource
+    ) {
+        liquidTabsBackground = tabsBackground;
+        liquidHiddenTabsBackground = hiddenTabsBackground;
+        layeredCaptureSource = captureSource;
+        liquidSelectorDrawable = factory.create(null, new BlurredBackgroundColorProvider() {
+            @Override
+            public int getShadowColor() {
+                return 0x1A000000;
+            }
+
+            @Override
+            public int getBackgroundColor() {
+                final boolean dark = resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark();
+                final int color = dark ? Color.WHITE : Color.BLACK;
+                return Theme.multAlpha(color, 0.1f * (1f - liquidPressProgress));
+            }
+
+            @Override
+            public int getStrokeColorTop() {
+                return 0;
+            }
+
+            @Override
+            public int getStrokeColorBottom() {
+                return 0;
+            }
+        });
+        liquidSelectorDrawable
+            .setSpectralSeparationEnabled(true)
+            .setBackdropSaturation(1f)
+            .setSurfaceBlurRadius(0f)
+            .setEdgeLightingStrength(0f)
+            .setThickness(1)
+            .setOpticalDisplacement(0f);
+        liquidSelectorDrawable.setShadowParams(dp(24), 0, dp(4));
+        liquidSelectorDrawable.setShadowAlpha(0f);
+        surfaceTouchLighting = new SurfaceTouchLighting();
+        setBackground(null);
+        for (int i = 0; i < getChildCount(); i++) {
+            final View child = getChildAt(i);
+            if (child instanceof GlassTabView) {
+                ((GlassTabView) child).setSplitSelectionRendering(true);
+            }
+        }
+        setSkipDrawSelector(true);
+        drawCustomSelector = false;
+        syncLiquidSelectorToSelectedTab();
+    }
+
+    public void renderSelectionCapture(Canvas canvas) {
+        if (liquidTabsBackground == null) {
+            return;
+        }
+
+        final int accent = Theme.getColor(Theme.key_glass_tabSelected, resourcesProvider);
+        canvas.save();
+        canvas.translate(liquidTabsBackground.getSourceOffsetX(), liquidTabsBackground.getSourceOffsetY());
+        liquidHiddenTabsBackground.draw(canvas);
+
+        final float contentScale = lerp(1f, 1.2f, liquidPressProgress);
+        for (int i = 0; i < getChildCount(); i++) {
+            final View child = getChildAt(i);
+            if (child.getVisibility() != View.VISIBLE) {
+                continue;
+            }
+            canvas.save();
+            canvas.translate(child.getX(), child.getY());
+            canvas.scale(contentScale, contentScale, child.getWidth() * 0.5f, child.getHeight() * 0.5f);
+            if (child instanceof GlassTabView) {
+                ((GlassTabView) child).renderSelectedPresentation(canvas, accent);
+            } else {
+                if (liquidTintColorFilter == null || liquidTintColor != accent) {
+                    liquidTintColor = accent;
+                    liquidTintColorFilter = new BlendModeColorFilter(accent, BlendMode.SRC_IN);
+                }
+                liquidTintPaint.setColorFilter(liquidTintColorFilter);
+                final int layer = canvas.saveLayer(
+                    0f,
+                    0f,
+                    child.getWidth(),
+                    child.getHeight(),
+                    liquidTintPaint
+                );
+                child.draw(canvas);
+                canvas.restoreToCount(layer);
+            }
+            canvas.restore();
+        }
+        canvas.restore();
+    }
+
     private static final float[] PASS_TEXT_SIZES_DP = {12f, 12f, 10f};
     private static final int[] PASS_PADDINGS_DP = {16, 8, 4};
+    private static final float LIQUID_PRESSED_SCALE = 80f / 56f;
 
     private int maxWidthPx;
 
@@ -66,7 +215,10 @@ public class MainTabsLayout extends AnimatedLinearLayout {
         }
 
         final int maxTotalWidthForTabs = width - getPaddingLeft() - getPaddingRight();
-        final int minTotalWidthForTabs = Math.min(dp(320), maxTotalWidthForTabs);
+        if (liquidSelectorDrawable == null) {
+            measureLegacyTabs(height, tabHeight, maxTotalWidthForTabs);
+            return;
+        }
 
         int chosenPass = PASS_TEXT_SIZES_DP.length - 1;
         float lastMeasuredTextSize = -1;
@@ -76,13 +228,17 @@ public class MainTabsLayout extends AnimatedLinearLayout {
                 lastMeasuredTextSize = PASS_TEXT_SIZES_DP[pass];
             }
             final int padding = dp(PASS_PADDINGS_DP[pass]);
-            float total = 0;
+            final float equalTabWidth = maxTotalWidthForTabs / (float) Math.max(1, visibleChildCount);
+            boolean fits = true;
             for (int a = 0, N = getChildCount(); a < N; a++) {
-                if (!isViewVisible(getChildAt(a))) continue;
-                final float withMargin = tabsTextWidth[a] + padding * 2;
-                total += withMargin;
+                if (!isViewVisible(getChildAt(a))) {
+                    continue;
+                }
+                if (tabsTextWidth[a] + padding * 2 > equalTabWidth) {
+                    fits = false;
+                    break;
+                }
             }
-            final boolean fits = total <= maxTotalWidthForTabs;
             if (fits || pass == PASS_TEXT_SIZES_DP.length - 1) {
                 chosenPass = pass;
                 break;
@@ -91,55 +247,15 @@ public class MainTabsLayout extends AnimatedLinearLayout {
 
         applyPassTextSize(chosenPass);
 
-        final int tabPadding = dp(PASS_PADDINGS_DP[chosenPass]);
-        final int maxTabTextWidthIfEq = (maxTotalWidthForTabs / Math.max(1, visibleChildCount)) - tabPadding * 2;
-
-        float totalWidth = 0;
-        int totalWeight = 0;
-        for (int a = 0, N = getChildCount(); a < N; a++) {
-            final View child = getChildAt(a);
-            if (!isViewVisible(child)) {
-                tabsTextWidth[a] = tabsTextWidthWithMargin[a] = 0;
-                tabsWeight[a] = 0;
-                continue;
-            }
-
-            tabsTextWidthWithMargin[a] = tabsTextWidth[a] + tabPadding * 2;
-            tabsWeight[a] = tabsTextWidthWithMargin[a] > (maxTabTextWidthIfEq + tabPadding * 2) ? 0 : 1;
-
-            totalWidth += tabsTextWidthWithMargin[a];
-            totalWeight += tabsWeight[a];
-        }
-
-        if (totalWeight == 0) {
-            for (int a = 0, N = getChildCount(); a < N; a++) {
-                tabsWeight[a] = isViewVisible(getChildAt(a)) ? 1 : 0;
-            }
-            totalWeight = visibleChildCount;
-        }
-
-        if (totalWidth > maxTotalWidthForTabs) {
-            final float m = maxTotalWidthForTabs / totalWidth;
-            for (int a = 0, N = getChildCount(); a < N; a++) {
-                tabsTextWidthWithMargin[a] *= m;
-            }
-        } else if (totalWidth < minTotalWidthForTabs) {
-            final float growW = minTotalWidthForTabs - totalWidth;
-            final float growP = growW / totalWeight;
-
-            for (int a = 0, N = getChildCount(); a < N; a++) {
-                tabsTextWidthWithMargin[a] += growP * tabsWeight[a];
-            }
-        }
-
+        final int equalWidth = maxTotalWidthForTabs / Math.max(1, visibleChildCount);
+        int remainingPixels = maxTotalWidthForTabs - equalWidth * visibleChildCount;
         int l = 0;
         for (int a = 0, N = getChildCount(); a < N; a++) {
             if (!isViewVisible(getChildAt(a))) {
+                tabsWidth[a] = 0;
                 continue;
             }
-
-            tabsWidth[a] = Math.round(tabsTextWidthWithMargin[a]);
-            tabsLeftPos[a] = l;
+            tabsWidth[a] = equalWidth + (remainingPixels-- > 0 ? 1 : 0);
             l += tabsWidth[a];
         }
         setMeasuredDimension(l + getPaddingLeft() + getPaddingRight(), height);
@@ -153,6 +269,88 @@ public class MainTabsLayout extends AnimatedLinearLayout {
         calculateTotalSizesAfterMeasure();
     }
 
+    private void measureLegacyTabs(int height, int tabHeight, int maxTotalWidthForTabs) {
+        final int minTotalWidthForTabs = Math.min(dp(320), maxTotalWidthForTabs);
+        int chosenPass = PASS_TEXT_SIZES_DP.length - 1;
+        float lastMeasuredTextSize = -1;
+        for (int pass = 0; pass < PASS_TEXT_SIZES_DP.length; pass++) {
+            if (PASS_TEXT_SIZES_DP[pass] != lastMeasuredTextSize) {
+                measureTabTexts(PASS_TEXT_SIZES_DP[pass]);
+                lastMeasuredTextSize = PASS_TEXT_SIZES_DP[pass];
+            }
+            final int padding = dp(PASS_PADDINGS_DP[pass]);
+            float total = 0;
+            for (int a = 0, N = getChildCount(); a < N; a++) {
+                if (!isViewVisible(getChildAt(a))) {
+                    continue;
+                }
+                total += tabsTextWidth[a] + padding * 2;
+            }
+            if (total <= maxTotalWidthForTabs || pass == PASS_TEXT_SIZES_DP.length - 1) {
+                chosenPass = pass;
+                break;
+            }
+        }
+
+        applyPassTextSize(chosenPass);
+        final int tabPadding = dp(PASS_PADDINGS_DP[chosenPass]);
+        final int maxTabTextWidthIfEq =
+            maxTotalWidthForTabs / Math.max(1, visibleChildCount) - tabPadding * 2;
+        float totalWidth = 0;
+        int totalWeight = 0;
+        for (int a = 0, N = getChildCount(); a < N; a++) {
+            final View child = getChildAt(a);
+            if (!isViewVisible(child)) {
+                tabsTextWidth[a] = tabsTextWidthWithMargin[a] = 0;
+                tabsWeight[a] = 0;
+                continue;
+            }
+            tabsTextWidthWithMargin[a] = tabsTextWidth[a] + tabPadding * 2;
+            tabsWeight[a] =
+                tabsTextWidthWithMargin[a] > maxTabTextWidthIfEq + tabPadding * 2 ? 0 : 1;
+            totalWidth += tabsTextWidthWithMargin[a];
+            totalWeight += tabsWeight[a];
+        }
+
+        if (totalWeight == 0) {
+            for (int a = 0, N = getChildCount(); a < N; a++) {
+                tabsWeight[a] = isViewVisible(getChildAt(a)) ? 1 : 0;
+            }
+            totalWeight = visibleChildCount;
+        }
+
+        if (totalWidth > maxTotalWidthForTabs) {
+            final float multiplier = maxTotalWidthForTabs / totalWidth;
+            for (int a = 0, N = getChildCount(); a < N; a++) {
+                tabsTextWidthWithMargin[a] *= multiplier;
+            }
+        } else if (totalWidth < minTotalWidthForTabs) {
+            final float growPerWeight = (minTotalWidthForTabs - totalWidth) / totalWeight;
+            for (int a = 0, N = getChildCount(); a < N; a++) {
+                tabsTextWidthWithMargin[a] += growPerWeight * tabsWeight[a];
+            }
+        }
+
+        int measuredWidth = 0;
+        for (int a = 0, N = getChildCount(); a < N; a++) {
+            if (!isViewVisible(getChildAt(a))) {
+                tabsWidth[a] = 0;
+                continue;
+            }
+            tabsWidth[a] = Math.round(tabsTextWidthWithMargin[a]);
+            measuredWidth += tabsWidth[a];
+        }
+        setMeasuredDimension(measuredWidth + getPaddingLeft() + getPaddingRight(), height);
+        for (int a = 0, N = getChildCount(); a < N; a++) {
+            final View child = getChildAt(a);
+            child.measure(
+                MeasureSpec.makeMeasureSpec(tabsWidth[a], MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(tabHeight, MeasureSpec.EXACTLY)
+            );
+        }
+        calculateTotalSizesAfterMeasure();
+    }
+
     public interface Tab {
         float measureTextWidth();
         default float measureTextWidth(float textSizeDp) { return measureTextWidth(); }
@@ -161,14 +359,10 @@ public class MainTabsLayout extends AnimatedLinearLayout {
 
 
 
-    // fills tabsTextWidth[] and return visible child count;
-
     private float[] tabsTextWidth;
     private float[] tabsTextWidthWithMargin;
     private int[] tabsWeight;
     private int[] tabsWidth;
-
-    private int[] tabsLeftPos;
 
 
     private int visibleChildCount;
@@ -180,7 +374,6 @@ public class MainTabsLayout extends AnimatedLinearLayout {
             tabsTextWidth = new float[childCount];
             tabsTextWidthWithMargin = new float[childCount];
             tabsWeight = new int[childCount];
-            tabsLeftPos = new int[childCount];
             tabsWidth = new int[childCount];
         }
 
@@ -232,12 +425,33 @@ public class MainTabsLayout extends AnimatedLinearLayout {
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
         super.onLayout(changed, l, t, r, b);
         checkVisualWidth();
+        if (liquidTabsBackground != null) {
+            liquidTabsBackground.setBounds(0, 0, getWidth(), getHeight());
+            liquidPanelBounds.set(liquidTabsBackground.getPaddedBounds());
+            liquidHiddenTabsBackground.setBounds(
+                Math.round(liquidPanelBounds.left),
+                getPaddingTop(),
+                Math.round(liquidPanelBounds.right),
+                getHeight() - getPaddingBottom()
+            );
+        }
+        if (!liquidTracking && !liquidPositionAnimation.isRunning()) {
+            syncLiquidSelectorToSelectedTab();
+        }
     }
 
     @Override
     protected void onItemsChanged() {
         super.onItemsChanged();
         checkVisualWidth();
+    }
+
+    @Override
+    public void onDescendantInvalidated(@NonNull View child, @NonNull View target) {
+        super.onDescendantInvalidated(child, target);
+        if (layeredCaptureSource != null) {
+            layeredCaptureSource.invalidateConsumers();
+        }
     }
 
     private void checkVisualWidth() {
@@ -262,6 +476,42 @@ public class MainTabsLayout extends AnimatedLinearLayout {
                 ((GlassTabView) child).setSelected(child == tab, animated);
             }
         }
+        if (liquidSelectorDrawable != null && tab != null && !liquidTracking) {
+            moveLiquidSelectorToTab(tab, animated);
+        }
+    }
+
+    private void moveLiquidSelectorToTab(View tab, boolean animated) {
+        final float targetX = getCenterX(tab);
+        if (!animated) {
+            liquidPositionAnimation.cancel();
+            liquidVelocityAnimation.cancel();
+            liquidPressAnimation.cancel();
+            liquidScaleXAnimation.cancel();
+            liquidScaleYAnimation.cancel();
+            liquidSelectorCenterX = targetX;
+            liquidSelectorVelocity = 0f;
+            liquidPressProgress = 0f;
+            liquidSelectorScaleX = 1f;
+            liquidSelectorScaleY = 1f;
+            liquidReleasePending = false;
+            invalidateLiquidContent();
+            return;
+        }
+        if (liquidReleasePending && Math.abs(liquidReleaseTargetX - targetX) < 0.5f) {
+            return;
+        }
+        if (!liquidReleasePending && Math.abs(liquidSelectorCenterX - targetX) < 0.5f) {
+            return;
+        }
+        liquidReleaseTargetX = targetX;
+        liquidReleasePending = true;
+        liquidPressAnimation.animateToFinalPosition(1f);
+        liquidScaleXAnimation.animateToFinalPosition(LIQUID_PRESSED_SCALE);
+        liquidScaleYAnimation.animateToFinalPosition(LIQUID_PRESSED_SCALE);
+        liquidPositionAnimation.getSpring().setStiffness(1000f).setDampingRatio(1f);
+        liquidPositionAnimation.animateToFinalPosition(targetX);
+        postOnAnimation(this::maybeFinishLiquidRelease);
     }
 
     private View findSelectedTab() {
@@ -284,16 +534,13 @@ public class MainTabsLayout extends AnimatedLinearLayout {
 
     private boolean drawCustomSelector;
     private void setSkipDrawSelector(boolean skipDrawSelector) {
-        drawCustomSelector = skipDrawSelector;
+        skipDrawSelector = skipDrawSelector || liquidSelectorDrawable != null;
+        drawCustomSelector = skipDrawSelector && liquidSelectorDrawable == null;
         if (drawCustomSelector) {
             selectorPaint.setColor(Theme.multAlpha(Theme.getColor(Theme.key_glass_tabSelected, resourcesProvider), 0.09f));
         }
         for (int a = 0, N = getChildCount(); a < N; a++) {
             final View child = getChildAt(a);
-            if (child.getVisibility() != View.VISIBLE) {
-                continue;
-            }
-
             if (child instanceof GlassTabView) {
                 ((GlassTabView) child).setSkipDrawSelector(skipDrawSelector);
             }
@@ -309,6 +556,27 @@ public class MainTabsLayout extends AnimatedLinearLayout {
 
     @Override
     protected void dispatchDraw(@NonNull Canvas canvas) {
+        final boolean liquid = liquidSelectorDrawable != null;
+        if (liquid) {
+            applyLiquidPanelSourceOffset();
+            canvas.save();
+            canvas.translate(liquidPanelOffsetX, 0f);
+        }
+        if (liquidSelectorDrawable != null) {
+            final float panelScale = getLiquidPanelScale();
+            canvas.save();
+            canvas.scale(panelScale, panelScale, getWidth() * 0.5f, getHeight() * 0.5f);
+            liquidTabsBackground.draw(canvas);
+            surfaceTouchLighting.render(
+                canvas,
+                liquidPanelBounds,
+                liquidSelectorCenterX,
+                getHeight() * 0.5f,
+                liquidInteractiveProgress
+            );
+            canvas.restore();
+            drawLiquidSelector(canvas);
+        }
         if (drawCustomSelector) {
             final float x = animatedLongSelectedViewCenterX + animatedLongSelectedViewOffsetX;
             final float sWidth = getInterpolatedWidthByX(x, this);
@@ -319,14 +587,264 @@ public class MainTabsLayout extends AnimatedLinearLayout {
                     x + sWidth / 2f, (getHeight() + sHeight) / 2f,
                     sHeight / 2f, sHeight / 2f, selectorPaint);
         }
+        if (liquidSelectorDrawable != null && !liquidSelectorRect.isEmpty()) {
+            canvas.save();
+            liquidSelectorPath.rewind();
+            liquidSelectorPath.addRoundRect(
+                liquidSelectorRect,
+                liquidSelectorRect.height() * 0.5f,
+                liquidSelectorRect.height() * 0.5f,
+                Path.Direction.CW
+            );
+            canvas.clipOutPath(liquidSelectorPath);
+            final float panelScale = getLiquidPanelScale();
+            canvas.scale(panelScale, panelScale, getWidth() * 0.5f, getHeight() * 0.5f);
+            super.dispatchDraw(canvas);
+            canvas.restore();
+        } else {
+            super.dispatchDraw(canvas);
+        }
+        if (liquid) {
+            canvas.restore();
+        }
+    }
 
-        super.dispatchDraw(canvas);
+    private void applyLiquidPanelSourceOffset() {
+        final float baseOffsetX = liquidTabsBackground.getSourceOffsetX() - liquidAppliedPanelOffsetX;
+        final float offsetY = liquidTabsBackground.getSourceOffsetY();
+        liquidAppliedPanelOffsetX = liquidPanelOffsetX;
+        liquidTabsBackground.setSourceOffset(baseOffsetX + liquidPanelOffsetX, offsetY);
+        liquidHiddenTabsBackground.setSourceOffset(baseOffsetX + liquidPanelOffsetX, offsetY);
+        liquidSelectorDrawable.setSourceOffset(baseOffsetX + liquidPanelOffsetX, offsetY);
+    }
+
+    private float getLiquidPanelScale() {
+        return getWidth() > 0
+            ? 1f + dp(16) / (float) getWidth() * liquidPressProgress
+            : 1f;
+    }
+
+    private void drawLiquidSelector(Canvas canvas) {
+        final float normalWidth = getInterpolatedWidthByX(liquidSelectorCenterX, this);
+        final float normalHeight = getHeight() - getPaddingTop() - getPaddingBottom();
+        if (normalWidth <= 0f || normalHeight <= 0f) {
+            liquidSelectorRect.setEmpty();
+            return;
+        }
+        final float velocity = liquidSelectorVelocity / 10f;
+        final float velocityX = Math.max(-0.2f, Math.min(0.2f, velocity * 0.75f));
+        final float velocityY = Math.max(-0.2f, Math.min(0.2f, velocity * 0.25f));
+        final float scaleX = liquidSelectorScaleX / (1f - velocityX);
+        final float scaleY = liquidSelectorScaleY * (1f - velocityY);
+        final float scaledWidth = normalWidth * scaleX;
+        final float scaledHeight = normalHeight * scaleY;
+        final float centerY = getHeight() * 0.5f;
+        final float selectorRadius = scaledHeight * 0.5f;
+        if (Float.isNaN(liquidSelectorRadius) || Math.abs(liquidSelectorRadius - selectorRadius) > 0.1f) {
+            liquidSelectorRadius = selectorRadius;
+            liquidSelectorDrawable.setRadius(selectorRadius);
+        }
+        liquidSelectorDrawable.setThickness(
+            Math.max(1, Math.round(dp(10) * liquidPressProgress * scaleY))
+        );
+        liquidSelectorDrawable.setOpticalDisplacement(
+            dp(14) * liquidPressProgress * scaleY
+        );
+
+        liquidSelectorRect.set(
+            liquidSelectorCenterX - scaledWidth * 0.5f,
+            centerY - scaledHeight * 0.5f,
+            liquidSelectorCenterX + scaledWidth * 0.5f,
+            centerY + scaledHeight * 0.5f
+        );
+
+        liquidSelectorDrawable.setBounds(
+            Math.round(liquidSelectorRect.left),
+            Math.round(liquidSelectorRect.top),
+            Math.round(liquidSelectorRect.right),
+            Math.round(liquidSelectorRect.bottom)
+        );
+        liquidSelectorDrawable.setSourceOffset(
+            liquidTabsBackground.getSourceOffsetX(),
+            liquidTabsBackground.getSourceOffsetY()
+        );
+        liquidHiddenTabsBackground.setSourceOffset(
+            liquidTabsBackground.getSourceOffsetX(),
+            liquidTabsBackground.getSourceOffsetY()
+        );
+        liquidSelectorDrawable.draw(canvas);
+    }
+
+    private float getLiquidCentersRange() {
+        float first = Float.NaN;
+        float last = Float.NaN;
+        for (int i = 0; i < getChildCount(); i++) {
+            final View child = getChildAt(i);
+            if (child.getVisibility() != View.VISIBLE) {
+                continue;
+            }
+            final float center = getCenterX(child);
+            if (Float.isNaN(first)) {
+                first = center;
+            }
+            last = center;
+        }
+        return Float.isNaN(first) || Float.isNaN(last) ? 0f : last - first;
+    }
+
+    private void syncLiquidSelectorToSelectedTab() {
+        if (liquidSelectorDrawable == null) {
+            return;
+        }
+        final View selected = findSelectedTab();
+        if (selected == null || selected.getWidth() == 0) {
+            return;
+        }
+        liquidSelectorCenterX = getCenterX(selected);
+        liquidSelectorVelocity = 0f;
+        liquidSelectorPositionTime = 0L;
+        liquidPositionAnimation.setStartValue(liquidSelectorCenterX);
+        invalidateLiquidGeometry();
+    }
+
+    private void invalidateLiquidContent() {
+        if (liquidSelectorDrawable == null) {
+            return;
+        }
+        liquidSelectorDrawable.setEdgeLightingStrength(liquidPressProgress);
+        liquidSelectorDrawable.setShadowAlpha(liquidPressProgress);
+        liquidSelectorDrawable.setSurfaceTintColor(
+            Theme.multAlpha(Color.BLACK, 0.03f * liquidPressProgress)
+        );
+        liquidSelectorDrawable.setInsetShadow(
+            dp(8) * liquidPressProgress,
+            liquidPressProgress
+        );
+        liquidHiddenTabsBackground.setThickness(Math.max(1, Math.round(dp(24) * liquidPressProgress)));
+        liquidHiddenTabsBackground.setOpticalDisplacement(dp(24) * liquidPressProgress);
+        liquidHiddenTabsBackground.setEdgeLightingStrength(liquidPressProgress);
+        liquidHiddenTabsBackground.updateColors();
+        liquidSelectorDrawable.updateColors();
+        layeredCaptureSource.invalidateConsumers();
+        invalidate();
+    }
+
+    private void invalidateLiquidGeometry() {
+        if (liquidSelectorDrawable != null) {
+            invalidate();
+        }
+    }
+
+    public void syncGlassSelectionPalette() {
+        if (liquidSelectorDrawable == null) {
+            invalidate();
+            return;
+        }
+        liquidTabsBackground.updateColors();
+        liquidHiddenTabsBackground.updateColors();
+        liquidSelectorDrawable.updateColors();
+        layeredCaptureSource.invalidateConsumers();
+        invalidate();
     }
 
 
     final Paint selectorPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     final SpringAnimation scaleX = new SpringAnimation(this, DynamicAnimation.SCALE_X, 1f);
     final SpringAnimation scaleY = new SpringAnimation(this, DynamicAnimation.SCALE_Y, 1f);
+    final SpringAnimation liquidPressAnimation = new SpringAnimation(this, new FloatPropertyCompat<MainTabsLayout>("liquidPressProgress") {
+        @Override
+        public float getValue(MainTabsLayout object) {
+            return object.liquidPressProgress;
+        }
+
+        @Override
+        public void setValue(MainTabsLayout object, float value) {
+            object.liquidPressProgress = value;
+            object.invalidateLiquidContent();
+        }
+    });
+    final SpringAnimation liquidScaleXAnimation = new SpringAnimation(this, new FloatPropertyCompat<MainTabsLayout>("liquidSelectorScaleX") {
+        @Override
+        public float getValue(MainTabsLayout object) {
+            return object.liquidSelectorScaleX;
+        }
+
+        @Override
+        public void setValue(MainTabsLayout object, float value) {
+            object.liquidSelectorScaleX = value;
+            object.invalidateLiquidGeometry();
+        }
+    });
+    final SpringAnimation liquidScaleYAnimation = new SpringAnimation(this, new FloatPropertyCompat<MainTabsLayout>("liquidSelectorScaleY") {
+        @Override
+        public float getValue(MainTabsLayout object) {
+            return object.liquidSelectorScaleY;
+        }
+
+        @Override
+        public void setValue(MainTabsLayout object, float value) {
+            object.liquidSelectorScaleY = value;
+            object.invalidateLiquidGeometry();
+        }
+    });
+    final SpringAnimation liquidInteractiveAnimation = new SpringAnimation(this, new FloatPropertyCompat<MainTabsLayout>("liquidInteractiveProgress") {
+        @Override
+        public float getValue(MainTabsLayout object) {
+            return object.liquidInteractiveProgress;
+        }
+
+        @Override
+        public void setValue(MainTabsLayout object, float value) {
+            object.liquidInteractiveProgress = value;
+            object.invalidate();
+        }
+    });
+    final SpringAnimation liquidVelocityAnimation = new SpringAnimation(this, new FloatPropertyCompat<MainTabsLayout>("liquidSelectorVelocity") {
+        @Override
+        public float getValue(MainTabsLayout object) {
+            return object.liquidSelectorVelocity;
+        }
+
+        @Override
+        public void setValue(MainTabsLayout object, float value) {
+            object.liquidSelectorVelocity = value;
+            object.invalidateLiquidGeometry();
+        }
+    });
+    final SpringAnimation liquidPanelOffsetAnimation = new SpringAnimation(this, new FloatPropertyCompat<MainTabsLayout>("liquidPanelDragOffset") {
+        @Override
+        public float getValue(MainTabsLayout object) {
+            return object.liquidPanelDragOffset;
+        }
+
+        @Override
+        public void setValue(MainTabsLayout object, float value) {
+            object.setLiquidPanelDragOffset(value);
+        }
+    });
+    final SpringAnimation liquidPositionAnimation = new SpringAnimation(this, new FloatPropertyCompat<MainTabsLayout>("liquidSelectorCenterX") {
+        @Override
+        public float getValue(MainTabsLayout object) {
+            return object.liquidSelectorCenterX;
+        }
+
+        @Override
+        public void setValue(MainTabsLayout object, float value) {
+            final long now = System.nanoTime();
+            if (object.liquidTracking && object.liquidSelectorPositionTime != 0L) {
+                final float dt = (now - object.liquidSelectorPositionTime) / 1_000_000_000f;
+                if (dt > 0f) {
+                    final float range = Math.max(object.getLiquidCentersRange(), 1f);
+                    final float velocity = (value - object.liquidSelectorCenterX) / dt / range;
+                    object.liquidVelocityAnimation.animateToFinalPosition(velocity);
+                }
+            }
+            object.liquidSelectorPositionTime = now;
+            object.liquidSelectorCenterX = value;
+            object.maybeFinishLiquidRelease();
+            object.invalidateLiquidGeometry();
+        }
+    });
 
     final SpringAnimation selectedTabPositionOffsetX = new SpringAnimation(this, new FloatPropertyCompat<MainTabsLayout>("selectedTabPositionOffsetX") {
         @Override
@@ -366,6 +884,33 @@ public class MainTabsLayout extends AnimatedLinearLayout {
         selectedTabPositionX.setSpring(new SpringForce(1f)
             .setStiffness(SpringForce.STIFFNESS_MEDIUM)
             .setDampingRatio(SpringForce.DAMPING_RATIO_LOW_BOUNCY));
+        liquidPressAnimation.setSpring(new SpringForce(0f)
+            .setStiffness(1000f)
+            .setDampingRatio(1f));
+        liquidScaleXAnimation.setSpring(new SpringForce(1f)
+            .setStiffness(250f)
+            .setDampingRatio(0.6f));
+        liquidScaleYAnimation.setSpring(new SpringForce(1f)
+            .setStiffness(250f)
+            .setDampingRatio(0.7f));
+        liquidPositionAnimation.setSpring(new SpringForce(0f)
+            .setStiffness(1000f)
+            .setDampingRatio(1f));
+        liquidVelocityAnimation.setSpring(new SpringForce(0f)
+            .setStiffness(300f)
+            .setDampingRatio(0.5f));
+        liquidPanelOffsetAnimation.setSpring(new SpringForce(0f)
+            .setStiffness(300f)
+            .setDampingRatio(0.5f));
+        liquidInteractiveAnimation.setSpring(new SpringForce(0f)
+            .setStiffness(300f)
+            .setDampingRatio(0.5f));
+        liquidPressAnimation.setMinimumVisibleChange(0.001f);
+        liquidScaleXAnimation.setMinimumVisibleChange(0.001f);
+        liquidScaleYAnimation.setMinimumVisibleChange(0.001f);
+        liquidVelocityAnimation.setMinimumVisibleChange(0.01f);
+        liquidPanelOffsetAnimation.setMinimumVisibleChange(0.001f);
+        liquidInteractiveAnimation.setMinimumVisibleChange(0.001f);
     }
 
     private float animatedLongSelectedViewCenterX;
@@ -376,6 +921,12 @@ public class MainTabsLayout extends AnimatedLinearLayout {
     private float lastLongSelectedViewWidth;
     private View lastLongSelectedView;
 
+    private final Set<View> tabsWithIgnoreClick = new HashSet<>();
+
+    public void addTabToIgnoreClick(View view) {
+        tabsWithIgnoreClick.add(view);
+    }
+
 
 
 
@@ -385,8 +936,24 @@ public class MainTabsLayout extends AnimatedLinearLayout {
 
             if (child.getVisibility() != View.VISIBLE) continue;
 
-            if (x >= child.getLeft() && x <= child.getRight()
-                    && y >= child.getTop() && y <= child.getBottom()) {
+            if (x >= child.getX() && x <= child.getX() + child.getWidth()
+                    && y >= child.getY() && y <= child.getY() + child.getHeight()) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private static View findLegacyChildUnder(ViewGroup parent, float x, float y) {
+        for (int i = parent.getChildCount() - 1; i >= 0; i--) {
+            final View child = parent.getChildAt(i);
+            if (child.getVisibility() != View.VISIBLE) {
+                continue;
+            }
+            if (x >= child.getLeft() &&
+                x <= child.getRight() &&
+                y >= child.getTop() &&
+                y <= child.getBottom()) {
                 return child;
             }
         }
@@ -428,11 +995,6 @@ public class MainTabsLayout extends AnimatedLinearLayout {
         }
     }
 
-    private final Set<View> tabsWithIgnoreClick = new HashSet<>();
-    public void addTabToIgnoreClick(View v) {
-        tabsWithIgnoreClick.add(v);
-    }
-
     private final BoolAnimator animatorIsScaled = new BoolAnimator(0, (a, factor, c, g) -> {
         setScaleX(lerp(1, 1.019f, factor));
         setScaleY(lerp(1, 1.019f, factor));
@@ -442,7 +1004,7 @@ public class MainTabsLayout extends AnimatedLinearLayout {
         @Override
         public boolean needClickAt(View view, float x, float y) {
             lastLongSelectedView = null;
-            final View found = findChildUnder(MainTabsLayout.this, x, y);
+            final View found = findLegacyChildUnder(MainTabsLayout.this, x, y);
             return found != null && !tabsWithIgnoreClick.contains(found);
         }
 
@@ -605,8 +1167,233 @@ public class MainTabsLayout extends AnimatedLinearLayout {
 
     @Override
     public boolean dispatchTouchEvent(MotionEvent ev) {
+        if (liquidSelectorDrawable != null) {
+            return dispatchLiquidTouchEvent(ev);
+        }
         clickHelper.onTouchEvent(this, ev);
         return super.dispatchTouchEvent(ev);
+    }
+
+    private boolean dispatchLiquidTouchEvent(MotionEvent ev) {
+        final int action = ev.getActionMasked();
+        if (action == MotionEvent.ACTION_DOWN) {
+            cancelPendingLiquidLongPress();
+            liquidPointerId = ev.getPointerId(0);
+            liquidDownTime = ev.getDownTime();
+            liquidLastTouchX = ev.getX();
+            liquidLastTouchY = ev.getY();
+            liquidDownX = liquidLastTouchX;
+            liquidDownY = liquidLastTouchY;
+            liquidDownTab = findChildUnder(this, liquidLastTouchX, liquidLastTouchY);
+            if (liquidDownTab == null) {
+                liquidGestureState = LiquidGestureState.IDLE;
+                return super.dispatchTouchEvent(ev);
+            }
+            if (liquidDownTab == findSelectedTab()) {
+                liquidGestureState = LiquidGestureState.TRACKING;
+                startLiquidTracking(liquidDownTab, liquidLastTouchX);
+                if (getParent() != null) {
+                    getParent().requestDisallowInterceptTouchEvent(true);
+                }
+                return true;
+            }
+            liquidGestureState = LiquidGestureState.PENDING_LONG_PRESS;
+            postDelayed(
+                liquidLongPressRunnable,
+                ViewConfiguration.getLongPressTimeout() * 3L / 4L
+            );
+            return super.dispatchTouchEvent(ev);
+        }
+
+        final int pointerIndex = liquidPointerId == MotionEvent.INVALID_POINTER_ID
+            ? -1
+            : ev.findPointerIndex(liquidPointerId);
+        if (pointerIndex >= 0) {
+            liquidLastTouchX = ev.getX(pointerIndex);
+            liquidLastTouchY = ev.getY(pointerIndex);
+        }
+
+        if (liquidGestureState == LiquidGestureState.PENDING_LONG_PRESS) {
+            final boolean activePointerUp =
+                action == MotionEvent.ACTION_POINTER_UP &&
+                    ev.getPointerId(ev.getActionIndex()) == liquidPointerId;
+            final float dx = liquidLastTouchX - liquidDownX;
+            final float dy = liquidLastTouchY - liquidDownY;
+            final int touchSlop = ViewConfiguration.get(getContext()).getScaledTouchSlop();
+            if (action == MotionEvent.ACTION_UP ||
+                action == MotionEvent.ACTION_CANCEL ||
+                activePointerUp ||
+                pointerIndex < 0 ||
+                dx * dx + dy * dy > touchSlop * touchSlop) {
+                cancelPendingLiquidLongPress();
+            }
+            return super.dispatchTouchEvent(ev);
+        }
+
+        if (liquidGestureState == LiquidGestureState.TRACKING) {
+            if (action == MotionEvent.ACTION_MOVE) {
+                moveLiquidTracking(liquidLastTouchX);
+            } else if (action == MotionEvent.ACTION_UP) {
+                finishLiquidTracking(true);
+                resetLiquidGesture();
+            } else if (action == MotionEvent.ACTION_CANCEL ||
+                action == MotionEvent.ACTION_POINTER_UP &&
+                    ev.getPointerId(ev.getActionIndex()) == liquidPointerId) {
+                finishLiquidTracking(false);
+                resetLiquidGesture();
+            }
+            return true;
+        }
+
+        return super.dispatchTouchEvent(ev);
+    }
+
+    private void startPendingLiquidLongPress() {
+        if (liquidGestureState != LiquidGestureState.PENDING_LONG_PRESS ||
+            liquidDownTab == null ||
+            !isViewVisible(liquidDownTab)) {
+            return;
+        }
+        performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+        liquidGestureState = LiquidGestureState.TRACKING;
+        startLiquidTrackingFromInactive(
+            liquidDownTab,
+            liquidLastTouchX,
+            liquidLastTouchY
+        );
+        if (getParent() != null) {
+            getParent().requestDisallowInterceptTouchEvent(true);
+        }
+    }
+
+    private void cancelPendingLiquidLongPress() {
+        removeCallbacks(liquidLongPressRunnable);
+        if (liquidGestureState == LiquidGestureState.PENDING_LONG_PRESS) {
+            liquidGestureState = LiquidGestureState.IDLE;
+            liquidDownTab = null;
+            liquidPointerId = MotionEvent.INVALID_POINTER_ID;
+        }
+    }
+
+    private void resetLiquidGesture() {
+        removeCallbacks(liquidLongPressRunnable);
+        liquidGestureState = LiquidGestureState.IDLE;
+        liquidDownTab = null;
+        liquidPointerId = MotionEvent.INVALID_POINTER_ID;
+        if (getParent() != null) {
+            getParent().requestDisallowInterceptTouchEvent(false);
+        }
+    }
+
+    private void startLiquidTrackingFromInactive(View target, float touchX, float touchY) {
+        liquidTracking = true;
+        liquidTargetTab = target;
+        liquidReleasePending = false;
+        liquidLastTouchX = touchX;
+        liquidPositionAnimation.cancel();
+        liquidVelocityAnimation.cancel();
+        liquidSelectorVelocity = 0f;
+        liquidSelectorPositionTime = 0L;
+        liquidPressAnimation.animateToFinalPosition(1f);
+        liquidInteractiveAnimation.animateToFinalPosition(1f);
+        liquidScaleXAnimation.animateToFinalPosition(LIQUID_PRESSED_SCALE);
+        liquidScaleYAnimation.animateToFinalPosition(LIQUID_PRESSED_SCALE);
+        liquidPositionAnimation.getSpring().setStiffness(1000f).setDampingRatio(1f);
+        liquidPositionAnimation.animateToFinalPosition(getCenterX(target));
+        final MotionEvent cancel = MotionEvent.obtain(
+            liquidDownTime,
+            android.os.SystemClock.uptimeMillis(),
+            MotionEvent.ACTION_CANCEL,
+            touchX,
+            touchY,
+            0
+        );
+        super.dispatchTouchEvent(cancel);
+        cancel.recycle();
+        invalidateLiquidGeometry();
+    }
+
+    private void startLiquidTracking(View selected, float touchX) {
+        liquidTracking = true;
+        liquidTargetTab = selected;
+        liquidReleasePending = false;
+        liquidLastTouchX = touchX;
+        liquidPositionAnimation.cancel();
+        liquidVelocityAnimation.cancel();
+        liquidSelectorCenterX = getCenterX(selected);
+        liquidSelectorVelocity = 0f;
+        liquidSelectorPositionTime = 0L;
+        liquidPressAnimation.animateToFinalPosition(1f);
+        liquidInteractiveAnimation.animateToFinalPosition(1f);
+        liquidScaleXAnimation.animateToFinalPosition(LIQUID_PRESSED_SCALE);
+        liquidScaleYAnimation.animateToFinalPosition(LIQUID_PRESSED_SCALE);
+        invalidateLiquidGeometry();
+    }
+
+    private void moveLiquidTracking(float x) {
+        final float dragAmount = x - liquidLastTouchX;
+        liquidLastTouchX = x;
+        liquidPanelOffsetAnimation.cancel();
+        setLiquidPanelDragOffset(liquidPanelDragOffset + dragAmount);
+        x = clampXToChildrenCenters(x, this);
+        liquidPositionAnimation.getSpring().setStiffness(1000f).setDampingRatio(1f);
+        liquidPositionAnimation.animateToFinalPosition(x);
+        final View found = findNearestVisibleChildByX(x, this);
+        if (found != null && found != liquidTargetTab) {
+            liquidTargetTab = found;
+        }
+    }
+
+    private void finishLiquidTracking(boolean performClick) {
+        liquidTracking = false;
+        final View target;
+        if (performClick) {
+            target = liquidTargetTab;
+        } else {
+            target = findSelectedTab();
+            liquidTargetTab = target;
+        }
+        if (target != null) {
+            liquidReleaseTargetX = getCenterX(target);
+            liquidReleasePending = true;
+            liquidPositionAnimation.getSpring().setStiffness(1000f).setDampingRatio(1f);
+            liquidPositionAnimation.animateToFinalPosition(liquidReleaseTargetX);
+        }
+        liquidVelocityAnimation.animateToFinalPosition(0f);
+        liquidPanelOffsetAnimation.animateToFinalPosition(0f);
+        liquidInteractiveAnimation.animateToFinalPosition(0f);
+        postOnAnimation(this::maybeFinishLiquidRelease);
+        if (performClick && target != null) {
+            target.performClick();
+        }
+        liquidTargetTab = null;
+    }
+
+    private void setLiquidPanelDragOffset(float value) {
+        liquidPanelDragOffset = value;
+        final float fraction = getWidth() > 0
+            ? Math.max(-1f, Math.min(1f, value / getWidth()))
+            : 0f;
+        liquidPanelOffsetX = dp(4)
+            * Math.signum(fraction)
+            * CubicBezierInterpolator.EASE_OUT.getInterpolation(Math.abs(fraction));
+        invalidateLiquidContent();
+    }
+
+    private void maybeFinishLiquidRelease() {
+        if (!liquidReleasePending) {
+            return;
+        }
+        final float threshold = Math.max(getLiquidCentersRange() * 0.025f, 0.001f);
+        if (Math.abs(liquidSelectorCenterX - liquidReleaseTargetX) >= threshold) {
+            return;
+        }
+        liquidReleasePending = false;
+        postOnAnimation(() -> {
+            liquidPressAnimation.animateToFinalPosition(0f);
+            liquidScaleXAnimation.animateToFinalPosition(1f);
+            liquidScaleYAnimation.animateToFinalPosition(1f);
+        });
     }
 
 

--- a/TMessagesProj/src/main/res/raw/glass_surface_edge_shader.agsl
+++ b/TMessagesProj/src/main/res/raw/glass_surface_edge_shader.agsl
@@ -1,0 +1,36 @@
+uniform float2 size;
+uniform float4 cornerRadii;
+uniform float angle;
+uniform float falloff;
+
+float resolveEdgeRadius(float2 coord, float4 radii) {
+    if (coord.x >= 0.0) {
+        if (coord.y <= 0.0) return radii.y;
+        else return radii.z;
+    } else {
+        if (coord.y <= 0.0) return radii.x;
+        else return radii.w;
+    }
+}
+
+float2 resolveEdgeGradient(float2 coord, float2 halfSize, float radius) {
+    float2 cornerCoord = abs(coord) - (halfSize - float2(radius));
+    if (cornerCoord.x >= 0.0 || cornerCoord.y >= 0.0) {
+        return sign(coord) * normalize(max(cornerCoord, 0.0));
+    } else {
+        float gradX = step(cornerCoord.y, cornerCoord.x);
+        return sign(coord) * float2(gradX, 1.0 - gradX);
+    }
+}
+
+half4 main(float2 coord) {
+    float2 halfSize = size * 0.5;
+    float2 centeredCoord = coord - halfSize;
+    float radius = resolveEdgeRadius(centeredCoord, cornerRadii);
+    float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
+    float2 grad = resolveEdgeGradient(centeredCoord, halfSize, gradRadius);
+    float2 normal = float2(cos(angle), sin(angle));
+    float d = dot(grad, normal);
+    float intensity = pow(abs(d), falloff);
+    return half4(1.0) * intensity;
+}

--- a/TMessagesProj/src/main/res/raw/glass_surface_touch_shader.agsl
+++ b/TMessagesProj/src/main/res/raw/glass_surface_touch_shader.agsl
@@ -1,0 +1,8 @@
+uniform float radius;
+uniform float2 position;
+
+half4 main(float2 coord) {
+    float dist = distance(coord, position);
+    float intensity = smoothstep(radius, radius * 0.5, dist);
+    return half4(1.0) * intensity;
+}

--- a/TMessagesProj/src/main/res/raw/liquid_glass_shader.agsl
+++ b/TMessagesProj/src/main/res/raw/liquid_glass_shader.agsl
@@ -1,46 +1,87 @@
-uniform shader img;
+uniform shader content;
 
-uniform float2 resolution;
-uniform float2 center;
 uniform float2 size;
-uniform float4 radius;
-uniform float thickness;
-uniform float refract_index;
-uniform float refract_intensity;
-uniform float4 foreground_color_premultiplied;
+uniform float2 offset;
+uniform float4 cornerRadii;
+uniform float refractionHeight;
+uniform float refractionAmount;
+uniform float depthEffect;
+uniform float chromaticAberration;
 
-half sdfRect(half2 p, half4 r) {
-  r.xy = (p.x > 0.0) ? r.xy : r.zw;
-  r.x  = (p.y > 0.0) ? r.x  : r.y;
-  half2 q = abs(p) - size + r.x;
-  return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - r.x;
+float resolveCornerRadius(float2 coord, float4 radii) {
+    if (coord.x >= 0.0) {
+        if (coord.y <= 0.0) return radii.y;
+        else return radii.z;
+    } else {
+        if (coord.y <= 0.0) return radii.x;
+        else return radii.w;
+    }
 }
 
-half4 srcOver(half4 src, half4 dst) {
-    half3 outRGB = (src.rgb + dst.rgb * (1.0 - src.a));
-    float outA = src.a + (1.0 - src.a) * dst.a;
-    return half4(outRGB, outA);
+float signedSurfaceDistance(float2 coord, float2 halfSize, float radius) {
+    float2 cornerCoord = abs(coord) - (halfSize - float2(radius));
+    float outside = length(max(cornerCoord, 0.0)) - radius;
+    float inside = min(max(cornerCoord.x, cornerCoord.y), 0.0);
+    return outside + inside;
 }
 
-half4 main(in float2 fragCoord) {
-  half2 p = fragCoord - center;
-  half sd = sdfRect(p, radius);
-  half2 uv = fragCoord;
-  if (sd < 0.0) {
-    half sdX = sdfRect(p + half2(1.0, 0.0), radius);
-    half sdY = sdfRect(p + half2(0.0, 1.0), radius);
+float2 resolveSurfaceGradient(float2 coord, float2 halfSize, float radius) {
+    float2 cornerCoord = abs(coord) - (halfSize - float2(radius));
+    if (cornerCoord.x >= 0.0 || cornerCoord.y >= 0.0) {
+        return sign(coord) * normalize(max(cornerCoord, 0.0));
+    } else {
+        float gradX = step(cornerCoord.y, cornerCoord.x);
+        return sign(coord) * float2(gradX, 1.0 - gradX);
+    }
+}
 
-    half n_cos = max(thickness + sd, 0.0) / thickness;
-    half n_cos2 = n_cos * n_cos;
-    half n_sin = sqrt(1.0 - n_cos2);
-    half3 normal = normalize(half3((sdX - sd) * n_cos, (sdY - sd) * n_cos, n_sin));
+float mapLensCurve(float x) {
+    return 1.0 - sqrt(1.0 - x * x);
+}
 
-    half3 refract_vec = refract(half3(0.0, 0.0, -1.0), normal, 1.0 / refract_index);
-    half h = sd < -thickness ? thickness : sqrt(sd * (-2.0 * thickness - sd));
-    half refract_length = (h + 8.0 * thickness) / -refract_vec.z;
-
-    uv += refract_vec.xy * refract_length * refract_intensity;
-  }
-
-  return srcOver(half4(foreground_color_premultiplied), img.eval(uv));
+half4 main(float2 coord) {
+    float2 halfSize = size * 0.5;
+    float2 centeredCoord = (coord + offset) - halfSize;
+    float radius = resolveCornerRadius(centeredCoord, cornerRadii);
+    float sd = signedSurfaceDistance(centeredCoord, halfSize, radius);
+    if (-sd >= refractionHeight) {
+        return content.eval(coord);
+    }
+    sd = min(sd, 0.0);
+    float d = mapLensCurve(1.0 - -sd / refractionHeight) * refractionAmount;
+    float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
+    float2 grad = normalize(resolveSurfaceGradient(centeredCoord, halfSize, gradRadius) + depthEffect * normalize(centeredCoord));
+    float2 refractedCoord = coord + d * grad;
+    if (chromaticAberration <= 0.0) {
+        return content.eval(refractedCoord);
+    }
+    float dispersionIntensity = chromaticAberration * ((centeredCoord.x * centeredCoord.y) / (halfSize.x * halfSize.y));
+    float2 dispersedCoord = d * grad * dispersionIntensity;
+    half4 color = half4(0.0);
+    half4 red = content.eval(refractedCoord + dispersedCoord);
+    color.r += red.r / 3.5;
+    color.a += red.a / 7.0;
+    half4 orange = content.eval(refractedCoord + dispersedCoord * (2.0 / 3.0));
+    color.r += orange.r / 3.5;
+    color.g += orange.g / 7.0;
+    color.a += orange.a / 7.0;
+    half4 yellow = content.eval(refractedCoord + dispersedCoord * (1.0 / 3.0));
+    color.r += yellow.r / 3.5;
+    color.g += yellow.g / 3.5;
+    color.a += yellow.a / 7.0;
+    half4 green = content.eval(refractedCoord);
+    color.g += green.g / 3.5;
+    color.a += green.a / 7.0;
+    half4 cyan = content.eval(refractedCoord - dispersedCoord * (1.0 / 3.0));
+    color.g += cyan.g / 3.5;
+    color.b += cyan.b / 3.0;
+    color.a += cyan.a / 7.0;
+    half4 blue = content.eval(refractedCoord - dispersedCoord * (2.0 / 3.0));
+    color.b += blue.b / 3.0;
+    color.a += blue.a / 7.0;
+    half4 purple = content.eval(refractedCoord - dispersedCoord);
+    color.r += purple.r / 7.0;
+    color.b += purple.b / 3.0;
+    color.a += purple.a / 7.0;
+    return color;
 }


### PR DESCRIPTION
## Summary

Here introduces an interactive Liquid Glass implementation for the bottom navigation.

## Changes

- Added RenderNode-based lens refraction and chromatic dispersion.
- Added directional edge lighting, inner shadows and dynamic highlights.
- Added dynamic transitions between outlined and filled tab icons.
- Added support for layouts with and without the Calls tab.

## Compatibility

The new rendering path is enabled only when:

- Android 13 or newer is used;
- Liquid Glass is enabled in Power Saving settings.

Other configurations continue to use the original Telegram navigation implementation.

## Testing

Tested on two physical Android devices.

Verified:

- single-tap navigation;
- long press and drag interactions;
- haptic feedback;
- tab selection animations;
- outlined and filled icon transitions;
- navigation with the Calls tab enabled;
- legacy behavior with Liquid Glass disabled;


https://github.com/user-attachments/assets/234fbeae-775a-437f-8e42-78f16004e84a



## Attribution

Portions of the optical rendering implementation are derived from [AndroidLiquidGlass / Backdrop by Kyant](https://github.com/Kyant0/AndroidLiquidGlass) and are licensed under Apache License 2.0.