### PR TITLE
Free the bottom of a chat after a locked voice recording

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -7004,6 +7004,9 @@ public class ChatActivityEnterView extends FrameLayout implements
                     if (recordedAudioPanel != null) {
                         recordedAudioPanel.setVisibility(GONE);
                     }
+                    if (controlsView != null) {
+                        controlsView.setVisibility(GONE);
+                    }
                     if (messageEditText != null) {
                         messageEditText.requestFocus();
                     }
@@ -7209,6 +7212,11 @@ public class ChatActivityEnterView extends FrameLayout implements
         }
         if (recordedAudioPanel != null) {
             recordedAudioPanel.setVisibility(GONE);
+        }
+        // the recording controls are only faded out when the panel closes: left visible they keep
+        // covering the bottom of the screen and swallow touch exploration of what is under them
+        if (controlsView != null) {
+            controlsView.setVisibility(GONE);
         }
         isRecordingStateChanged();
     }


### PR DESCRIPTION
## Summary

When a voice recording is locked and then stopped, sending or deleting it leaves the bottom of the chat unreachable for screen reader users: touch exploration finds nothing there, up to the last message or two.

The recording controls are shown for the whole recording flow and hidden again when it ends, except on the path that leads to the preview panel, where they are only faded out. The view stays in place with no alpha, still taking touch exploration over the messages and the buttons under it.

Hide the controls along with the preview panel, the same way the unlocked recording flow already does.


## Checking it

With TalkBack on, lock a voice recording, stop it, and then send or delete what was recorded. Explore the bottom of the chat by touch.

Before, an invisible view was left covering it, so the messages and the buttons under it could not be touched. Now the bottom of the chat is free, as it is after an unlocked recording.
