### PR TITLE
Say what the update bar is and how far its download has got

### DIFF
--- a/TMessagesProj_AppHockeyApp/src/main/java/org/telegram/ui/Components/UpdateLayout.java
+++ b/TMessagesProj_AppHockeyApp/src/main/java/org/telegram/ui/Components/UpdateLayout.java
@@ -9,6 +9,7 @@ import android.graphics.Canvas;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.FrameLayout;
 
 import org.telegram.messenger.AndroidUtilities;
@@ -40,7 +41,7 @@ public class UpdateLayout extends IUpdateLayout {
         if (ApplicationLoader.applicationLoaderInstance.isDownloadingUpdate()) {
             final float progress = ApplicationLoader.applicationLoaderInstance.getDownloadingUpdateProgress();
             updateLayoutIcon.setProgress(progress, true);
-            updateTextView.setText(LocaleController.formatString(R.string.AppUpdateDownloading, (int) (progress * 100)));
+            setUpdateText(LocaleController.formatString(R.string.AppUpdateDownloading, (int) (progress * 100)), true);
             updateLayout.invalidate();
         }
     }
@@ -49,7 +50,25 @@ public class UpdateLayout extends IUpdateLayout {
         if (sideMenuContainer == null || updateLayout != null) {
             return;
         }
-        updateLayout = new FrameLayout(activity);
+        updateLayout = new FrameLayout(activity) {
+            @Override
+            public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
+                super.onInitializeAccessibilityNodeInfo(info);
+                // the bar is a button that draws itself, so it reports as one, and says what
+                // pressing it does, which its icon is all that tells everyone else
+                info.setClassName("android.widget.Button");
+                final int icon = updateLayoutIcon == null ? MediaActionDrawable.ICON_UPDATE : updateLayoutIcon.getIcon();
+                final CharSequence action;
+                if (icon == MediaActionDrawable.ICON_DOWNLOAD) {
+                    action = LocaleController.getString(R.string.AccActionDownload);
+                } else if (icon == MediaActionDrawable.ICON_CANCEL) {
+                    action = LocaleController.getString(R.string.AccActionCancelDownload);
+                } else {
+                    action = LocaleController.getString(R.string.AppUpdateNow);
+                }
+                info.addAction(new AccessibilityNodeInfo.AccessibilityAction(AccessibilityNodeInfo.ACTION_CLICK, action));
+            }
+        };
         updateLayout.setVisibility(View.INVISIBLE);
         updateLayout.setTranslationY(dp(44));
         updateLayout.setBackground(Theme.getSelectorDrawable(0x40ffffff, false));
