### PR TITLE
Stop reading a translated caption twice on media messages

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -27137,6 +27137,12 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         }
                     } else if (!TextUtils.isEmpty(currentMessageObject.messageText)) {
                         CharSequence messageText = currentMessageObject.messageText;
+                        // translating a chat puts the translated caption in the message text of a
+                        // media message, where its type belongs: the caption is read on its own
+                        // below, so report the type here as an untranslated message does
+                        if (!currentMessageObject.isMediaEmpty() && !TextUtils.isEmpty(currentMessageObject.caption) && TextUtils.equals(messageText, currentMessageObject.caption)) {
+                            messageText = currentMessageObject.getMediaTitle(MessageObject.getMedia(currentMessageObject.messageOwner));
+                        }
                         if (messageText instanceof Spanned) {
                             final Spanned spanned = (Spanned) messageText;
                             CodeHighlighting.Span[] codeSpans = spanned.getSpans(0, spanned.length(), CodeHighlighting.Span.class);
@@ -27156,7 +27162,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                                 messageText = ssb;
                             }
                         }
-                        sb.append(messageText);
+                        if (!TextUtils.isEmpty(messageText)) {
+                            sb.append(messageText);
+                        }
                     }
                     if (documentAttach != null && (documentAttachType == DOCUMENT_ATTACH_TYPE_DOCUMENT || documentAttachType == DOCUMENT_ATTACH_TYPE_GIF || documentAttachType == DOCUMENT_ATTACH_TYPE_VIDEO)) {
                         if (buttonState == 1 && loadingProgressLayout != null) {


### PR DESCRIPTION
## Summary

When a chat is translated, screen readers read the caption of a media message twice: once where the media type belongs, and once again as the caption.

Translating replaces the message text of a media message with the translated caption, and the message text is what stands for the media type when the message is read. The type is therefore lost and the caption takes its place, on top of being read where it belongs.

Report the media type in that case, the same as an untranslated message does, and leave the caption to be read once. Messages without media are unaffected.


## Checking it

With TalkBack on, turn on translation for a chat, then swipe onto a photo or a video that carries a caption.

Before, the translated caption was read twice: once where the kind of media belongs, and once again as the caption. Now the kind of media is said there, as it is on an untranslated message, and the caption is read once.
