### PR TITLE
Make the voice recording controls work with a screen reader

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -1849,7 +1849,9 @@ public class ChatActivityEnterView extends FrameLayout implements
                 if (onceVisible && (recordCircle != null && snapAnimationProgress > .1f) && onceRect.contains(x, y)) {
                     return 4;
                 }
-                return HOST_ID;
+                // this view covers the whole bottom of the chat while recording: exploring by
+                // touch off its buttons has to reach the timer and the rest under it
+                return INVALID_ID;
             }
 
             @Override
@@ -1877,7 +1879,15 @@ public class ChatActivityEnterView extends FrameLayout implements
 
             @Override
             protected boolean onPerformActionForVirtualView(int id, int action, @Nullable Bundle args) {
-                return true;
+                if (action != AccessibilityNodeInfoCompat.ACTION_CLICK) {
+                    return false;
+                }
+                if (id == 2) {
+                    return togglePauseForAccessibility();
+                } else if (id == 4) {
+                    return pressViewAt(ControlsView.this, onceRect.centerX(), onceRect.centerY());
+                }
+                return false;
             }
         }
     }
@@ -2521,14 +2531,18 @@ public class ChatActivityEnterView extends FrameLayout implements
                         }
                     }
                 }
-                return HOST_ID;
+                if (pauseRect.contains(x, y)) {
+                    return 2;
+                }
+                return INVALID_ID;
             }
 
             @Override
             protected void getVisibleVirtualViews(List<Integer> list) {
                 if (isSendButtonVisible()) {
                     list.add(1);
-//                    list.add(2);
+                    // the pause button is already reported by the controls drawn over the circle,
+                    // and reporting it here as well would leave two buttons on the same spot
                     list.add(3);
                 }
             }
@@ -2557,9 +2571,64 @@ public class ChatActivityEnterView extends FrameLayout implements
 
             @Override
             protected boolean onPerformActionForVirtualView(int id, int action, @Nullable Bundle args) {
-                return true;
+                if (action != AccessibilityNodeInfoCompat.ACTION_CLICK) {
+                    return false;
+                }
+                if (id == 1) {
+                    // sending is taken from where the record button is pressed
+                    return pressViewAt(audioVideoButtonContainer, audioVideoButtonContainer.getMeasuredWidth() / 2f, audioVideoButtonContainer.getMeasuredHeight() / 2f);
+                } else if (id == 2) {
+                    return togglePauseForAccessibility();
+                } else if (id == 3 && slideText != null) {
+                    return pressViewAt(slideText, slideText.cancelRect.centerX(), slideText.cancelRect.centerY());
+                }
+                return false;
             }
         }
+    }
+
+    private boolean togglePauseForAccessibility() {
+        if (isInVideoMode()) {
+            if (slideText != null) {
+                slideText.setEnabled(false);
+            }
+            delegate.toggleVideoRecordingPause();
+            return true;
+        }
+        if (!MediaController.getInstance().isRecordingPaused()) {
+            MessagesController.getGlobalMainSettings().edit().putInt("voicepausehint", 3).apply();
+        }
+        if (recordCircle != null && recordCircle.isSendButtonVisible()) {
+            calledRecordRunnable = true;
+        }
+        if (audioTimelineView != null) {
+            audioTimelineView.setPlaying(false);
+        }
+        MediaController.getInstance().toggleRecordingPause(voiceOnce);
+        delegate.needStartRecordAudio(0);
+        if (slideText != null) {
+            slideText.setEnabled(false);
+        }
+        return true;
+    }
+
+    // the recording controls are drawn rather than laid out, so what stands for them to a screen
+    // reader has to be carried out where they are drawn
+    private static boolean pressViewAt(View view, float x, float y) {
+        if (view == null) {
+            return false;
+        }
+        final long now = SystemClock.uptimeMillis();
+        final MotionEvent down = MotionEvent.obtain(now, now, MotionEvent.ACTION_DOWN, x, y, 0);
+        final MotionEvent up = MotionEvent.obtain(now, now, MotionEvent.ACTION_UP, x, y, 0);
+        try {
+            view.onTouchEvent(down);
+            view.onTouchEvent(up);
+        } finally {
+            down.recycle();
+            up.recycle();
+        }
+        return true;
     }
 
     public ChatActivityEnterView(Activity context, SizeNotifierFrameLayout parent, ChatActivity fragment, final boolean isChat) {
@@ -14221,6 +14290,18 @@ public class ChatActivityEnterView extends FrameLayout implements
 
         public TimerView(Context context) {
             super(context);
+            setFocusable(true);
+            setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
+        }
+
+        // the time is drawn rather than written, so it is reported when a screen reader asks for
+        // it: telling it as it runs would talk over everything else while recording
+        @Override
+        public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
+            super.onInitializeAccessibilityNodeInfo(info);
+            info.setClassName("android.widget.TextView");
+            final long recorded = isRunning ? System.currentTimeMillis() - startTime : stopTime - startTime;
+            info.setText(LocaleController.formatDuration((int) Math.max(0, recorded / 1000)));
         }
 
         public void start(long milliseconds) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/RecordedAudioPlayerView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/RecordedAudioPlayerView.java
