### PR TITLE
Migrate Android Auto implementation to androidx.car.app:app:1.7.0

### DIFF
--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -27,9 +27,10 @@ dependencies {
 
     implementation 'com.google.android.gms:play-services-cast-framework:21.4.0'
     implementation "androidx.mediarouter:mediarouter:1.7.0"
+    implementation "androidx.media:media:1.7.0"
+    implementation "androidx.lifecycle:lifecycle-runtime:2.7.0"
 
-    implementation 'androidx.car.app:app:1.4.0'
-    implementation 'androidx.car.app:app-projected:1.4.0'
+    implementation 'androidx.car.app:app:1.7.0'
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
 
     compileOnly 'org.checkerframework:checker-qual:2.5.2'

--- a/TMessagesProj/src/main/AndroidManifest.xml
+++ b/TMessagesProj/src/main/AndroidManifest.xml
@@ -672,7 +672,6 @@
 
         <meta-data android:name="com.google.android.gms.wallet.api.enabled" android:value="true" />
 
-        <!--
         <meta-data android:name="com.google.android.gms.car.notification.SmallIcon" android:resource="@drawable/ic_player" />
         <meta-data android:name="com.google.android.gms.car.application" android:resource="@xml/automotive_app_desc" />
 
@@ -688,8 +687,7 @@
 
         <meta-data
             android:name="androidx.car.app.minCarApiLevel"
-            android:value="5" />
-        -->
+            android:value="7" />
 
         <meta-data android:name="com.google.android.gms.vision.DEPENDENCIES" android:value="face,barcode" />
 

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MusicPlayerService.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MusicPlayerService.java
@@ -526,7 +526,9 @@ public class MusicPlayerService extends Service implements NotificationCenter.No
                 }
             }
 
-            mediaSession.setPlaybackState(playbackState.build());
+            PlaybackStateCompat currentPlaybackState = playbackState.build();
+            mediaSession.setPlaybackState(currentPlaybackState);
+            TelegramMediaSession.getInstance(this).publishPlaybackState(currentPlaybackState);
             updateRepeatMode();
             updateShuffleMode();
             MediaMetadataCompat.Builder meta = new MediaMetadataCompat.Builder()
@@ -540,6 +542,7 @@ public class MusicPlayerService extends Service implements NotificationCenter.No
             }
 
             mediaSession.setMetadata(meta.build());
+            TelegramMediaSession.getInstance(this).publishMetadata(messageObject, audioInfo, fullAlbumArt);
 
             bldr.setVisibility(Notification.VISIBILITY_PUBLIC);
 
@@ -749,7 +752,9 @@ public class MusicPlayerService extends Service implements NotificationCenter.No
                         NOTIFY_REPEAT, LocaleController.getString(R.string.RepeatSong), repeatIcon).build());
             }
         }
-        mediaSession.setPlaybackState(playbackState.build());
+        PlaybackStateCompat currentPlaybackState = playbackState.build();
+        mediaSession.setPlaybackState(currentPlaybackState);
+        TelegramMediaSession.getInstance(this).publishPlaybackState(currentPlaybackState);
     }
 
     private void updateRepeatMode() {
@@ -821,6 +826,12 @@ public class MusicPlayerService extends Service implements NotificationCenter.No
         }
         if (mediaSession != null) {
             mediaSession.release();
+        }
+        TelegramMediaSession sessionHolder = TelegramMediaSession.peekInstance();
+        if (sessionHolder != null && MediaController.getInstance().getPlayingMessageObject() == null) {
+            sessionHolder.publishPlaybackState(new PlaybackStateCompat.Builder()
+                    .setState(PlaybackStateCompat.STATE_STOPPED, PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN, 0)
+                    .build());
         }
         for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
             NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.messagePlayingDidSeek);

--- a/TMessagesProj/src/main/java/org/telegram/messenger/TelegramMediaSession.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/TelegramMediaSession.java
@@ -436,7 +436,9 @@ public class TelegramMediaSession {
     }
 
     public void publishPlaybackState(PlaybackStateCompat state) {
-        session.setPlaybackState(state);
+        session.setPlaybackState(new PlaybackStateCompat.Builder(state)
+                .setActions(state.getActions() | getAvailableActions())
+                .build());
     }
 
     public long getAvailableActions() {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/car/HomeScreen.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/car/HomeScreen.java
@@ -268,7 +268,7 @@ public class HomeScreen extends Screen
         } else if (chat != null) {
             senderBuilder.setName(chat.title != null ? chat.title : "").setKey("c" + chat.id);
         } else {
-            senderBuilder.setName("");
+            senderBuilder.setName("").setKey("d" + dialogId);
         }
 
         return new CarMessage.Builder()

