### PR TITLE
Stop reading a poll of a previous message on other messages

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -27182,7 +27182,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                             sb.append(getString("AccDescrMsgPlayed", R.string.AccDescrMsgPlayed));
                         }
                     }
-                    if (lastPoll != null) {
+                    // the poll of a previous message stays around on a recycled cell, so it is
+                    // only of this message when this message is a poll itself
+                    if (lastPoll != null && currentMessageObject.isPoll()) {
                         sb.append(", ");
                         sb.append(lastPoll.question.text);
                         sb.append(", ");


### PR DESCRIPTION
## Summary

In a chat that contains a poll, screen readers read the question and type of that poll on unrelated messages, at the start or the end of their own text.

The poll a cell was bound to is kept in a field that is never cleared. Once a cell has shown a poll, every message that cell is later reused for still has that poll appended to what is read, while the message is drawn correctly.

Only report the poll when the message being read is a poll itself.


## Checking it

With TalkBack on, swipe onto a poll in a chat, then scroll on until the cell it was drawn in is reused for an ordinary message, and swipe onto that one.

Before, the question and the kind of that poll were read at the end of a message that has nothing to do with it. Now only a poll reports a poll.