@@ -14,15 +14,26 @@ import android.graphics.RectF;
 import android.graphics.SurfaceTexture;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.graphics.Rect;
+import android.os.Bundle;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
+import androidx.customview.widget.ExploreByTouchHelper;
 
 import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.LocaleController;
+import org.telegram.messenger.R;
 import org.telegram.ui.ActionBar.Theme;
 
 import java.io.File;
+import java.util.List;
 
 public class RecordedAudioPlayerView extends View {
 
@@ -50,6 +61,133 @@ public class RecordedAudioPlayerView extends View {
         text.setTextSize(dp(12));
         text.setTypeface(AndroidUtilities.bold());
         text.setOverrideFullWidth(AndroidUtilities.displaySize.x);
+
+        setFocusable(true);
+        setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
+        trimHandlesHelper = new TrimHandlesHelper(this);
+        ViewCompat.setAccessibilityDelegate(this, trimHandlesHelper);
+    }
+
+    private final TrimHandlesHelper trimHandlesHelper;
+
+    // exploring by touch asks the view where the handles are, so the question has to reach them
+    @Override
+    public boolean dispatchHoverEvent(MotionEvent event) {
+        return trimHandlesHelper.dispatchHoverEvent(event) || super.dispatchHoverEvent(event);
+    }
+
+    // the ends of the recording are moved by dragging two handles that are drawn on the waveform:
+    // report them where they are drawn and let them be moved a step at a time
+    private class TrimHandlesHelper extends ExploreByTouchHelper {
+
+        private static final int START_HANDLE = 1;
+        private static final int END_HANDLE = 2;
+
+        private final Rect bounds = new Rect();
+
+        public TrimHandlesHelper(@NonNull View host) {
+            super(host);
+        }
+
+        @Override
+        protected int getVirtualViewAt(float x, float y) {
+            if (leftHandleClickRect.contains(x, y)) {
+                return START_HANDLE;
+            } else if (rightHandleClickRect.contains(x, y)) {
+                return END_HANDLE;
+            }
+            return HOST_ID;
+        }
+
+        @Override
+        protected void getVisibleVirtualViews(List<Integer> list) {
+            // before the waveform is laid out the handles have no place yet, and reporting them
+            // without one is refused
+            if (leftHandleClickRect.isEmpty() || rightHandleClickRect.isEmpty()) {
+                return;
+            }
+            list.add(START_HANDLE);
+            list.add(END_HANDLE);
+        }
+
+        @Override
+        protected void onPopulateNodeForVirtualView(int id, @NonNull AccessibilityNodeInfoCompat info) {
+            final boolean start = id == START_HANDLE;
+            final RectF handle = start ? leftHandleClickRect : rightHandleClickRect;
+            if (handle.isEmpty()) {
+                bounds.set(0, 0, getWidth(), getHeight());
+            } else {
+                bounds.set((int) handle.left, (int) handle.top, (int) handle.right, (int) handle.bottom);
+            }
+            info.setBoundsInParent(bounds);
+            info.setClassName("android.widget.SeekBar");
+            info.setText(LocaleController.getString(start ? R.string.AccDescrRecordingTrimStart : R.string.AccDescrRecordingTrimEnd)
+                + ", " + LocaleController.formatDuration((int) ((start ? getAudioLeftMs() : getAudioRightMs()) / 1000L)));
+            info.addAction(AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD);
+            info.addAction(AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD);
+        }
+
+        @Override
+        protected boolean onPerformActionForVirtualView(int id, int action, @Nullable Bundle args) {
+            if (action != AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD && action != AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD) {
+                return false;
+            }
+            if (!moveTrimHandle(id == START_HANDLE, action == AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD)) {
+                return false;
+            }
+            invalidateVirtualView(id);
+            sendEventForVirtualView(id, AccessibilityEvent.TYPE_VIEW_SELECTED);
+            return true;
+        }
+    }
+
+    // a second at a time, kept apart by the same room the handles need when they are dragged
+    private boolean moveTrimHandle(boolean start, boolean forward) {
+        if (duration <= 0 || backgroundRect.width() <= dp(22.66f)) {
+            return false;
+        }
+        final float step = 1.0f / duration;
+        final float room = Math.max(1.0f / duration, (float) dp(30) / (backgroundRect.width() - dp(22.66f)));
+        if (start) {
+            final float wanted = left + (forward ? step : -step);
+            final float moved = clamp(wanted, clamp01(right - room), 0);
+            if (moved == left) {
+                return false;
+            }
+            left = moved;
+        } else {
+            final float wanted = right + (forward ? step : -step);
+            final float moved = clamp(wanted, 1.0f, clamp01(left + room));
+            if (moved == right) {
+                return false;
+            }
+            right = moved;
+        }
+        text.setText(AndroidUtilities.formatDuration((int) Math.round(Math.max(1, duration * (right - left))), false), true);
+        invalidate();
+        return true;
+    }
+
+    // the recorded voice message is drawn as a waveform that plays and can be trimmed, and none
+    // of it is written anywhere: report what it holds and let it be played from where it is read
+    @Override
+    public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
+        super.onInitializeAccessibilityNodeInfo(info);
+        info.setClassName("android.widget.Button");
+        info.setEnabled(true);
+        info.setClickable(true);
+        info.setText(LocaleController.formatDuration((int) Math.max(0, getNewDuration())));
+        info.addAction(new AccessibilityNodeInfo.AccessibilityAction(AccessibilityNodeInfo.ACTION_CLICK,
+            LocaleController.getString(isPlaying() ? R.string.AccActionPause : R.string.AccActionPlay)));
+    }
+
+    @Override
+    public boolean performAccessibilityAction(int action, android.os.Bundle arguments) {
+        if (action == AccessibilityNodeInfo.ACTION_CLICK) {
+            setPlaying(!isPlaying());
+            return true;
+        }
+        return super.performAccessibilityAction(action, arguments);
     }
 
     @Override

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5059,6 +5059,8 @@
     <string name="AccDescrCameraGallery">Gallery</string>
     <string name="AccDescrTakePhoto">Take photo</string>
     <string name="AccDescrStartRecording">Start recording</string>