--- a/TMessagesProj/src/main/res/xml/automotive_app_desc.xml
+++ b/TMessagesProj/src/main/res/xml/automotive_app_desc.xml
@@ -2,4 +2,5 @@
 <automotiveApp>
     <uses name="notification"/>
     <uses name="template"/>
+    <uses name="media"/>
 </automotiveApp>


### PR DESCRIPTION
## What
Aligns the Android Auto code path in `DrKLO/Telegram` with the `androidx.car.app:app:1.7.0` contract, and adds the `MusicPlayerService -> TelegramMediaSession` publish hooks so that the CarApp / MediaBrowserService surface is in sync with the phone player.

## Why
The 1.7.x line of androidx.car.app tightened the contract that CarAppService implementations have to satisfy:
- `ConversationItem.validateSender()` now requires every `Person` passed in to have a non-null key. A missing key throws at runtime.
- The new contract needs `androidx.media:1.7.0` (for the `android.support.v4.media.*` compat shims) and `androidx.lifecycle:lifecycle-runtime:2.7.0` (for `DefaultLifecycleObserver` used by `HomeScreen`).
- `minCarApiLevel` has to be bumped from 5 to 7.

The phone player's `MusicPlayerService` keeps its own `MediaSessionCompat`, but the CarApp / MediaBrowserService surface that Android Auto uses is backed by `TelegramMediaSession`. Without explicitly publishing playback state and metadata to `TelegramMediaSession`, the Android Auto side has no view of what the phone player is doing. The same goes for `STATE_STOPPED` on service teardown.

## How
**6 files changed (+23/-10 vs `master`):**

### Build
- `TMessagesProj/build.gradle` - bump `androidx.car.app:app:1.4.0 -> 1.7.0`; drop `app-projected:1.4.0`; add `androidx.media:1.7.0` and `androidx.lifecycle:lifecycle-runtime:2.7.0`

### Manifest / config
- `TMessagesProj/src/main/AndroidManifest.xml` - uncomment the CarApp `<meta-data>` + `<service>` block, bump `minCarApiLevel` 5 -> 7
- `TMessagesProj/src/main/res/xml/automotive_app_desc.xml` - add `<uses name="media"/>`

### Code
- `TMessagesProj/src/main/java/org/telegram/messenger/car/HomeScreen.java` - the `senderBuilder.setName("")` empty-fallback branch in `buildCarMessage` now also calls `setKey("d" + dialogId)`, so every `Person` handed to a `ConversationItem` has a key.
- `TMessagesProj/src/main/java/org/telegram/messenger/MusicPlayerService.java` - after every `mediaSession.setPlaybackState()` and `mediaSession.setMetadata()`, also `publishPlaybackState()` / `publishMetadata()` on `TelegramMediaSession`; on `onDestroy` publish `STATE_STOPPED` when nothing is playing.
- `TMessagesProj/src/main/java/org/telegram/messenger/TelegramMediaSession.java` - `publishPlaybackState` now merges `getAvailableActions()` into the state so Android Auto renders the full action set.

## Notes
- The `androidx.media:1.7.0` artifact keeps its classes under the legacy `android.support.v4.media.*` package for binary compatibility - no import migration needed.
- The `MusicPlayerService` / `TelegramMediaSession` changes are applied as targeted hunks on top of upstream `master`, not as a verbatim file copy, because upstream `master` carries additional MIUI-specific lock-screen logic in `supportLockScreenControls` and an `accountLogin` handler in `didReceivedNotification` that the NagramX-derived forks do not have. Only the contract-alignment hunks are taken; the rest of the upstream file is preserved as-is.
- This PR is intentionally limited in scope: it does not touch the upstream `accountLogin` handler in `MusicPlayerService` (which is the NagramX-specific quirk that is being removed there). If upstream later wants to follow the same removal, that should be a separate change with its own discussion.
- Final diff against master: 6 files, 23 insertions(+), 10 deletions(-).
