### PR TITLE
Fix the record button being reported twice and losing its place

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -586,6 +586,11 @@ public class ChatActivityEnterView extends FrameLayout implements
         }
     };
 
+    // recording fades the record button out: a view of no alpha at all counts as gone to a
+    // screen reader, which would take the place it is reading away from it, so keep the least
+    // alpha there is, which draws nothing either
+    private static final float HIDDEN_BUTTON_ALPHA = 1 / 255f;
+
     boolean ctrlPressed = false;
     boolean shiftPressed = false;
 
@@ -6146,7 +6151,9 @@ public class ChatActivityEnterView extends FrameLayout implements
             preferences.edit().putBoolean(isChannel ? "currentModeVideoChannel" : "currentModeVideo", visible).apply();
         }
         audioVideoSendButton.setState(isInVideoMode() ? ChatActivityEnterViewAnimatedIconView.State.VIDEO : ChatActivityEnterViewAnimatedIconView.State.VOICE, animated);
-        audioVideoSendButton.setContentDescription(getString(isInVideoMode() ? R.string.AccDescrVideoMessage : R.string.AccDescrVoiceMessage));
+        // the container is what a screen reader lands on, so describing the icon inside it as
+        // well leaves the record button reported twice at the very same place
+        audioVideoSendButton.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
         audioVideoButtonContainer.setContentDescription(getString(isInVideoMode() ? R.string.AccDescrVideoMessage : R.string.AccDescrVoiceMessage));
         audioVideoSendButton.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
     }
@@ -8895,7 +8902,7 @@ public class ChatActivityEnterView extends FrameLayout implements
                 iconChanges.playTogether(ObjectAnimator.ofFloat(controlsView, View.ALPHA, 1));
             }
             if (audioVideoSendButton != null) {
-                iconChanges.playTogether(ObjectAnimator.ofFloat(audioVideoButtonContainer, View.ALPHA, 0));
+                iconChanges.playTogether(ObjectAnimator.ofFloat(audioVideoButtonContainer, View.ALPHA, HIDDEN_BUTTON_ALPHA));
             }
             if (botCommandsMenuButton != null) {
                 iconChanges.playTogether(


### PR DESCRIPTION
## Summary

Screen readers find the record voice message button twice in the message bar, at the very same place, and lose their place when a recording starts.

The button is a container with an animated icon inside it, and both are given the same description whenever the voice or video mode is set, so the icon that only draws the button is reported next to the container that can be used.

Recording then fades the container out. A view left with no alpha at all counts as gone, so a screen reader that was reading the button has nothing to hold on to and jumps to whatever it finds next, the back button or a message in the chat. The icon never caused that, because recording only fades its parent.

Keep the description on the container, which is the one landed on and acted on, leave the icon out of what is reported, and fade the button for recording with the least alpha there is, which draws nothing either.


## Checking it

With TalkBack on, swipe through the bottom of a chat onto the record button, then start recording.

Before, the button was found twice at the very same place, and starting to record faded it to nothing, which counts as gone, so the reading jumped away to the back button or a message. Now it is found once, and recording keeps it where it is.
