### PR TITLE
Keep a screen reader from skipping over rows of a list

### DIFF
--- a/TMessagesProj/src/main/java/androidx/recyclerview/widget/RecyclerView.java
+++ b/TMessagesProj/src/main/java/androidx/recyclerview/widget/RecyclerView.java
@@ -10578,18 +10578,18 @@ public class RecyclerView extends ViewGroup implements ScrollingView,
             switch (action) {
                 case AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD:
                     if (mRecyclerView.canScrollVertically(-1)) {
-                        vScroll = -(getHeight() - getPaddingTop() - getPaddingBottom());
+                        vScroll = -accessibilityScrollAmount(true, false);
                     }
                     if (mRecyclerView.canScrollHorizontally(-1)) {
-                        hScroll = -(getWidth() - getPaddingLeft() - getPaddingRight());
+                        hScroll = -accessibilityScrollAmount(false, false);
                     }
                     break;
                 case AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD:
                     if (mRecyclerView.canScrollVertically(1)) {
-                        vScroll = getHeight() - getPaddingTop() - getPaddingBottom();
+                        vScroll = accessibilityScrollAmount(true, true);
                     }
                     if (mRecyclerView.canScrollHorizontally(1)) {
-                        hScroll = getWidth() - getPaddingLeft() - getPaddingRight();
+                        hScroll = accessibilityScrollAmount(false, true);
                     }
                     break;
             }
@@ -10598,6 +10598,49 @@ public class RecyclerView extends ViewGroup implements ScrollingView,
             }
             mRecyclerView.smoothScrollBy(hScroll, vScroll);
             return true;
+        }
+
+        private final Rect mAccessibilityVisibleRect = new Rect();
+
+        // a screen reader asks a list to scroll once it reaches the last row it can see, and a
+        // page of the list is what it is given. a list can be measured taller than the part of
+        // it that is on screen, and a page of it is then more than what is shown, which carries
+        // the rows that come next past the edge before they can be reached: go by the part that
+        // is really in sight, and only far enough to bring the last row that fits in it wholly
+        // to the edge, so the row after it is the next to be read and none in between are lost
+        private int accessibilityScrollAmount(boolean vertical, boolean forward) {
+            final boolean clipToPadding = mRecyclerView.getClipToPadding();
+            int start = vertical
+                ? (clipToPadding ? getPaddingTop() : 0)
+                : (clipToPadding ? getPaddingLeft() : 0);
+            int end = vertical
+                ? (clipToPadding ? getHeight() - getPaddingBottom() : getHeight())
+                : (clipToPadding ? getWidth() - getPaddingRight() : getWidth());
+            final Rect visible = mAccessibilityVisibleRect;
+            if (mRecyclerView.getLocalVisibleRect(visible)) {
+                start = Math.max(start, vertical ? visible.top : visible.left);
+                end = Math.min(end, vertical ? visible.bottom : visible.right);
+            }
+            final int page = end - start;
+            if (page <= 0) {
+                return vertical
+                    ? getHeight() - getPaddingTop() - getPaddingBottom()
+                    : getWidth() - getPaddingLeft() - getPaddingRight();
+            }
+            int amount = 0;
+            for (int i = 0; i < getChildCount(); ++i) {
+                final View child = getChildAt(i);
+                final int childStart = vertical ? getDecoratedTop(child) : getDecoratedLeft(child);
+                final int childEnd = vertical ? getDecoratedBottom(child) : getDecoratedRight(child);
+                // a row the edge cuts through was not offered whole to the screen reader, so it
+                // is not one to carry to the edge
+                if (childStart < start || childEnd > end) {
+                    continue;
+                }
+                amount = Math.max(amount, forward ? childStart - start : end - childEnd);
+            }
+            // a row taller than what is in sight leaves nothing to go by: fall back to a page
+            return amount > 0 ? Math.min(page, amount) : page;
         }
 
         // called by accessibility delegate


### PR DESCRIPTION
## Summary

Going through the results of an inline bot with a screen reader skips over entries, and so does going through the list of people to mention: it happens at the point where the list has to scroll to carry on.

A screen reader asks a list to scroll once it reaches the last row it can see, and the list answers with a page of itself, which it takes to be its own height. That list is measured taller than the part of it that is on screen, so a page of it is more than what is shown, and the rows that come next are carried past the edge before they can be reached.

Take the page from the part of the list that is really in sight, and scroll only as far as it takes to bring the last row that fits in it wholly to the edge. The row after it is then the next one to be read, and none of the rows in between are lost. A list that is shown whole is unaffected beyond the row it now keeps.

## Checking it

With TalkBack on, open the results of an inline bot, or the list of people to mention, and swipe through them past the point where the list has to scroll.

Before, entries were skipped at exactly that point: the list scrolled by its whole measured height rather than the part of it on screen, carrying the rows that come next past the edge. Now it scrolls only as far as it takes to bring the next row into sight.
