### PR TITLE
Use transient audio focus for voice media

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -3158,7 +3158,7 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
             if (neededAudioFocus == 3) {
                 result = NotificationsController.audioManager.requestAudioFocus(this, AudioManager.STREAM_VOICE_CALL, AudioManager.AUDIOFOCUS_GAIN);
             } else {
-                result = NotificationsController.audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, neededAudioFocus == 2 && !SharedConfig.pauseMusicOnMedia ? AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK : AudioManager.AUDIOFOCUS_GAIN);
+                result = NotificationsController.audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, neededAudioFocus == 2 ? (SharedConfig.pauseMusicOnMedia ? AudioManager.AUDIOFOCUS_GAIN_TRANSIENT : AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK) : AudioManager.AUDIOFOCUS_GAIN);
             }
             if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
                 audioFocus = AUDIO_FOCUSED;


### PR DESCRIPTION
## Summary

Use `AUDIOFOCUS_GAIN_TRANSIENT` for voice messages and round videos when **Pause music while playing media** is enabled.

Currently, `checkAudioFocus()` requests `AUDIOFOCUS_GAIN` in that case. This represents a permanent audio-focus takeover, so another media player can treat the loss as final and stay paused even after Telegram calls `abandonAudioFocus()` when the voice message ends.

## Behavior

- Voice / round video + pause-music setting off: keep `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK`.
- Voice / round video + pause-music setting on: use `AUDIOFOCUS_GAIN_TRANSIENT`, allowing background playback to resume after Telegram releases focus.
- Other Telegram media playback: keep `AUDIOFOCUS_GAIN` unchanged.

## Reproduction

Observed with Telegram for Android while using Android Auto and Yandex Music:

1. Start music playback.
2. Enable **Pause music while playing media** in Telegram.
3. Play a Telegram voice message.
4. Music pauses correctly, but does not resume after the voice message finishes; the user must press Play manually.

With the setting disabled, Telegram requests transient ducking and the background player continues/resumes normally, which points to the permanent `AUDIOFOCUS_GAIN` request as the difference.