@@ -84,8 +103,10 @@ public class UpdateLayout extends IUpdateLayout {
         updateTextView.setTypeface(AndroidUtilities.bold());
         updateTextView.setTextColor(0xffffffff);
         updateTextView.setGravity(Gravity.CENTER);
+        // the bar speaks for what it holds, so what it holds is left out of what is read
+        updateTextView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
         updateLayout.addView(updateTextView, LayoutHelper.createFrameMatchParent());
-        updateTextView.setText(LocaleController.getString(R.string.AppUpdateBeta), false);
+        setUpdateText(LocaleController.getString(R.string.AppUpdateBeta), false);
 
         updateLayoutIcon = new RadialProgress2(updateTextView);
         updateLayoutIcon.setColors(0xffffffff, 0xffffffff, Theme.getColor(Theme.key_featuredStickers_addButton), Theme.getColor(Theme.key_featuredStickers_addButton));
@@ -146,5 +167,10 @@ public class UpdateLayout extends IUpdateLayout {
 
     private void setUpdateText(String text, boolean animate) {
         updateTextView.setText(text, animate);
+        // what the bar says is drawn rather than laid out: a screen reader is told none of it
+        // unless the bar itself says it
+        if (updateLayout != null) {
+            updateLayout.setContentDescription(text);
+        }
     }
 }

--- a/TMessagesProj_AppStandalone/src/main/java/org/telegram/ui/Components/UpdateLayout.java
+++ b/TMessagesProj_AppStandalone/src/main/java/org/telegram/ui/Components/UpdateLayout.java
@@ -7,9 +7,11 @@ import android.animation.AnimatorListenerAdapter;
 import android.app.Activity;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
+import android.text.TextUtils;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
@@ -35,6 +37,11 @@ public class UpdateLayout extends IUpdateLayout {
     private final Activity activity;
     private final ViewGroup sideMenuContainer;
 
+    // what the bar says, and the size beside it, are drawn rather than laid out: a screen reader
+    // is told none of it unless the bar itself says it
+    private CharSequence updateStateText;
+    private CharSequence updateSizeText;
+
     public UpdateLayout(Activity activity, ViewGroup sideMenuContainer) {
         super(activity, sideMenuContainer);
         this.activity = activity;
@@ -51,7 +58,7 @@ public class UpdateLayout extends IUpdateLayout {
                 Long totalSize = (Long) args[2];
                 float loadProgress = loadedSize / (float) totalSize;
                 updateLayoutIcon.setProgress(loadProgress, true);
-                updateTextView.setText(LocaleController.formatString(R.string.AppUpdateDownloading, (int) (loadProgress * 100)));
+                setUpdateText(LocaleController.formatString(R.string.AppUpdateDownloading, (int) (loadProgress * 100)), true);
             }
         }
     }
@@ -60,7 +67,25 @@ public class UpdateLayout extends IUpdateLayout {
         if (sideMenuContainer == null || updateLayout != null) {
             return;
         }
-        updateLayout = new FrameLayout(activity);
+        updateLayout = new FrameLayout(activity) {
+            @Override
+            public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
+                super.onInitializeAccessibilityNodeInfo(info);
+                // the bar is a button that draws itself, so it reports as one, and says what
+                // pressing it does, which its icon is all that tells everyone else
+                info.setClassName("android.widget.Button");
+                final int icon = updateLayoutIcon == null ? MediaActionDrawable.ICON_UPDATE : updateLayoutIcon.getIcon();
+                final CharSequence action;
+                if (icon == MediaActionDrawable.ICON_DOWNLOAD) {
+                    action = LocaleController.getString(R.string.AccActionDownload);
+                } else if (icon == MediaActionDrawable.ICON_CANCEL) {
+                    action = LocaleController.getString(R.string.AccActionCancelDownload);
+                } else {
+                    action = LocaleController.getString(R.string.AppUpdateNow);
+                }
+                info.addAction(new AccessibilityNodeInfo.AccessibilityAction(AccessibilityNodeInfo.ACTION_CLICK, action));
+            }
+        };
         updateLayout.setVisibility(View.INVISIBLE);
         updateLayout.setTranslationY(dp(44));
         updateLayout.setBackground(Theme.getSelectorDrawable(0x40ffffff, false));
@@ -103,8 +128,10 @@ public class UpdateLayout extends IUpdateLayout {
         updateTextView.setTypeface(AndroidUtilities.bold());
         updateTextView.setTextColor(0xffffffff);
         updateTextView.setGravity(Gravity.CENTER);
+        // the bar speaks for what it holds, so what it holds is left out of what is read
+        updateTextView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
         updateLayout.addView(updateTextView, LayoutHelper.createFrameMatchParent());
-        updateTextView.setText(LocaleController.getString(R.string.AppUpdateBeta), false);
+        setUpdateText(LocaleController.getString(R.string.AppUpdateBeta), false);
 
         updateLayoutIcon = new RadialProgress2(updateTextView);
         updateLayoutIcon.setColors(0xffffffff, 0xffffffff, Theme.getColor(Theme.key_featuredStickers_addButton), Theme.getColor(Theme.key_featuredStickers_addButton));
@@ -147,7 +174,9 @@ public class UpdateLayout extends IUpdateLayout {
                     showSize = true;
                 }
             }
-            updateSizeTextView.setText(showSize ? AndroidUtilities.formatFileSize(SharedConfig.pendingAppUpdate.document.size) : null, animated);
+            updateSizeText = showSize ? AndroidUtilities.formatFileSize(SharedConfig.pendingAppUpdate.document.size) : null;
+            updateSizeTextView.setText(updateSizeText, animated);
+            updateAccessibilityText();
             if (updateLayout.getTag() != null) {
                 return;
             }
@@ -180,6 +209,17 @@ public class UpdateLayout extends IUpdateLayout {
     }
 
     private void setUpdateText(String text, boolean animate) {
+        updateStateText = text;
         updateTextView.setText(text, animate);
+        updateAccessibilityText();
+    }
+
+    private void updateAccessibilityText() {
+        if (updateLayout == null) {
+            return;
+        }
+        updateLayout.setContentDescription(TextUtils.isEmpty(updateSizeText)
+            ? updateStateText
+            : TextUtils.concat(updateStateText, ", ", updateSizeText));
     }
 }


### PR DESCRIPTION
## Summary

A new version announces itself with a dialog that reads well enough, and pressing update on it leaves a bar at the bottom of the main screen. That bar is the only way to follow the download, to stop it, and to install what came down, and a screen reader has nothing to say about it: the text it shows is drawn rather than laid out, the size beside it is drawn by something that is not a view at all, and so is the icon that carries its state.

Have the bar say what it draws. It reports as the button it is, it says the text it shows along with the size of what is to be downloaded, and the label of its click action says what pressing it does at that moment, which is downloading, stopping, or installing, all of which its icon is alone in telling everyone else. The text it holds is left out of what is read, so the bar is one stop rather than two.

Both builds that carry an update bar of their own are covered.

## Checking it

With TalkBack on, take an in-app update and press update on the dialog, which leaves a bar at the bottom of the main screen.

Before, that bar said nothing at all: not what it was, not the size of what was coming down, not how far it had got. Now it reports as the button it is, says its text and the size beside it, and its action says what pressing it does at that moment, which is downloading, stopping or installing.
