### PR TITLE
Fix search hint drawn under the back button in the audio player playlist

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AudioPlayerAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AudioPlayerAlert.java
@@ -1343,6 +1343,11 @@ public class AudioPlayerAlert extends BottomSheet implements NotificationCenter.
             actionBar.setAlpha(1.0f);
             actionBarBackground.setAlpha(0.0f);
             actionBarSlideProperty.set(actionBar, 0.0f);
+        } else {
+            // actionBar.menuOccupyBack makes the search field start at the very left edge, and only
+            // actionBarSlideProperty (profile playlists only) offsets it past the back button, so
+            // without this the search hint is drawn underneath the back button
+            offsetSearchContainerFromBackButton(1.0f);
         }
 
         listAdapter.setup();
@@ -2029,6 +2034,19 @@ public class AudioPlayerAlert extends BottomSheet implements NotificationCenter.
         }
     }
 
+    private void offsetSearchContainerFromBackButton(float value) {
+        if (searchItem == null || searchItem.getSearchContainer() == null) {
+            return;
+        }
+        searchItem.getSearchContainer().setClipChildren(false);
+        searchItem.getSearchContainer().setClipToPadding(false);
+        searchItem.getSearchContainer().setPadding(0, 0, dp(AndroidUtilities.isTablet() ? 74 : 66), 0);
+        searchItem.getSearchContainer().setTranslationX(dp(AndroidUtilities.isTablet() ? 74 : 66) + dp(-52) * (1.0f - value));
+        if (searchItem.getSearchClearButton() != null) {
+            searchItem.getSearchClearButton().setTranslationX(dp(52) * (1.0f - value));
+        }
+    }
+
     private float actionBarSlide;
     private final Property<ActionBar, Float> actionBarSlideProperty = new AnimationProperties.FloatProperty<ActionBar>("actionBarSlide") {
         @Override
@@ -2039,15 +2057,7 @@ public class AudioPlayerAlert extends BottomSheet implements NotificationCenter.
 
             titleTextView.setTranslationX(dp(-52) * (1.0f - value));
             backButton.setTranslationX(dp(-52) * (1.0f - value));
-            if (searchItem != null && searchItem.getSearchContainer() != null) {
-                searchItem.getSearchContainer().setClipChildren(false);
-                searchItem.getSearchContainer().setClipToPadding(false);
-                searchItem.getSearchContainer().setPadding(0, 0, dp(AndroidUtilities.isTablet() ? 74 : 66), 0);
-                searchItem.getSearchContainer().setTranslationX(dp(AndroidUtilities.isTablet() ? 74 : 66) + dp(-52) * (1.0f - value));
-                if (searchItem.getSearchClearButton() != null) {
-                    searchItem.getSearchClearButton().setTranslationX(dp(52) * (1.0f - value));
-                }
-            }
+            offsetSearchContainerFromBackButton(value);
 
             backButton.setScaleX(lerp(0.6f, 1.0f, value));
             backButton.setScaleY(lerp(0.6f, 1.0f, value));


### PR DESCRIPTION
### Problem

In the audio player, opening the search over a regular playlist draws the search field — and its `Search` hint — underneath the back button:

![search hint overlapping the back button](https://raw.githubusercontent.com/abdullaabdullazade/Telegram-X/assets/audio-player-search-bug.png)

Steps to reproduce:
1. Play any music file so the audio player sheet opens
2. Expand the sheet to the playlist
3. Tap the search icon

### Cause

`AudioPlayerAlert` sets `actionBar.menuOccupyBack = true`, so `ActionBar` lays the expanded search field out starting at the very left edge instead of leaving room for the back button (`ActionBar.onLayout`, `menuLeft`).

The offset that pushes the search container past the back button lives only inside `actionBarSlideProperty`:

```java
searchItem.getSearchContainer().setPadding(0, 0, dp(AndroidUtilities.isTablet() ? 74 : 66), 0);
searchItem.getSearchContainer().setTranslationX(dp(AndroidUtilities.isTablet() ? 74 : 66) + dp(-52) * (1.0f - value));
```

and that property is only ever animated on the `isProfilePlaylist` branch of `updateLayout()`. For a regular playlist the offset is never applied, so the search container stays at `translationX = 0` while the back button is drawn on top of it.

### Fix

Extract the offset into `offsetSearchContainerFromBackButton(float)` and apply it once at construction time for non-profile playlists. Profile playlists keep the existing animated behaviour — the property now calls the same helper, so there is no change for that path.
