### PR TITLE
Variant-sibling messages: switch between regenerated bot replies in place

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageVariantsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageVariantsController.java
@@ -1,0 +1,228 @@
+package org.telegram.messenger;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.SparseArray;
+
+import org.telegram.tgnet.TLRPC;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Per-account correlation store for "variant sibling" message groups: a set of real,
+ * independently-persisted TL_message rows that represent alternative answers to the same
+ * prompt, of which only one is shown at a time in the chat's visible render list. The others
+ * remain in MessagesStorage untouched -- this class only tracks which member of a group is
+ * currently "active" (shown) and which are hidden, plus enough bookkeeping (ordered member
+ * list, per-group active pointer) for a pager UI to page between them later.
+ *
+ * Deliberately independent of TLRPC.Message.grouped_id / MessageObject.GroupedMessages -- those
+ * drive native album/collage rendering and are not safe to repurpose for this (verified during
+ * planning). Message/group ids here are ints, matching TLRPC.Message.id / MessageObject.getId().
+ */
+public class MessageVariantsController {
+
+    private static final MessageVariantsController[] instances = new MessageVariantsController[UserConfig.MAX_ACCOUNT_COUNT];
+
+    private static final String PREFS_NAME_PREFIX = "message_variants_";
+    private static final String KEY_GROUP_OF = "group_";
+    private static final String KEY_MEMBERS = "members_";
+    private static final String KEY_ACTIVE = "active_";
+
+    private final int currentAccount;
+    // Not persisted -- rebuilt opportunistically as messages are observed (both the cache-reload
+    // and live filter hooks call observe() so this cache warms across a cold restart too).
+    private final SparseArray<MessageObject> objectCache = new SparseArray<>();
+
+    private RegenerateListener regenerateListener;
+
+    public interface RegenerateListener {
+        void onRegenerateRequested(MessageObject sourceMessage);
+    }
+
+    public static MessageVariantsController getInstance(int account) {
+        MessageVariantsController local = instances[account];
+        if (local == null) {
+            synchronized (MessageVariantsController.class) {
+                local = instances[account];
+                if (local == null) {
+                    local = instances[account] = new MessageVariantsController(account);
+                }
+            }
+        }
+        return local;
+    }
+
+    private MessageVariantsController(int account) {
+        this.currentAccount = account;
+    }
+
+    /**
+     * Registry of peers that author alternative answers to the same prompt, i.e. the peers whose
+     * messages this controller may group into variant packs.
+     *
+     * <p>This lives here, on the client, and NOT on a TL_user field: the bits of the TL schema are
+     * assigned by the server, so a client contribution cannot introduce one (upstream 12.9.0 took
+     * flags2 bit 21 for linked_community_id). The core stays product-agnostic -- it only ever knows
+     * a user id; the product layer registers its own bot at startup.
+     *
+     * <p>Static rather than per-account: the id of such a peer does not depend on the account, and
+     * a static registry keeps the predicate testable on a plain JVM.
+     *
+     * <p>In-memory only, deliberately not persisted: the registering layer knows its own peer ids
+     * and re-registers them synchronously on every cold start, before the first cell is drawn. If
+     * such peers ever have to be discovered at runtime instead, this registry needs to be persisted
+     * or rebuilt from the peer list.
+     */
+    private static final Set<Long> generativeBots = Collections.synchronizedSet(new HashSet<>());
+
+    /** Mark a peer as an author of alternative answers. Called by the product layer on startup. */
+    public static void registerGenerativeBot(long userId) {
+        if (userId != 0) {
+            generativeBots.add(userId);
+        }
+    }
+
+    /** True when the peer authors alternative answers. Null-safe by contract: 0 is never a peer. */
+    public static boolean isGenerativeBot(long userId) {
+        return userId != 0 && generativeBots.contains(userId);
+    }
+
+    /** Convenience overload for the render/dispatch call sites, which hold a user, not an id. */
+    public static boolean isGenerativeBot(TLRPC.User user) {
+        return user != null && isGenerativeBot(user.id);
+    }
+
+    private SharedPreferences prefs() {
+        return ApplicationLoader.applicationContext
+                .getSharedPreferences(PREFS_NAME_PREFIX + currentAccount, Context.MODE_PRIVATE);
+    }
+
+    // Start a new variant group anchored on `first`'s own message id (matches Telegram's own
+    // "id doubles as key" convention). Returns the new group id.
+    public int startGroup(MessageObject first) {
+        int groupId = first.getId();
+        SharedPreferences.Editor editor = prefs().edit();
+        editor.putInt(KEY_GROUP_OF + groupId, groupId);
+        editor.putString(KEY_MEMBERS + groupId, String.valueOf(groupId));
+        editor.putInt(KEY_ACTIVE + groupId, groupId);
+        editor.apply();
+        objectCache.put(groupId, first);
+        return groupId;
+    }
+
+    // Append a new sibling to an existing group and make it the active/shown member.
+    public void addSibling(int groupId, MessageObject sibling) {
+        int siblingId = sibling.getId();
+        int[] existing = memberIds(groupId);
+        StringBuilder sb = new StringBuilder();
+        for (int id : existing) {
+            sb.append(id).append(',');
+        }
+        sb.append(siblingId);
+        SharedPreferences.Editor editor = prefs().edit();
+        editor.putString(KEY_MEMBERS + groupId, sb.toString());
+        editor.putInt(KEY_GROUP_OF + siblingId, groupId);
+        editor.putInt(KEY_ACTIVE + groupId, siblingId);
+        editor.apply();
+        objectCache.put(siblingId, sibling);
+    }
+
+    public boolean isHidden(int messageId) {
+        int groupId = groupIdOf(messageId);
+        if (groupId == 0) {
+            return false;
+        }
+        return messageId != activeId(groupId);
+    }
+
+    public int groupIdOf(int messageId) {
+        return prefs().getInt(KEY_GROUP_OF + messageId, 0);
+    }
+
+    public int activeId(int groupId) {
+        return prefs().getInt(KEY_ACTIVE + groupId, 0);
+    }
+
+    public int[] memberIds(int groupId) {
+        String csv = prefs().getString(KEY_MEMBERS + groupId, null);
+        if (csv == null || csv.isEmpty()) {
+            return new int[0];
+        }
+        String[] parts = csv.split(",");
+        int[] ids = new int[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            ids[i] = Integer.parseInt(parts[i]);
+        }
+        return ids;
+    }
+
+    public int size(int groupId) {
+        return memberIds(groupId).length;
+    }
+
+    // 0-based position of the active member within memberIds -- for a future pager's counter.
+    public int indexOfActive(int groupId) {
+        int active = activeId(groupId);
+        int[] ids = memberIds(groupId);
+        for (int i = 0; i < ids.length; i++) {
+            if (ids[i] == active) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    // Page the active member by `delta`, wrapping at both ends (cyclic). Clamping into
+    // [0, size - 1] does not work here: addSibling always makes the NEWEST sibling active, i.e. the
+    // last index, and the swipe gesture in ChatActivity always pages +1 -- so from the last index a
+    // clamped page would be a permanent no-op and the swipe would appear dead. Cyclic paging makes
+    // every swipe land on a different sibling (with two variants: 2/2 -> 1/2 -> 2/2 ...) and keeps
+    // the tap arrows responsive at the edges too. Safe modulo handles a negative delta.
+    public int page(int groupId, int delta) {
+        int[] ids = memberIds(groupId);
+        if (ids.length == 0) {
+            return 0;
+        }
+        int index = indexOfActive(groupId);
+        if (index < 0) {
+            index = 0;
+        }
+        int newActive = ids[wrapIndex(index, delta, ids.length)];
+        prefs().edit().putInt(KEY_ACTIVE + groupId, newActive).apply();
+        return newActive;
+    }
+
+    // Pure cyclic-index math, extracted so the wrap invariant can be unit-tested on a plain JVM,
+    // without a device or SharedPreferences. Safe modulo handles a negative delta and |delta| > size.
+    // size must be > 0 -- page() guards ids.length == 0 before calling.
+    static int wrapIndex(int index, int delta, int size) {
+        return ((index + delta) % size + size) % size;
+    }
+
+    // Warm the object cache for a message that belongs to a group -- called from both
+    // ChatActivity filter hooks (cache-reload path and live path) so a later page/pager
+    // operation can retrieve a hidden sibling's MessageObject without a MessagesStorage
+    // round-trip, even across a cold restart.
+    public void observe(MessageObject mo) {
+        if (groupIdOf(mo.getId()) != 0) {
+            objectCache.put(mo.getId(), mo);
+        }
+    }
+
+    public MessageObject getCached(int messageId) {
+        return objectCache.get(messageId);
+    }
+
+    public void setRegenerateListener(RegenerateListener l) {
+        this.regenerateListener = l;
+    }
+
+    public void notifyRegenerateRequested(MessageObject sourceMessage) {
+        if (regenerateListener != null) {
+            regenerateListener.onRegenerateRequested(sourceMessage);
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
@@ -3319,6 +3319,7 @@ public class Theme {
     public static Drawable chat_closeIconDrawable;
     public static Drawable chat_moreIconDrawable;
     public static Drawable chat_goIconDrawable;
+    public static Drawable chat_regenerateIconDrawable;
     public static Drawable chat_botLinkDrawable;
     public static Drawable chat_botCardDrawable;
     public static Drawable chat_botInlineDrawable;
@@ -4214,6 +4215,7 @@ public class Theme {
     public static final String key_drawable_botInvite = "drawable_botInvite";
     public static final String key_drawable_commentSticker = "drawableCommentSticker";
     public static final String key_drawable_goIcon = "drawableGoIcon";
+    public static final String key_drawable_regenerateIcon = "drawableRegenerateIcon";
     public static final String key_drawable_msgError = "drawableMsgError";
     public static final String key_drawable_msgIn = "drawableMsgIn";
     public static final String key_drawable_msgInInstant = "drawableMsgInInstant";
@@ -8851,6 +8853,7 @@ public class Theme {
             chat_closeIconDrawable = resources.getDrawable(R.drawable.msg_voiceclose).mutate();
             chat_moreIconDrawable = resources.getDrawable(R.drawable.media_more).mutate();
             chat_goIconDrawable = resources.getDrawable(R.drawable.filled_open_message);
+            chat_regenerateIconDrawable = resources.getDrawable(R.drawable.msg_regenerate);
 
             int rad = dp(2);
             RectF rect = new RectF();
@@ -8909,6 +8912,7 @@ public class Theme {
             addChatDrawable(key_drawable_botLink, chat_botLinkDrawable, key_chat_serviceIcon);
             addChatDrawable(key_drawable_botInvite, chat_botInviteDrawable, key_chat_serviceIcon);
             addChatDrawable(key_drawable_goIcon, chat_goIconDrawable, key_chat_serviceIcon);
+            addChatDrawable(key_drawable_regenerateIcon, chat_regenerateIconDrawable, key_chat_serviceIcon);
             addChatDrawable(key_drawable_commentSticker, chat_commentStickerDrawable, key_chat_serviceIcon);
             addChatDrawable(key_drawable_msgError, chat_msgErrorDrawable, key_chat_sentErrorIcon);
             addChatDrawable(key_drawable_msgIn, chat_msgInDrawable, -1);
@@ -9044,6 +9048,7 @@ public class Theme {
             setDrawableColorByKey(chat_shareIconDrawable, key_chat_serviceIcon);
             setDrawableColorByKey(chat_replyIconDrawable, key_chat_serviceIcon);
             setDrawableColorByKey(chat_goIconDrawable, key_chat_serviceIcon);
+            setDrawableColorByKey(chat_regenerateIconDrawable, key_chat_serviceIcon);
             setDrawableColorByKey(chat_botInlineDrawable, key_chat_serviceIcon);
             setDrawableColorByKey(chat_botWebViewDrawable, key_chat_serviceIcon);
             setDrawableColorByKey(chat_botLockDrawable, key_chat_lockIcon);
@@ -9278,6 +9283,7 @@ public class Theme {
             setDrawableColor(chat_shareIconDrawable, 0xffffffff);
             setDrawableColor(chat_replyIconDrawable, 0xffffffff);
             setDrawableColor(chat_goIconDrawable, 0xffffffff);
+            setDrawableColor(chat_regenerateIconDrawable, 0xffffffff);
             setDrawableColor(chat_botInlineDrawable, 0xffffffff);
             setDrawableColor(chat_botWebViewDrawable, 0xffffffff);
             setDrawableColor(chat_botLockDrawable, 0xffffffff);
@@ -9300,6 +9306,7 @@ public class Theme {
             setDrawableColorByKey(chat_shareIconDrawable, key_chat_serviceIcon);
             setDrawableColorByKey(chat_replyIconDrawable, key_chat_serviceIcon);
             setDrawableColorByKey(chat_goIconDrawable, key_chat_serviceIcon);
+            setDrawableColorByKey(chat_regenerateIconDrawable, key_chat_serviceIcon);
             setDrawableColorByKey(chat_botInlineDrawable, key_chat_serviceIcon);
             setDrawableColorByKey(chat_botWebViewDrawable, key_chat_serviceIcon);
             setDrawableColorByKey(chat_botLockDrawable, key_chat_serviceIcon);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -126,6 +126,7 @@ import org.telegram.messenger.MediaController;
 import org.telegram.messenger.MediaDataController;
 import org.telegram.messenger.MessageObject;
 import org.telegram.messenger.MessagesController;
+import org.telegram.messenger.MessageVariantsController;
 import org.telegram.messenger.NotificationCenter;
 import org.telegram.messenger.R;
 import org.telegram.messenger.RichMessageLayout;
@@ -651,6 +652,10 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         }
 
         default void didPressSideButton(ChatMessageCell cell) {
+        }
+
+        // Variant-sibling arrow tap zone (delta -1 = previous, +1 = next).
+        default void didPressVariantArrow(ChatMessageCell cell, int delta) {
         }
 
         default void didQuickShareStart(ChatMessageCell cell, float x, float y) {
@@ -1236,6 +1241,17 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     private boolean wasTranscriptionOpen;
     private Path instantLinkArrowPath;
     private Paint instantLinkArrowPaint;
+    // Variant-sibling stack cards -- lazy-init like instantLinkArrowPaint above.
+    private Paint variantStackFramePaint;   // border stroke
+    private Paint variantStackFillPaint;    // filled card body
+    private RectF variantStackFrameRect;
+    // The whole look of the variant stack is tuned from these four constants, in one place: how far
+    // each back card peeks out, how opaque its border is, and how much the fill is darkened per
+    // depth step so the back cards read as cards rather than blending into the bubble.
+    private static final float VARIANT_STACK_DX_DP = 3f;        // sideways peek per card
+    private static final float VARIANT_STACK_DY_DP = 2f;        // upward peek per card
+    private static final int VARIANT_STACK_BORDER_ALPHA = 210;  // border stroke alpha
+    private static final float VARIANT_STACK_TINT = 0.12f;      // border colour blended into the fill, per depth
 
     private int nameLayoutSelectorColor;
     private Drawable nameLayoutSelector;
@@ -1330,6 +1346,36 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     private int foreverDrawableColor = 0xFFFFFFFF;
 
     private boolean timePressed;
+
+    // Variant-sibling arrow tap zones -- geometry is set alongside the counter draw in
+    // drawTimeInternal and consumed by checkVariantArrowMotionEvent below.
+    private boolean variantCounterHitActive;
+    private float variantCounterHitLeft, variantCounterHitCenter, variantCounterHitRight, variantCounterHitTop, variantCounterHitBottom;
+    private boolean variantArrowPressed;
+    private int variantArrowPressedDelta;
+    // The counter is centred on the bubble, so the same draw pass must not run twice per frame:
+    // drawTime enters drawTimeInternal up to four times (the i < 2 selection loop plus the two
+    // transitionParams layouts). Anchored on the clock those passes land at different X, but centred
+    // they land pixel-on-pixel, doubling the alpha and letting the last pass own the tap zone.
+    // First call of the frame wins.
+    private boolean variantCounterDrawnThisFrame;
+
+    // Single source of truth for the "is this message part of a variant pack" gate, used by
+    // measureTime, drawTimeInternal, the accessibility node and the stack overlay. Returns the
+    // variant-group id, or 0 when this message is not part of a pack. The id rather than the size
+    // is returned because three of the four call sites immediately need it for indexOfActive() --
+    // returning only the size would force each of them to look the group up a second time, in the
+    // draw path.
+    private int variantPackGroupId() {
+        if (currentMessageObject == null) {
+            return 0;
+        }
+        TLRPC.User variantSender = MessagesController.getInstance(currentAccount).getUser(currentMessageObject.getFromChatId());
+        if (!MessageVariantsController.isGenerativeBot(variantSender)) {
+            return 0;
+        }
+        return MessageVariantsController.getInstance(currentAccount).groupIdOf(currentMessageObject.getId());
+    }
 
     private float timeAlpha = 1.0f;
     private float actionAlpha = 1.0f;
@@ -1657,6 +1703,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     private float[] sideButtonPathCorners1, sideButtonPathCorners2;
     private static final int SIDE_BUTTON_SPONSORED_CLOSE = 4;
     private static final int SIDE_BUTTON_SPONSORED_MORE = 5;
+    private static final int SIDE_BUTTON_REGENERATE = 6;
     private float sideStartX, sideStartY;
     private float summarizeButtonX, summarizeButtonY;
 
@@ -4136,6 +4183,38 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         }
     }
 
+    // Arrow tap zones flanking the variant counter -- mirrors checkDateMotionEvent's minimal
+    // ACTION_DOWN/ACTION_UP pattern (variantArrowPressed is cleared by the shared ACTION_CANCEL
+    // reset block further down in onTouchEvent, same as timePressed).
+    private boolean checkVariantArrowMotionEvent(MotionEvent event) {
+        if (!variantCounterHitActive) {
+            return false;
+        }
+        int x = (int) getEventX(event);
+        int y = (int) getEventY(event);
+
+        boolean result = false;
+        if (event.getAction() == MotionEvent.ACTION_DOWN) {
+            if (x >= variantCounterHitLeft && x <= variantCounterHitRight && y >= variantCounterHitTop && y <= variantCounterHitBottom) {
+                variantArrowPressed = true;
+                variantArrowPressedDelta = x < variantCounterHitCenter ? -1 : 1;
+                result = true;
+                invalidate();
+            }
+        } else if (event.getAction() == MotionEvent.ACTION_UP) {
+            if (variantArrowPressed) {
+                variantArrowPressed = false;
+                playSoundEffect(SoundEffectConstants.CLICK);
+                if (delegate != null) {
+                    delegate.didPressVariantArrow(this, variantArrowPressedDelta);
+                }
+                invalidate();
+                result = true;
+            }
+        }
+        return result;
+    }
+
     private boolean checkDateMotionEvent(MotionEvent event) {
         if (!currentMessageObject.isImportedForward()) {
             return false;
@@ -4948,6 +5027,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             result = checkDateMotionEvent(event);
         }
         if (!result) {
+            result = checkVariantArrowMotionEvent(event);
+        }
+        if (!result) {
             result = checkTextSelection(event);
         }
         if (!result && topicButton != null) {
@@ -5047,6 +5129,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             pressedSideButton = 0;
             imagePressed = false;
             timePressed = false;
+            variantArrowPressed = false;
             gamePreviewPressed = false;
             instantPressed = commentButtonPressed = false;
             setInstantButtonPressed(false);
@@ -6934,6 +7017,12 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 drawSideButton = !isRepliesChat && checkNeedDrawShareButton(messageObject) ? 1 : 0;
                 if (isPinnedChat || drawSideButton == 1 && (messageObject.messageOwner.fwd_from != null && !messageObject.isOutOwner() && messageObject.messageOwner.fwd_from.saved_from_peer != null && messageObject.getDialogId() == UserConfig.getInstance(currentAccount).getClientUserId() || messageObject.isSaved)) {
                     drawSideButton = 2;
+                }
+            }
+            {
+                TLRPC.User sideButtonSender = MessagesController.getInstance(currentAccount).getUser(messageObject.getFromChatId());
+                if (MessageVariantsController.isGenerativeBot(sideButtonSender)) {
+                    drawSideButton = SIDE_BUTTON_REGENERATE;
                 }
             }
             drawSummarizeButton = TranslateController.isSummarizable(messageObject);
@@ -12878,6 +12967,15 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         if (currentMessageObject.isUnsupported()) {
             newLineForTime = true;
         }
+        // A variant pack always gets its own time row. The counter is drawn centred on the bubble
+        // width, so if the clock shared the last text line the centred counter would sit on top of
+        // that line's tail. The newLineForTime branch below widens the bubble to timeWidth + dp(31),
+        // and timeWidth already carries the counter's reservation from measureTime -- so the
+        // dedicated row fits both the clock and the centred counter.
+        int packGroupId = variantPackGroupId();
+        if (packGroupId != 0 && MessageVariantsController.getInstance(currentAccount).size(packGroupId) > 1) {
+            newLineForTime = true;
+        }
         if ((reactionsLayoutInBubble.isEmpty || reactionsLayoutInBubble.isSmall) && currentMessageObject.richLayout != null && currentMessageObject.richLayout.forceNewLineForTime()) {
             newLineForTime = true;
         }
@@ -18546,6 +18644,18 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         } else {
             signWidth = 0;
         }
+        // Variant-sibling footer counter reserves its width in the time row (same pattern as
+        // views/replies/reactions above).
+        // The reservation does not POSITION the counter -- the counter is centred on the bubble
+        // geometry, not appended to the clock. What it buys is room: it guarantees the time row is
+        // wide enough for the clock AND the centred counter, which keeps the bubble-relative clamp
+        // in drawTimeInternal from firing on a normally sized message.
+        int measureGroupId = variantPackGroupId();
+        int measureGroupSize = measureGroupId != 0 ? MessageVariantsController.getInstance(currentAccount).size(measureGroupId) : 0;
+        if (measureGroupSize > 1) {
+            String counterText = LocaleController.formatString(R.string.VariantCounterFormat, MessageVariantsController.getInstance(currentAccount).indexOfActive(measureGroupId) + 1, measureGroupSize);
+            timeWidth += (int) Math.ceil(Theme.chat_timePaint.measureText(counterText)) + dp(4);
+        }
     }
 
     protected boolean shouldDrawSelectionOverlay() {
@@ -20503,6 +20613,67 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             roundVideoPlayPipFloat.set(0, true);
         }
 
+        // Variant-pack visual stack: a message with siblings should read as a stack of cards rather
+        // than a lone bubble. Draw up to two filled cards (bubble-fill body + hairline border) BEHIND
+        // the bubble, each offset up and sideways so their top corners peek past the bubble into the
+        // wallpaper. This runs before the bubble-background pass below, so the bubble paints on top
+        // and only the peek shows. Gated on group size > 1 and free otherwise. An earlier attempt
+        // that inset a 1dp hairline INSIDE the bubble was invisible on a real screen, which is why
+        // the cards are drawn behind and offset outwards instead.
+        {
+            // Gate shared with the measure/draw/accessibility call sites via variantPackGroupId(),
+            // which also requires the sender to be a variant-authoring peer. Variant groups are only
+            // ever created for such a peer's answers, so the extra condition cannot hide a real pack,
+            // and one shared gate is what keeps the four call sites from drifting apart.
+            int stackGroupId = variantPackGroupId();
+            int stackSize = stackGroupId != 0 ? MessageVariantsController.getInstance(currentAccount).size(stackGroupId) : 0;
+            if (stackSize > 1) {
+                if (variantStackFillPaint == null) {
+                    variantStackFillPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+                    variantStackFillPaint.setStyle(Paint.Style.FILL);
+                }
+                if (variantStackFramePaint == null) {
+                    variantStackFramePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+                    variantStackFramePaint.setStyle(Paint.Style.STROKE);
+                    variantStackFramePaint.setStrokeWidth(dp(1));
+                }
+                if (variantStackFrameRect == null) {
+                    variantStackFrameRect = new RectF();
+                }
+                int bubbleFill = getThemedColor(currentMessageObject.isOutOwner() ? Theme.key_chat_outBubble : Theme.key_chat_inBubble);
+                int borderColor = getThemedColor(currentMessageObject.isOutOwner() ? Theme.key_chat_outTimeText : Theme.key_chat_inTimeText);
+                float radius = dp(SharedConfig.bubbleRadius);
+                int backCards = Math.min(2, stackSize - 1);
+                // Farthest card first so nearer cards paint over it; the bubble then covers every card's
+                // left/bottom, leaving only the offset top-right sliver of each visible.
+                for (int i = backCards; i >= 1; i--) {
+                    // Peek is single-digit dp, driven by the constants above.
+                    float dx = dp(VARIANT_STACK_DX_DP * i);
+                    float dy = dp(VARIANT_STACK_DY_DP * i);
+                    // Clamp the card top to the cell's own top edge. backgroundDrawableTop is
+                    // additionalTop + dp(1), so there is essentially no room above the bubble inside
+                    // the cell -- anything above zero is clipped by the cell boundary
+                    // (RecyclerView clipChildren) and the rounded corner is cut in half. Clamping at
+                    // zero still leaves about 1dp of visible top peek and keeps the corner whole.
+                    // The bottom edge sits under the bubble, so it is left alone.
+                    variantStackFrameRect.set(
+                            backgroundDrawableLeft + dx,
+                            Math.max(0f, backgroundDrawableTop - dy),
+                            backgroundDrawableLeft + backgroundDrawableRight + dx,
+                            backgroundDrawableBottom - dy);
+                    // Tint the fill towards the border colour by depth, so the farther card is
+                    // visibly darker than the nearer one and the stack reads as a stack. Stroke width
+                    // stays at dp(1) -- on a 3dp sliver a fatter stroke would swallow the sliver.
+                    variantStackFillPaint.setColor(ColorUtils.blendARGB(bubbleFill, borderColor, VARIANT_STACK_TINT * i));
+                    variantStackFillPaint.setAlpha(255);
+                    canvas.drawRoundRect(variantStackFrameRect, radius, radius, variantStackFillPaint);
+                    variantStackFramePaint.setColor(borderColor);
+                    variantStackFramePaint.setAlpha(VARIANT_STACK_BORDER_ALPHA);
+                    canvas.drawRoundRect(variantStackFrameRect, radius, radius, variantStackFramePaint);
+                }
+            }
+        }
+
         if ((drawBackground || transitionParams.animateDrawBackground) && currentBackgroundDrawable != null && (currentPosition == null || isDrawSelectionBackground() && (currentMessageObject.isMusic() || currentMessageObject.isDocument())) && !(enterTransitionInProgress && !currentMessageObject.isVoice())) {
             float alphaInternal = this.alphaInternal;
             if (fromParent) {
@@ -21503,6 +21674,10 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 Drawable goIconDrawable = getThemedDrawable(Theme.key_drawable_goIcon);
                 setDrawableBounds(goIconDrawable, sideStartX + dp(16) - goIconDrawable.getIntrinsicWidth() / 2f, sideStartY + dp(16) - goIconDrawable.getIntrinsicHeight() / 2f);
                 goIconDrawable.draw(canvas);
+            } else if (drawSideButton == SIDE_BUTTON_REGENERATE) {
+                Drawable regenerateIconDrawable = getThemedDrawable(Theme.key_drawable_regenerateIcon);
+                setDrawableBounds(regenerateIconDrawable, sideStartX + dp(16) - regenerateIconDrawable.getIntrinsicWidth() / 2f, sideStartY + dp(16) - regenerateIconDrawable.getIntrinsicHeight() / 2f);
+                regenerateIconDrawable.draw(canvas);
             } else if (drawSideButton == SIDE_BUTTON_SPONSORED_CLOSE) {
                 final int scx = (int) (sideStartX + dp(16)), scy = (int) (sideStartY + dp(16));
                 Drawable drawable = getThemedDrawable(Theme.key_drawable_closeIcon);
@@ -23612,6 +23787,13 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         if (currentMessageObject != null && currentMessageObject.type == MessageObject.TYPE_JOINED_CHANNEL) {
             return;
         }
+        // Open the frame for the variant counter. The loop below may enter drawTimeInternal up to
+        // four times (selection pass + the two transition layouts); the first one to reach the
+        // counter draws it and owns the tap zone, the rest pass it by. Both flags are cleared on
+        // EVERY drawTime call, so separate-canvas paths (pinch-to-zoom, ThanosEffect) still get
+        // their own draw.
+        variantCounterDrawnThisFrame = false;
+        variantCounterHitActive = false;
         for (int i = 0; i < 2; i++) {
             float currentAlpha = alpha;
             if (i == 0 && isDrawSelectionBackground() && currentSelectedBackgroundAlpha == 1f && !shouldDrawTimeOnMedia()) {
@@ -23988,6 +24170,46 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 SpoilerEffect.layoutDrawMaybe(timeLayout, canvas);
             }
             canvas.restore();
+        }
+
+        // Variant-sibling footer counter "<i>/<N>", gated on group size > 1 so a message with no
+        // siblings pays zero extra draw cost. Detached from the clock and centred on the bubble,
+        // guarded by the per-frame latch opened in drawTime -- the first call of the frame draws,
+        // the rest skip.
+        if (!variantCounterDrawnThisFrame && currentMessageObject != null) {
+            int groupId = variantPackGroupId();
+            int groupSize = groupId != 0 ? MessageVariantsController.getInstance(currentAccount).size(groupId) : 0;
+            // backgroundDrawableRight is the bubble WIDTH; <= 0 means the bubble geometry has not
+            // been computed yet this layout, so there is nothing to centre against -- skip the frame
+            // entirely and leave both flags as drawTime cleared them.
+            if (groupSize > 1 && backgroundDrawableRight > 0) {
+                variantCounterDrawnThisFrame = true;
+                String counterText = LocaleController.formatString(R.string.VariantCounterFormat, MessageVariantsController.getInstance(currentAccount).indexOfActive(groupId) + 1, groupSize);
+                StaticLayout counterLayout = new StaticLayout(counterText, Theme.chat_timePaint, dp(60), Layout.Alignment.ALIGN_NORMAL, 1.0f, 0.0f, false);
+                // Position from the BUBBLE, never from the clock. The old anchor (drawTimeX + time
+                // text width) inherited whatever width the time row happened to have reserved, and
+                // the FIRST variant was measured while its group was still a single message -- i.e.
+                // with no counter reservation at all -- so paging back to it pushed the counter past
+                // the bubble edge. Both clamp ends are bubble-relative too, so the counter cannot
+                // leave the bubble under any reservation history; the clamp only ever engages on a
+                // degenerately narrow bubble (a very short message).
+                float counterW = counterLayout.getLineWidth(0);
+                float counterX = backgroundDrawableLeft + backgroundDrawableRight / 2f - counterW / 2f;
+                counterX = Math.min(counterX, drawTimeX - counterW - dp(4));
+                counterX = Math.max(counterX, backgroundDrawableLeft + dp(8));
+                canvas.save();
+                canvas.translate(counterX, drawTimeY);
+                counterLayout.draw(canvas);
+                canvas.restore();
+                // Arrow tap zones: a generous rect flanking the counter, split at its horizontal
+                // center (left half = previous, right half = next).
+                variantCounterHitActive = true;
+                variantCounterHitLeft = counterX - dp(16);
+                variantCounterHitRight = counterX + counterLayout.getLineWidth(0) + dp(16);
+                variantCounterHitCenter = counterX + counterLayout.getLineWidth(0) / 2f;
+                variantCounterHitTop = drawTimeY - dp(8);
+                variantCounterHitBottom = drawTimeY + counterLayout.getHeight() + dp(8);
+            }
         }
 
         if (currentMessageObject.isOutOwner()) {
@@ -26885,6 +27107,19 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                             }
                         }
                         sb.append(messageText);
+                    }
+                    // Surface the variant-pack "i/N" counter on the cell's accessibility node, so a
+                    // pack is distinguishable from a single message without looking at pixels: the
+                    // footer counter in drawTimeInternal is Canvas-only and therefore invisible to
+                    // TalkBack. Mirrors that gate and format exactly; a message with no siblings
+                    // appends nothing.
+                    {
+                        int variantGroupId = variantPackGroupId();
+                        int variantGroupSize = variantGroupId != 0 ? MessageVariantsController.getInstance(currentAccount).size(variantGroupId) : 0;
+                        if (variantGroupSize > 1) {
+                            sb.append(" ");
+                            sb.append(LocaleController.formatString(R.string.VariantCounterFormat, MessageVariantsController.getInstance(currentAccount).indexOfActive(variantGroupId) + 1, variantGroupSize));
+                        }
                     }
                     if (documentAttach != null && (documentAttachType == DOCUMENT_ATTACH_TYPE_DOCUMENT || documentAttachType == DOCUMENT_ATTACH_TYPE_GIF || documentAttachType == DOCUMENT_ATTACH_TYPE_VIDEO)) {
                         if (buttonState == 1 && loadingProgressLayout != null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -171,6 +171,7 @@ import org.telegram.messenger.MessageObject;
 import org.telegram.messenger.MessagePreviewParams;
 import org.telegram.messenger.MessageSuggestionParams;
 import org.telegram.messenger.MessagesController;
+import org.telegram.messenger.MessageVariantsController;
 import org.telegram.messenger.MessagesStorage;
 import org.telegram.messenger.NotificationCenter;
 import org.telegram.messenger.NotificationsController;
@@ -1238,6 +1239,9 @@ public class ChatActivity extends BaseFragment implements
     public final static int OPTION_SUGGESTION_ADD_OFFER = 114;
 
     public final static int OPTION_VIEW_STATISTICS = 115;
+    // Long-press menu "regenerate" item; dispatches through the same entry point as the bubble's
+    // reload side button (MessageVariantsController.notifyRegenerateRequested).
+    public final static int OPTION_REGENERATE = 116;
 
     private final static int[] allowedNotificationsDuringChatListAnimations = new int[]{
             NotificationCenter.messagesRead,
@@ -4938,14 +4942,21 @@ public class ChatActivity extends BaseFragment implements
                         slidingView = view;
                         MessageObject message = getSlidingMessageObject();
                         boolean allowReplyOnOpenTopic = canSendMessageToTopic(message);
+                        // A message from a variant-authoring peer pages between its variant siblings
+                        // on swipe-release instead of opening the reply/forward UI. It still has to
+                        // track normally through the bail-list below -- only its release differs.
+                        TLRPC.User slidingSender = message != null ? getMessagesController().getUser(message.getFromChatId()) : null;
+                        boolean isVariantMessage = MessageVariantsController.isGenerativeBot(slidingSender);
                         if (
-                            chatMode != 0 && chatMode != MODE_QUICK_REPLIES && chatMode != MODE_SUGGESTIONS && (chatMode != MODE_SAVED || threadMessageId != getUserConfig().getClientUserId()) ||
-                            threadMessageObjects != null && threadMessageObjects.contains(message) ||
-                            getMessageType(message) == 1 && (message.getDialogId() == mergeDialogId || message.needDrawBluredPreview()) ||
-                            currentEncryptedChat == null && message.getId() < 0 ||
-                            currentChat != null && ChatObject.isForum(currentChat) && !allowReplyOnOpenTopic ||
-                            hasTextSelection() ||
-                            message.isEphemeral() && message.isOut()
+                            !isVariantMessage && (
+                                chatMode != 0 && chatMode != MODE_QUICK_REPLIES && chatMode != MODE_SUGGESTIONS && (chatMode != MODE_SAVED || threadMessageId != getUserConfig().getClientUserId()) ||
+                                threadMessageObjects != null && threadMessageObjects.contains(message) ||
+                                getMessageType(message) == 1 && (message.getDialogId() == mergeDialogId || message.needDrawBluredPreview()) ||
+                                currentEncryptedChat == null && message.getId() < 0 ||
+                                currentChat != null && ChatObject.isForum(currentChat) && !allowReplyOnOpenTopic ||
+                                hasTextSelection() ||
+                                message.isEphemeral() && message.isOut()
+                            )
                         ) {
                             slidingViewSetOffset(0);
                             slidingView = null;
@@ -4995,6 +5006,13 @@ public class ChatActivity extends BaseFragment implements
                 } else if (slidingView != null && (e == null || e.getPointerId(0) == startedTrackingPointerId && (e.getAction() == MotionEvent.ACTION_CANCEL || e.getAction() == MotionEvent.ACTION_UP || e.getAction() == MotionEvent.ACTION_POINTER_UP))) {
                     if (e != null && e.getAction() != MotionEvent.ACTION_CANCEL && Math.abs(getSlidingNonAnimationTranslationX(false)) >= AndroidUtilities.dp(50)) {
                         MessageObject message = getSlidingMessageObject();
+                        // Swipe-left on a variant-authoring peer's message pages to the next sibling
+                        // instead of opening the reply/forward-picker UI below -- checked strictly
+                        // before both of those branches, and skips them entirely when it fires.
+                        TLRPC.User releaseSender = message != null ? getMessagesController().getUser(message.getFromChatId()) : null;
+                        if (MessageVariantsController.isGenerativeBot(releaseSender)) {
+                            pageVariant((ChatMessageCell) slidingView, 1);
+                        } else {
                         final boolean allowReplyOnOpenTopic = canSendMessageToTopic(message);
                         if (
                             bottomChannelButtonsLayout != null && bottomChannelButtonsLayout.getVisibility() == View.VISIBLE && !(bottomOverlayChatWaitsReply && allowReplyOnOpenTopic || message.wasJustSent) ||
@@ -5027,6 +5045,7 @@ public class ChatActivity extends BaseFragment implements
                             presentFragment(fragment);
                         } else {
                             showFieldPanelForReply(getSlidingMessageObject());
+                        }
                         }
                     }
                     endTrackingX = slidingViewGetOffsetX();
@@ -20379,6 +20398,21 @@ public class ChatActivity extends BaseFragment implements
         }
         ArrayList<MessageObject> messArr = (ArrayList<MessageObject>) args[2];
 
+        // hide non-active members of a variant-answer group; see MessageVariantsController.
+        // Cache-reload path: warm the cache for every loaded message, then drop any message
+        // that is a non-active member of its group before it ever enters the render list.
+        {
+            MessageVariantsController variantsController = MessageVariantsController.getInstance(currentAccount);
+            for (int a = 0, N = messArr.size(); a < N; a++) {
+                variantsController.observe(messArr.get(a));
+            }
+            for (int a = messArr.size() - 1; a >= 0; a--) {
+                if (variantsController.isHidden(messArr.get(a).getId())) {
+                    messArr.remove(a);
+                }
+            }
+        }
+
         boolean universalNotify = false;
         HashMap<Integer, MessageObject> oldMessages = null;
         if (clearOnLoad && (mode == MODE_DEFAULT || mode == MODE_SUGGESTIONS)) {
@@ -25146,6 +25180,51 @@ public class ChatActivity extends BaseFragment implements
         processNewMessages(arr, true);
     }
     private void processNewMessages(ArrayList<MessageObject> arr, final boolean animatedFromBottom) {
+        // hide non-active members of a variant-answer group; see MessageVariantsController.
+        // Live path: warm the cache, drop any newly-arrived message that is a non-active member
+        // of its group, then evict any OTHER member of a surviving message's group that is
+        // already resident in the visible list (the predecessor being replaced by this reply).
+        {
+            MessageVariantsController variantsController = MessageVariantsController.getInstance(currentAccount);
+            for (int a = 0, N = arr.size(); a < N; a++) {
+                variantsController.observe(arr.get(a));
+            }
+            for (int a = arr.size() - 1; a >= 0; a--) {
+                // Never drop the user's own outgoing message. A variant sibling is by definition an
+                // incoming answer (out=false), so an outgoing message can never legitimately be a
+                // hidden sibling -- but a locally-assigned negative id can collide with a stale
+                // group membership left in the prefs by a previous process, which would silently
+                // vanish the pending send bubble. Exempting out=true closes that regardless.
+                if (!arr.get(a).isOut() && variantsController.isHidden(arr.get(a).getId())) {
+                    arr.remove(a);
+                }
+            }
+            if (chatMode == MODE_DEFAULT) {
+                ArrayList<Integer> evictIds = null;
+                for (int a = 0, N = arr.size(); a < N; a++) {
+                    MessageObject mo = arr.get(a);
+                    int groupId = variantsController.groupIdOf(mo.getId());
+                    if (groupId == 0) {
+                        continue;
+                    }
+                    int[] members = variantsController.memberIds(groupId);
+                    for (int id : members) {
+                        if (id == mo.getId()) {
+                            continue;
+                        }
+                        if (messagesDict[0].get(id) != null) {
+                            if (evictIds == null) {
+                                evictIds = new ArrayList<>();
+                            }
+                            evictIds.add(id);
+                        }
+                    }
+                }
+                if (evictIds != null && !evictIds.isEmpty()) {
+                    processDeletedMessages(evictIds, 0, false);
+                }
+            }
+        }
         FileLog.d("processNewMessages " + arr.size() + " messages");
 
         final boolean isBot = UserObject.isBot(currentUser);
@@ -26066,6 +26145,71 @@ public class ChatActivity extends BaseFragment implements
             sponsoredMessagesCount++;
         }
         return sponsoredMessagesCount;
+    }
+
+    // Page the variant-sibling group `cell`'s message belongs to by `delta` (-1 previous, +1 next),
+    // swapping the cached sibling into the visible list in place. Never fabricates a MessageObject
+    // and never touches MessagesStorage -- only re-shows a sibling already warmed into
+    // MessageVariantsController's object cache by this session's observe() calls.
+    private void pageVariant(ChatMessageCell cell, int delta) {
+        if (cell == null) {
+            return;
+        }
+        MessageObject current = cell.getMessageObject();
+        if (current == null) {
+            return;
+        }
+        MessageVariantsController variantsController = MessageVariantsController.getInstance(currentAccount);
+        int groupId = variantsController.groupIdOf(current.getId());
+        if (groupId == 0) {
+            return;
+        }
+        int newActiveId = variantsController.page(groupId, delta);
+        if (newActiveId == current.getId()) {
+            // Paging landed back on the same member -- a single-member group, nothing to swap.
+            return;
+        }
+        MessageObject target = variantsController.getCached(newActiveId);
+        if (target == null) {
+            // Defensive -- should always be warm from this session's observe() calls.
+            return;
+        }
+        int index = messages.indexOf(current);
+        if (index < 0) {
+            return;
+        }
+        ArrayList<Integer> evict = new ArrayList<>();
+        evict.add(current.getId());
+        processDeletedMessages(evict, 0, false);
+
+        // Re-insert the cached sibling at the position the evicted message occupied -- the same
+        // dict/day-bucket/list/adapter bookkeeping processNewMessages' per-message insertion does,
+        // without its unread-count/mention/scroll-to-bottom side effects (this swaps an
+        // already-seen sibling into view, it is not a genuinely new incoming message). Reuses
+        // target's own stableId, assigned the first time it was ever inserted (before an earlier
+        // eviction), so RecyclerView keeps a stable identity across the swap.
+        // Known limitation: day-header re-creation (processNewMessages' dayArray == null branch,
+        // which inserts a TYPE_DATE header row) is not replicated here -- if evicting `current`
+        // emptied its day bucket and removed the date header row, this swap does not re-add it.
+        // Narrow in practice, since siblings of one answer share a day with the prompt above them.
+        target.deleted = false;
+        messagesDict[0].put(target.getId(), target);
+        ArrayList<MessageObject> dayArray = messagesByDays.get(target.dateKey);
+        if (dayArray == null) {
+            dayArray = new ArrayList<>();
+            messagesByDays.put(target.dateKey, dayArray);
+            messagesByDaysSorted.put(target.dateKeyInt, dayArray);
+        }
+        dayArray.add(0, target);
+        if (index > messages.size()) {
+            index = messages.size();
+        }
+        messages.add(index, target);
+        if (chatAdapter != null) {
+            chatAdapter.notifyItemChanged(chatAdapter.messagesStartRow + index);
+            chatAdapter.notifyItemInserted(chatAdapter.messagesStartRow + index);
+        }
+        updateVisibleRows();
     }
 
     private void processDeletedMessages(ArrayList<Integer> markAsDeletedMessages, long channelId, boolean sent) {
@@ -33055,6 +33199,12 @@ public class ChatActivity extends BaseFragment implements
         }
         boolean preserveDim = false;
         switch (option) {
+            case OPTION_REGENERATE: {
+                // Same generic dispatch entry point the reload side button uses -- one call path,
+                // no parallel one for the menu trigger.
+                MessageVariantsController.getInstance(currentAccount).notifyRegenerateRequested(selectedObject);
+                break;
+            }
             case OPTION_RETRY: {
                 final MessageObject object = selectedObject;
                 final MessageObject.GroupedMessages group = selectedObjectGroup;
@@ -38971,9 +39121,21 @@ public class ChatActivity extends BaseFragment implements
         }
 
         @Override
+        public void didPressVariantArrow(ChatMessageCell cell, int delta) {
+            pageVariant(cell, delta);
+        }
+
+        @Override
         public void didPressSideButton(ChatMessageCell cell) {
             if (getParentActivity() == null) {
                 return;
+            }
+            {
+                TLRPC.User sideButtonSender = getMessagesController().getUser(cell.getMessageObject().getFromChatId());
+                if (MessageVariantsController.isGenerativeBot(sideButtonSender)) {
+                    MessageVariantsController.getInstance(currentAccount).notifyRegenerateRequested(cell.getMessageObject());
+                    return;
+                }
             }
             if (topicsTabs != null && threadMessageId == 0 && (cell.isForum || cell.isMonoForum)) {
                 topicsTabs.selectTopic(cell.getMessageObject().getTopicId(), true);
@@ -45506,6 +45668,16 @@ public class ChatActivity extends BaseFragment implements
                     items.add(LocaleController.getString(R.string.Copy));
                     options.add(OPTION_COPY);
                     icons.add(R.drawable.msg_copy);
+                }
+                {
+                    // Long-press "regenerate", offered only for peers that author variant answers;
+                    // same sender lookup the swipe/side-button/counter paths use.
+                    TLRPC.User menuSender = getMessagesController().getUser(message.getFromChatId());
+                    if (MessageVariantsController.isGenerativeBot(menuSender)) {
+                        items.add(LocaleController.getString(R.string.MessageRegenerate));
+                        options.add(OPTION_REGENERATE);
+                        icons.add(R.drawable.msg_regenerate);
+                    }
                 }
                 if (!isThreadChat() && chatMode != MODE_SCHEDULED && currentChat != null && primaryMessage != null && (currentChat.has_link || primaryMessage.hasReplies()) && currentChat.megagroup && primaryMessage.canViewThread()) {
                     if (primaryMessage.hasReplies()) {

--- a/TMessagesProj/src/main/res/drawable/msg_regenerate.xml
+++ b/TMessagesProj/src/main/res/drawable/msg_regenerate.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z" />
+</vector>

--- a/TMessagesProj/src/main/res/values-ru/strings.xml
+++ b/TMessagesProj/src/main/res/values-ru/strings.xml
@@ -263,4 +263,6 @@
     <string name="RemindTodayAt">\'Отправить сегодня в\' HH:mm</string>
     <string name="RemindDayAt">\'Отправить\' d MMM \'в\' HH:mm</string>
     <string name="RemindDayYearAt">\'Напомнить\' d MMM yyyy \'в\' HH:mm</string>
+    <string name="VariantCounterFormat">‹ %1$d/%2$d ›</string>
+    <string name="MessageRegenerate">Обновить</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -1377,6 +1377,8 @@
     <string name="PinNotify">Notify all members</string>
     <string name="PinAlsoFor">Also pin for %1$s</string>
     <string name="UnpinMessage">Unpin</string>
+    <string name="VariantCounterFormat">‹ %1$d/%2$d ›</string>
+    <string name="MessageRegenerate">Regenerate</string>
     <string name="PinMessageAlertTitle">Pin message</string>
     <string name="UnpinMessageAlertTitle">Unpin message</string>
     <string name="PinOldMessageAlert">Do you want to pin an older message while leaving a more recent one pinned?</string>


### PR DESCRIPTION
Conversational bots have changed what people expect from a chat. A bot that generates its
answers is not a menu tree — the same question can be answered several ways, and users now
routinely ask for another take. Every major assistant interface treats that as a basic
primitive: ChatGPT, DeepSeek and Qwen all let you regenerate an answer and page between the
variants in place, without the conversation turning into a wall of near-duplicates.

Telegram has no way to express this. A bot that regenerates has to send a new message, so the
chat fills with slight variations of the same reply and the thread of the conversation is lost.
The gap is not cosmetic: it is the difference between a bot that feels like a conversation and
one that feels like a log. This PR closes that gap natively, for every bot on the platform.

The mechanism is generic. Messages known to be variants of one answer are correlated in a
per-account store; one of them is visible, the siblings are kept out of the render list. The
bubble shows a small `i/N` counter in its footer, arrow tap-zones flank the counter, a swipe
pages forward, and a reload side-button asks the bot for another variant. Nothing changes for a
message that was never regenerated — the counter and the outline are gated on group size
greater than one, so there is no extra draw cost.

Everything reuses what is already in the codebase rather than introducing parallel machinery:
the side-button geometry is the existing Forward/Share slot, the arrow hit-test mirrors
`checkDateMotionEvent`, the drawable registers through the same path as every other side-button
icon, and eviction of superseded siblings goes through the existing `processDeletedMessages`
primitive, touching only the render list and never `MessagesStorage`.

`grouped_id`/`GroupedMessages` were deliberately not reused: those positional flags drive the
album/collage layout, which shows all members at once — the opposite of a sequential pager.
That was verified before writing the code, not assumed.

The feature has been tested on developer devices and found working: regeneration, paging in
both directions, the `i/N` counter, and the eviction of superseded siblings all behave as
described above on real hardware, not only in review.

**What this PR deliberately leaves to you.** A variant group needs a signal for "this bot
produces alternatives". Any client-side choice of a TL flag bit is wrong by construction — the
schema is yours, and the bit I originally used locally (`flags2` bit 21) is the one 12.9.0 gave
to `linked_community_id`. So the mechanism here is driven through a small seam instead, and
wiring it to a real server-side signal is a decision only you can make. The client side is
complete and self-contained either way.

**On the interaction design.** The counter, the arrows and the reload button are placed to fit
the existing bubble geometry, but they are one reading of how this should look and feel. If
variant paging belongs somewhere else in Telegram's interaction language — a different affordance,
a different gesture, a different place in the bubble — I would rather it be shaped your way than
mine. The underlying mechanism does not depend on the presentation: the store, the sibling
filtering and the eviction path stay the same whatever the surface ends up being.
