### PR TITLE
Keep the attach button reachable by touch exploration

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -2927,7 +2927,41 @@ public class ChatActivityEnterView extends FrameLayout implements
                 if (!isSendButtonEnabled()) {
                     return false;
                 }
+                if (ev.getAction() == MotionEvent.ACTION_DOWN && !isRecording() && !isOverShownButton(ev.getX(), ev.getY())) {
+                    return false;
+                }
                 return super.dispatchTouchEvent(ev);
+            }
+
+            // while recording, the button of this container is faded out and the recording circle
+            // takes its place, so the container has to keep taking what happens over it
+            private boolean isRecording() {
+                return recordingAudioVideo || recordCircle != null && recordCircle.isSendButtonVisible();
+            }
+
+            @Override
+            public boolean dispatchHoverEvent(MotionEvent event) {
+                if (!isRecording() && !isOverShownButton(event.getX(), event.getY())) {
+                    return false;
+                }
+                return super.dispatchHoverEvent(event);
+            }
+
+            // this container is wider than the button it shows and reaches over the attach button
+            // next to it, so what happens where the attach button is drawn belongs to it: touching
+            // there would otherwise be read as the send button and open the send options
+            private boolean isOverShownButton(float x, float y) {
+                for (int i = 0; i < getChildCount(); ++i) {
+                    final View child = getChildAt(i);
+                    if (child.getVisibility() != VISIBLE || child.getAlpha() <= 0.01f) {
+                        continue;
+                    }
+                    if (x >= child.getX() && x < child.getX() + child.getWidth() &&
+                        y >= child.getY() && y < child.getY() + child.getHeight()) {
+                        return true;
+                    }
+                }
+                return false;
             }
 
             @Override


### PR DESCRIPTION
## Summary

With nothing typed, exploring the message bar by touch where the attach button is drawn lands on the record voice message button, and a long press there opens the send options instead of the attach menu. Moving by swipe reaches the attach button correctly, so only exploring by touch is affected.

The container of the send button is 100dp wide and sits over the attach button next to it, while the button shown inside it is only as wide as itself. Touch and hover therefore stop at the container wherever the attach button is, and a long press on the container is what a screen reader is given to reach the send options.

Let the container take touch and hover only where a button of its own is shown, so what is touched is what is drawn. While recording it keeps taking everything over it, since its button is faded out and the recording circle takes its place there.


## Checking it

With TalkBack on, in a chat with something typed in the box, drag a finger over the attach button next to the send button.

Before, the touch landed on the send button, since its container reaches over what is drawn beside it, and a long press there opened the send options. Now what is touched is what is drawn.

Swiping found the attach button correctly before this, which is why only exploring by touch was affected.
