### PR TITLE
Use Android Photo Picker for external media selection

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -99,6 +99,7 @@ import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.animation.DecelerateInterpolator;
 import android.view.inputmethod.EditorInfo;
+import android.webkit.MimeTypeMap;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.HorizontalScrollView;
@@ -13799,17 +13800,7 @@ public class ChatActivity extends BaseFragment implements
                 @Override
                 public void startPhotoSelectActivity() {
                     try {
-                        Intent videoPickerIntent = new Intent();
-                        videoPickerIntent.setType("video/*");
-                        videoPickerIntent.setAction(Intent.ACTION_GET_CONTENT);
-                        videoPickerIntent.putExtra(MediaStore.EXTRA_SIZE_LIMIT, FileLoader.DEFAULT_MAX_FILE_SIZE);
-
-                        Intent photoPickerIntent = new Intent(Intent.ACTION_PICK);
-                        photoPickerIntent.setType("image/*");
-                        Intent chooserIntent = Intent.createChooser(photoPickerIntent, null);
-                        chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[]{videoPickerIntent});
-
-                        startActivityForResult(chooserIntent, 1);
+                        startActivityForResult(ChatAttachAlertPhotoLayout.createSystemMediaPickerIntent(getParentActivity(), true), 1);
                     } catch (Exception e) {
                         FileLog.e(e);
                     }
@@ -20182,6 +20173,32 @@ public class ChatActivity extends BaseFragment implements
         hideFieldPanel(false);
     }
 