+    <string name="AccDescrRecordingTrimStart">Trim start</string>
+    <string name="AccDescrRecordingTrimEnd">Trim end</string>
     <string name="AccDescrStopRecording">Stop recording</string>
     <string name="AccDescrLockRecording">Lock recording</string>
     <string name="AccDescrStickerSet">Sticker set</string>


### PR DESCRIPTION
## Summary

While a voice message is being recorded, the controls are drawn on a canvas rather than laid out, and what stands for them to a screen reader is incomplete: the stop button is only found by touch and never by swiping, the recorded time is not reported at all, and activating any of them does nothing, since the handler behind them returns without doing the action.

This change:

- Reports the stop button along with send and cancel, so all of them are reached by swiping as well as by touch.
- Carries out what each of them stands for, where it is drawn, so they work when they are activated.
- Reports the recorded time when a screen reader asks for it, rather than telling it as it runs, which would talk over everything else while recording.
- Reports the recorded message that is left once recording stops: how long it is, and playing and pausing it from where it is read.
- Reports the two handles that trim that recording, which can then be moved a second at a time, so the recording can be cut without dragging them.

Nothing changes visually, and the controls keep working by touch exactly as before.


## Checking it

With TalkBack on, hold the record button to start a voice recording, then swipe through the controls that appear.

Before, the stop button could only be found by touch and never by swiping, the recorded time was not reported at all, and activating any of them did nothing. Now each of them is found, does what it stands for, and the recorded time is said when it is asked for.

The recorded message left once recording stops is the other half of it.
