### PR TITLE
Stop the pause button of a video from starting it over

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
@@ -7858,8 +7858,14 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
             playButtonAccessibilityOverlay.setContentDescription(getString("AccActionPlay", R.string.AccActionPlay));
             playButtonAccessibilityOverlay.setFocusable(true);
             playButtonAccessibilityOverlay.setOnClickListener(v -> {
-                onActionClick(true);
-                checkProgress(0, false, true);
+                final int state = photoProgressViews[0] != null ? photoProgressViews[0].backgroundState : PROGRESS_NONE;
+                if (isVideoOnScreen() && (state == PROGRESS_PLAY || state == PROGRESS_PAUSE)) {
+                    manuallyPaused = true;
+                    toggleVideoPlayer();
+                } else {
+                    onActionClick(true);
+                    checkProgress(0, false, true);
+                }
             });
             containerView.addView(playButtonAccessibilityOverlay, LayoutHelper.createFrame(64, 64, Gravity.CENTER));
         }
@@ -20520,6 +20526,14 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
     }
 
 
+    // a video that is on screen is played and paused where it stands, while one that is not
+    // there yet has to be asked for: asking for one that is already playing prepares the player
+    // anew, which starts it over
+    private boolean isVideoOnScreen() {
+        return aspectRatioFrameLayout != null && aspectRatioFrameLayout.getVisibility() == View.VISIBLE
+            || photoViewerWebView != null && photoViewerWebView.isControllable();
+    }
+
     private void onActionClick(boolean download) {
         if (currentMessageObject == null && currentBotInlineResult == null && (pageBlocksAdapter == null || currentFileNames[0] == null) && sendPhotoType != SELECT_TYPE_NO_SELECT) {
             return;
@@ -20821,7 +20835,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
             }
         }
         if (containerView.getTag() != null) {
-            boolean drawTextureView = aspectRatioFrameLayout != null && aspectRatioFrameLayout.getVisibility() == View.VISIBLE || photoViewerWebView != null && photoViewerWebView.isControllable();
+            boolean drawTextureView = isVideoOnScreen();
 
             if (sharedMediaType == MediaDataController.MEDIA_FILE && currentMessageObject != null) {
                 if (!currentMessageObject.canPreviewDocument()) {


### PR DESCRIPTION
## Summary

Pausing a video in the media viewer with a screen reader holds it for a moment and then leaves it playing again, and the button never becomes a play button.

What a screen reader lands on is an overlay of its own, laid over the middle of the viewer to give the button a place to be found, and it asks for the video every time it is pressed. Asking for a video that is already on screen prepares the player anew, which starts it playing right after the press appeared to pause it.

A tap in the middle of the viewer plays and pauses a video that is on screen where it stands, and only asks for one that is not there yet: have the button do the same, so pressing it pauses what is playing and plays what is paused, as it does for everyone else.

## Checking it

With TalkBack on, open a video in the media viewer and activate the middle of it to pause.

Before, it held for a moment and then went on playing, and the button never became a play button. Now it pauses and stays paused, as a tap in the middle does.