+    private void openExternalPickerVideo(Uri uri, String mimeType) {
+        Utilities.globalQueue.postRunnable(() -> {
+            String videoPath = null;
+            try {
+                videoPath = AndroidUtilities.getPath(uri);
+                if (videoPath == null) {
+                    String extension = mimeType == null ? null : MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+                    videoPath = MediaController.copyFileToCache(uri, TextUtils.isEmpty(extension) ? "mp4" : extension, FileLoader.DEFAULT_MAX_FILE_SIZE);
+                }
+            } catch (Exception e) {
+                FileLog.e(e);
+            }
+            String finalVideoPath = videoPath;
+            AndroidUtilities.runOnUIThread(() -> {
+                if (finalVideoPath == null) {
+                    showAttachmentError();
+                } else if (paused) {
+                    startVideoEdit = finalVideoPath;
+                } else {
+                    openVideoEditor(finalVideoPath, null);
+                }
+                afterMessageSend();
+            });
+        });
+    }
+
     @Override
     public void onActivityResultFragment(int requestCode, int resultCode, Intent data) {
         if (resultCode == Activity.RESULT_OK) {
@@ -20201,21 +20218,15 @@ public class ChatActivity extends BaseFragment implements
                     return;
                 }
                 Uri uri = data.getData();
-                if (uri.toString().contains("video")) {
-                    String videoPath = null;
-                    try {
-                        videoPath = AndroidUtilities.getPath(uri);
-                    } catch (Exception e) {
-                        FileLog.e(e);
-                    }
-                    if (videoPath == null) {
-                        showAttachmentError();
-                    }
-                    if (paused) {
-                        startVideoEdit = videoPath;
-                    } else {
-                        openVideoEditor(videoPath, null);
-                    }
+                String mimeType = null;
+                try {
+                    mimeType = getParentActivity().getContentResolver().getType(uri);
+                } catch (Exception e) {
+                    FileLog.e(e);
+                }
+                if ((mimeType != null && mimeType.startsWith("video/")) || (mimeType == null && uri.toString().contains("video"))) {
+                    openExternalPickerVideo(uri, mimeType);
+                    return;
                 } else {
                     if (editingMessageObject == null && chatMode == MODE_SCHEDULED) {
                         AlertsCreator.createScheduleDatePickerDialog(getParentActivity(), dialog_id, (notify, scheduleDate, scheduleRepeatPeriod) -> {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPhotoLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPhotoLayout.java
@@ -3221,6 +3221,28 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
         return 1;
     }
 
+    public static Intent createSystemMediaPickerIntent(Context context, boolean allowVideo) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            Intent photoPickerIntent = new Intent(MediaStore.ACTION_PICK_IMAGES);
+            if (!allowVideo) {
+                photoPickerIntent.setType("image/*");
+            }
+            if (photoPickerIntent.resolveActivity(context.getPackageManager()) != null) {
+                return photoPickerIntent;
+            }
+        }
+
+        Intent documentPickerIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        documentPickerIntent.addCategory(Intent.CATEGORY_OPENABLE);
+        if (allowVideo) {
+            documentPickerIntent.setType("*/*");
+            documentPickerIntent.putExtra(Intent.EXTRA_MIME_TYPES, new String[]{"image/*", "video/*"});
+        } else {
+            documentPickerIntent.setType("image/*");
+        }
+        return documentPickerIntent;
+    }
+
     @Override
     public void onMenuItemClick(int id) {
         if (id == caption) {
@@ -3371,24 +3393,15 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
         } else if (id == open_in) {
             try {
                 if (parentAlert.baseFragment instanceof ChatActivity || parentAlert.avatarPicker == 2) {
-                    Intent videoPickerIntent = new Intent();
-                    videoPickerIntent.setType("video/*");
-                    videoPickerIntent.setAction(Intent.ACTION_GET_CONTENT);
-                    videoPickerIntent.putExtra(MediaStore.EXTRA_SIZE_LIMIT, FileLoader.DEFAULT_MAX_FILE_SIZE);
-
-                    Intent photoPickerIntent = new Intent(Intent.ACTION_PICK);
-                    photoPickerIntent.setType("image/*");
-                    Intent chooserIntent = Intent.createChooser(photoPickerIntent, null);
-                    chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[]{videoPickerIntent});
+                    Intent mediaPickerIntent = createSystemMediaPickerIntent(getContext(), true);
 
                     if (parentAlert.avatarPicker != 0) {
-                        parentAlert.baseFragment.startActivityForResult(chooserIntent, 14);
+                        parentAlert.baseFragment.startActivityForResult(mediaPickerIntent, 14);
                     } else {
-                        parentAlert.baseFragment.startActivityForResult(chooserIntent, 1);
+                        parentAlert.baseFragment.startActivityForResult(mediaPickerIntent, 1);
                     }
                 } else {
-                    Intent photoPickerIntent = new Intent(Intent.ACTION_PICK);
-                    photoPickerIntent.setType("image/*");
+                    Intent photoPickerIntent = createSystemMediaPickerIntent(getContext(), false);
                     if (parentAlert.avatarPicker != 0) {
                         parentAlert.baseFragment.startActivityForResult(photoPickerIntent, 14);
                     } else {


### PR DESCRIPTION
## Summary

- use the system `MediaStore.ACTION_PICK_IMAGES` flow for single external image/video selection on Android 13 and newer
- fall back to `ACTION_OPEN_DOCUMENT` with image/video MIME filters on older devices or when the system Photo Picker cannot be resolved
- detect returned videos by MIME type and copy non-file-backed picker URIs to Telegram's cache off the UI thread before opening the video editor

## Why

The external media action currently combines `ACTION_PICK` for images with `ACTION_GET_CONTENT` for videos. Because these are implicit intents, device manufacturers can resolve them to different apps; on Samsung devices this can open Samsung Gallery instead of Android's privacy-preserving Photo Picker and omit configured cloud media providers.

`ACTION_PICK_IMAGES` is the platform-recommended image/video selection action on supported Android versions. Picker URIs do not expose a normal filesystem path, so the result handling also needs to use the returned MIME type and copy video content when necessary.

## User impact

On supported devices, Telegram's external media action opens the Android Photo Picker consistently and can expose the user's configured cloud media provider. Older devices retain a system picker fallback without requiring a new dependency.

## Validation

- `git diff --check` passes
- verified both chat attachment entry points use the shared picker helper
- verified the existing request codes and single-URI result flow are preserved
- searched existing upstream pull requests for `photo picker` and `ACTION_PICK_IMAGES`; no duplicate implementation was found

