### PR TITLE
Fix permanent chats-list scroll lock when fast-scroll animation target equals current layout

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/RecyclerAnimationScrollHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/RecyclerAnimationScrollHelper.java
@@ -349,6 +349,14 @@ public class RecyclerAnimationScrollHelper {
                 animator.start();
             }
         });
+
+        // If the target layout matches the current one, onLayoutChange never fires and
+        // scrollEnabled/fastScrollAnimationRunning stay locked forever (list dead until restart).
+        recyclerView.postDelayed(() -> {
+            if (animator == null && recyclerView.fastScrollAnimationRunning) {
+                cancel();
+            }
+        }, 100);
     }
 
     public void cancel() {
@@ -359,6 +367,7 @@ public class RecyclerAnimationScrollHelper {
     private void clear() {
         recyclerView.setVerticalScrollBarEnabled(true);
         recyclerView.fastScrollAnimationRunning = false;
+        recyclerView.setScrollEnabled(true);
         final RecyclerView.Adapter adapter = recyclerView.getAdapter();
         if (adapter instanceof AnimatableAdapter)
             ((AnimatableAdapter) adapter).onAnimationEnd();


### PR DESCRIPTION
## Summary (one line)

**Bug:** after a programmatic smooth scroll, the chats list occasionally becomes permanently unscrollable — rows still show pressed state, taps work, other screens scroll fine — and only force-stopping the app recovers it. **Fix:** restore `scrollEnabled` in `clear()` and add a 100 ms guard in `scrollToPosition()` that force-cancels when the layout-change callback that drives the animator never fires.

## How it happens

`scrollToPosition()` calls `setScrollEnabled(false)` **before** registering a one-shot `OnLayoutChangeListener`; only inside that callback is the `ValueAnimator` created and started, and only its `onAnimationEnd()` re-enables scrolling (`RecyclerAnimationScrollHelper.java` L84 / L123-351).

If the requested position/offset produces a layout identical to the current one — typical case: `DialogsActivity.scrollToTop(animated=true)` (e.g. tapping the title) while the list is **already at the top** — `onLayoutChange` never fires, so:

- `animator` stays `null`,
- `fastScrollAnimationRunning` stays `true`,
- `scrollEnabled` stays `false`.

No code path ever clears this state:

- `cancel()` with a `null` animator never reaches `onAnimationEnd()`;
- `clear()` reset `fastScrollAnimationRunning` but did **not** restore `scrollEnabled`.

While `fastScrollAnimationRunning` is set, `DialogsRecyclerView.onInterceptTouchEvent()`/`onTouchEvent()` return `false`, so the RecyclerView never enters the dragging state and silently drops every touch sequence. The window is millisecond-scale, which is why this shows up as a rare, months-spanning "frozen chats list" that leaves no crash/ANR trace.

## What was captured to confirm

Verified live on a device exhibiting the freeze (self-built APK of this source tree):

1. `uiautomator dump` while frozen: the chats-list RecyclerView reports `scrollable="false"` although the list holds many off-screen items. The a11y `scrollable` flag is derived from view-level `canScrollVertically()` (RecyclerView.java ~L10386), which `RecyclerListView` gates behind `scrollEnabled` — direct runtime evidence of the leaked `scrollEnabled=false`.
2. Injected `input touchscreen swipe` (~1000 px): the full DOWN → 35×MOVE → UP sequence is delivered to the window (confirmed in system input logs), yet the view hierarchy is identical before/after — zero scroll displacement.
3. Entering a chat (its own list instance) scrolls normally; returning to the dialog list keeps it frozen — the lock outlives fragment transitions.
4. Tapping filter tabs does not recover it (that path never resets the state).
5. Only `am force-stop` + relaunch restores `scrollable="true"`.

## The fix (both changes confined to this class)

1. `clear()` now restores `setScrollEnabled(true)` — any `cancel()` path leaves the view in a consistent, scrollable state.
2. `scrollToPosition()` schedules a 100 ms `postDelayed` guard: if the animator was never created (`animator == null`) while `fastScrollAnimationRunning` is still set, the helper force-cancels and cleans up. A normally started animation is unaffected (`animator != null`); the guard only converts the "frozen forever" case into "animation skipped, list fully usable".

Since the fix lives entirely in `RecyclerAnimationScrollHelper`, every caller (DialogsActivity, ContactsActivity, ChatActivity, SharedMediaLayout, Stories, etc.) gets the protection for free.

## Testing

- `:TMessagesProj:compileReleaseJavaWithJavac` passes; inserted calls verified in compiled bytecode.
- Pre-fix frozen state documented with the a11y/`uiautomator` method above. The leak window is millisecond-scale so deterministic reproduction is not practical; the guard was reviewed against all `cancel()`/`clear()` call sites for consistency (they all expect scrolling to be restored after cancel).