### PR TITLE
Fix false translation bar shown for chats in native/restricted languages (A -> A)

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/TranslateController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/TranslateController.java
@@ -191,13 +191,18 @@ public class TranslateController extends BaseController {
     }
 
     public boolean isDialogTranslatable(long dialogId) {
-        return (
-            translatableDialogs.contains(dialogId) &&
-            isFeatureAvailable(dialogId) &&
-            !DialogObject.isEncryptedDialog(dialogId) &&
-            getUserConfig().getClientUserId() != dialogId
-            /* DialogObject.isChatDialog(dialogId) &&*/
-        );
+        if (!translatableDialogs.contains(dialogId) ||
+            !isFeatureAvailable(dialogId) ||
+            DialogObject.isEncryptedDialog(dialogId) ||
+            getUserConfig().getClientUserId() == dialogId) {
+            return false;
+        }
+        String from = getDialogDetectedLanguage(dialogId);
+        String to = getDialogTranslateTo(dialogId);
+        if (from != null && (from.equals(to) || isLanguageRestricted(from))) {
+            return false;
+        }
+        return true;
     }
 
     public boolean isTranslateDialogHidden(long dialogId) {


### PR DESCRIPTION
### Problem
In some cases, when a chat mostly contains messages in the user's native language (e.g. Russian) but also has occasional English words, links, emojis, or code snippets, `TranslateController` marks the chat as translatable (`translatableDialogs.add(dialogId)`).

As a result, when the user opens the chat, the translation header appears offering to translate the chat to the **same language** (e.g. *"Translate to Russian"* in a Russian chat, where target language == detected language). Additionally, the menu displays *"Do not translate Russian"*, even if Russian is already present in `RestrictedLanguages`.

### Solution
In `TranslateController.isDialogTranslatable(dialogId)`:
- Check if `detectedLanguage` matches `targetLanguage` (`from.equals(to)`).
- Check if `detectedLanguage` is already restricted (`isLanguageRestricted(from)`).
- Prevent showing the translation bar if the chat does not actually need translation.

### Changes
Modified `TMessagesProj/src/main/java/org/telegram/messenger/TranslateController.java`.