### PR TITLE
Name the buttons of the steps that put up a story

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/ColorPicker.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/ColorPicker.java
@@ -94,6 +94,7 @@ public class ColorPicker extends FrameLayout {
         settingsButton.setContentDescription(LocaleController.getString(R.string.AccDescrBrushType));
         settingsButton.setScaleType(ImageView.ScaleType.CENTER);
         settingsButton.setImageResource(R.drawable.photo_paint_brush);
+        setContentDescription(LocaleController.getString(R.string.AccDescrPaintColors));
         addView(settingsButton, LayoutHelper.createFrame(46, 52));
         settingsButton.setOnClickListener(v -> {
             if (delegate != null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/PaintColorsListView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/PaintColorsListView.java
@@ -15,6 +15,8 @@ import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.LocaleController;
+import org.telegram.messenger.R;
 import org.telegram.ui.Components.CubicBezierInterpolator;
 import org.telegram.ui.Components.Paint.PersistColorPalette;
 import org.telegram.ui.Components.RecyclerListView;
@@ -47,7 +49,10 @@ public class PaintColorsListView extends RecyclerListView {
             @NonNull
             @Override
             public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-                return new RecyclerListView.Holder(new ColorView(context));
+                final ColorView colorView = new ColorView(context);
+                // a swatch is a colour and nothing else, with no name to give it
+                colorView.setContentDescription(LocaleController.getString(R.string.AccDescrPaintColor));
+                return new RecyclerListView.Holder(colorView);
             }
 
             @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/PaintTextOptionsView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/PaintTextOptionsView.java
@@ -66,6 +66,7 @@ public class PaintTextOptionsView extends FrameLayout implements NotificationCen
         setWillNotDraw(false);
 
         colorClickableView = new View(context);
+        colorClickableView.setContentDescription(LocaleController.getString(R.string.AccDescrPaintColors));
         colorClickableView.setOnClickListener(v -> delegate.onColorPickerSelected());
         addView(colorClickableView, LayoutHelper.createFrame(24, 24, Gravity.TOP, 0, 0, 16, 0));
 
@@ -76,6 +77,7 @@ public class PaintTextOptionsView extends FrameLayout implements NotificationCen
         drawable.setCustomEndFrame(20);
         drawable.setCurrentFrame(20);
         alignView.setColorFilter(new PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN));
+        alignView.setContentDescription(LocaleController.getString(R.string.AccDescrTextAlignment));
         alignView.setOnClickListener(v -> setAlignment((currentAlign + 1) % 3, true));
         alignView.setPadding(AndroidUtilities.dp(2), AndroidUtilities.dp(2), AndroidUtilities.dp(2), AndroidUtilities.dp(2));
         addView(alignView, LayoutHelper.createFrame(28, 28, Gravity.CENTER_VERTICAL, 0, 0, 16, 0));
@@ -83,6 +85,7 @@ public class PaintTextOptionsView extends FrameLayout implements NotificationCen
         outlineView = new ImageView(context);
         outlineView.setImageResource(R.drawable.msg_text_outlined);
         outlineView.setPadding(AndroidUtilities.dp(1), AndroidUtilities.dp(1), AndroidUtilities.dp(1), AndroidUtilities.dp(1));
+        outlineView.setContentDescription(LocaleController.getString(R.string.AccDescrTextStyle));
         outlineView.setOnClickListener(v -> delegate.onTextOutlineSelected(v));
         addView(outlineView, LayoutHelper.createFrame(28, 28, Gravity.CENTER_VERTICAL, 0, 0, 16, 0));
 
@@ -90,6 +93,7 @@ public class PaintTextOptionsView extends FrameLayout implements NotificationCen
         plusView.setImageResource(R.drawable.msg_add);
         plusView.setColorFilter(new PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN));
         plusView.setBackground(Theme.createSelectorDrawable(Theme.ACTION_BAR_WHITE_SELECTOR_COLOR));
+        plusView.setContentDescription(LocaleController.getString(R.string.AccDescrPlaceText));
         plusView.setOnClickListener(v -> delegate.onNewTextSelected());
         plusView.setPadding(AndroidUtilities.dp(2), AndroidUtilities.dp(2), AndroidUtilities.dp(2), AndroidUtilities.dp(2));
         addView(plusView, LayoutHelper.createFrame(28, 28, Gravity.CENTER_VERTICAL, 0, 0, 16, 0));

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/PaintToolsView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/PaintToolsView.java
@@ -16,6 +16,7 @@ import android.view.View;
 import android.widget.LinearLayout;
 
 import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.LocaleController;
 import org.telegram.messenger.R;
 import org.telegram.ui.Components.CubicBezierInterpolator;
 import org.telegram.ui.Components.LayoutHelper;
@@ -53,6 +54,7 @@ public class PaintToolsView extends LinearLayout {
             buttons[a] = createView(i == 0, i == Brush.BRUSHES_LIST.size() + 1);
             int finalI = a;
             if (i == 0) {
+                buttons[a].setContentDescription(LocaleController.getString(R.string.AccDescrPaintColors));
                 buttons[a].setOnClickListener(v -> delegate.onColorPickerSelected());
             } else if (i > 0 && i <= Brush.BRUSHES_LIST.size()) {
                 Brush brush = Brush.BRUSHES_LIST.get(i - 1);
@@ -60,6 +62,8 @@ public class PaintToolsView extends LinearLayout {
                     continue;
                 }
                 buttons[a].setAnimation(brush.getIconRes(), 28, 28);
+                // a brush is drawn as its icon and nothing else, so it says which one it is
+                buttons[a].setContentDescription(LocaleController.getString(brushDescription(brush)));
                 buttons[a].setOnClickListener(v -> {
                     animateNextIndex(finalI);
                     delegate.onGetPalette().setCurrentBrush(finalI - 1);
@@ -67,11 +71,27 @@ public class PaintToolsView extends LinearLayout {
                 });
             } else if (i == Brush.BRUSHES_LIST.size() + 1) {
                 buttons[a].setImageResource(R.drawable.msg_add);
+                buttons[a].setContentDescription(LocaleController.getString(R.string.AccDescrPaintShapes));
                 buttons[a].setOnClickListener(v -> delegate.onAddButtonPressed(v));
             }
             addView(buttons[a]);
             a++;
         }
+    }
+
+    private static int brushDescription(Brush brush) {
+        if (brush instanceof Brush.Arrow) {
+            return R.string.PaintArrow;
+        } else if (brush instanceof Brush.Elliptical) {
+            return R.string.AccDescrPaintMarker;
+        } else if (brush instanceof Brush.Neon) {
+            return R.string.AccDescrPaintNeon;
+        } else if (brush instanceof Brush.Blurer) {
+            return R.string.AccDescrPaintBlur;
+        } else if (brush instanceof Brush.Eraser) {
+            return R.string.AccDescrPaintEraser;
+        }
+        return R.string.AccDescrPaintPen;
     }
 
     public void setSelectedIndex(int selectedIndex) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/PaintWeightChooserView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/PaintWeightChooserView.java
@@ -19,6 +19,8 @@ import androidx.core.math.MathUtils;
 import androidx.core.view.GestureDetectorCompat;
 
 import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.LocaleController;
+import org.telegram.messenger.R;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.AnimatedFloat;
 import org.telegram.ui.Components.CubicBezierInterpolator;
@@ -61,6 +63,7 @@ public class PaintWeightChooserView extends View {
 
     public PaintWeightChooserView(Context context) {
         super(context);
+        setContentDescription(LocaleController.getString(R.string.AccDescrPaintSize));
 
         gestureDetector = new GestureDetectorCompat(context, new GestureDetector.SimpleOnGestureListener() {
             float startWeight;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/DownloadButton.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/DownloadButton.java
@@ -79,6 +79,7 @@ public class DownloadButton extends ImageView {
         setVisibility(View.GONE);
         setAlpha(0f);
 
+        setContentDescription(LocaleController.getString(R.string.SaveToGallery));
         setOnClickListener(e -> onClick());
 
         progressDrawable = new CircularProgressDrawable(dp(18), dp(2), 0xffffffff);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/GalleryListView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/GalleryListView.java
@@ -560,6 +560,7 @@ public class GalleryListView extends FrameLayout implements NotificationCenter.N
             sb.setSpan(span, 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
             sb.append(" ").append(getString(R.string.StoriesCollage));
             button2View.setText(sb, false);
+            button2View.setContentDescription(getString(R.string.StoriesCollage));
             buttonsLayout.addView(button2View, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 48, 0, 0, 0, 0));
             button2View.setOnClickListener(v -> {
                 if (buttonsLayout.getAlpha() < 0.25f) return;
@@ -574,6 +575,7 @@ public class GalleryListView extends FrameLayout implements NotificationCenter.N
             selectButton = new ImageView(context);
             selectButton.setScaleType(ImageView.ScaleType.CENTER);
             selectButton.setImageResource(R.drawable.floating_check);
+            selectButton.setContentDescription(getString(R.string.Select));
             selectButton.setBackground(Theme.createCircleDrawable(dp(56), Theme.getColor(Theme.key_featuredStickers_addButton, resourcesProvider)));
             ScaleStateListAnimator.apply(selectButton, 0.1f, 1.5f);
             addView(selectButton, LayoutHelper.createFrame(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT, Gravity.BOTTOM | Gravity.RIGHT, 0, 0, 14, 14));

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/PaintView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/PaintView.java
@@ -654,6 +654,7 @@ public class PaintView extends SizeNotifierFrameLayoutPhoto implements IPhotoPai
         });
         undoButton.setAlpha(0.6f);
         undoButton.setClickable(false);
+        undoButton.setContentDescription(getString(R.string.Undo));
         topLayout.addView(undoButton, LayoutHelper.createFrame(32, 32, Gravity.TOP | Gravity.LEFT, 12, 0, 0, 0));
 
         zoomOutButton = new LinearLayout(context);
@@ -950,6 +951,7 @@ public class PaintView extends SizeNotifierFrameLayoutPhoto implements IPhotoPai
         cancelButton = new PaintCancelView(context);
         cancelButton.setPadding(dp(8), dp(8), dp(8), dp(8));
         cancelButton.setBackground(Theme.createSelectorDrawable(Theme.ACTION_BAR_WHITE_SELECTOR_COLOR));
+        cancelButton.setContentDescription(getString(R.string.Cancel));
         bottomLayout.addView(cancelButton, LayoutHelper.createFrame(32, 32, Gravity.BOTTOM | Gravity.LEFT, 12, 0, 0, 4));
         cancelButton.setOnClickListener(e -> {
             if (isColorListShown) {
@@ -1044,6 +1046,7 @@ public class PaintView extends SizeNotifierFrameLayoutPhoto implements IPhotoPai
                 onDoneButtonClickedListener.run();
             }
         });
+        doneButton.setContentDescription(getString(R.string.Done));
         bottomLayout.addView(doneButton, LayoutHelper.createFrame(32, 32, Gravity.BOTTOM | Gravity.RIGHT, 0, 0, 12, 4));
 
         weightChooserView = new PaintWeightChooserView(context);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/StoryPrivacyBottomSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/StoryPrivacyBottomSheet.java
@@ -3425,6 +3425,7 @@ public class StoryPrivacyBottomSheet extends BottomSheet implements Notification
             backDrawable.setRotatedColor(0xffffffff);
             backDrawable.setAnimationTime(220);
 //            closeView.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_dialogButtonSelector, resourcesProvider)));
+            closeView.setContentDescription(LocaleController.getString(R.string.AccDescrGoBack));
             addView(closeView, LayoutHelper.createFrame(24, 24, Gravity.CENTER_VERTICAL | (LocaleController.isRTL ? Gravity.RIGHT : Gravity.LEFT), 16, 0, 16, 0));
             closeView.setOnClickListener(e -> {
                 if (onCloseClickListener != null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/StoryRecorder.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/StoryRecorder.java
@@ -2711,6 +2711,7 @@ public class StoryRecorder implements NotificationCenter.NotificationCenterDeleg
         muteButton = new RLottieImageView(context);
         muteButton.setScaleType(ImageView.ScaleType.CENTER);
         muteButton.setImageResource(outputEntry != null && outputEntry.muted ? R.drawable.media_unmute : R.drawable.media_mute);
+        muteButton.setContentDescription(getString(outputEntry != null && outputEntry.muted ? R.string.Unmute : R.string.Mute));
         muteButton.setColorFilter(new PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.MULTIPLY));
         muteButton.setBackground(Theme.createSelectorDrawable(0x20ffffff));
         muteButton.setOnClickListener(e -> {
@@ -2741,6 +2742,7 @@ public class StoryRecorder implements NotificationCenter.NotificationCenterDeleg
         muteButton.setAlpha(0f);
 
         playButton = new PlayPauseButton(context);
+        playButton.setContentDescription(getString(R.string.AccActionPause));
         playButton.setBackground(Theme.createSelectorDrawable(0x20ffffff));
         playButton.setVisibility(View.GONE);
         playButton.setAlpha(0f);
@@ -2748,6 +2750,7 @@ public class StoryRecorder implements NotificationCenter.NotificationCenterDeleg
             boolean playing = previewView.isPlaying();
             previewView.play(!playing);
             playButton.drawable.setPause(!playing, true);
+            playButton.setContentDescription(getString(!playing ? R.string.AccActionPause : R.string.AccActionPlay));
         });
 
         actionBarButtons.addView(playButton, LayoutHelper.createLinear(46, 56, Gravity.TOP | Gravity.RIGHT));
@@ -5186,6 +5189,7 @@ public class StoryRecorder implements NotificationCenter.NotificationCenterDeleg
             previewButtons.setButtonVisible(PreviewButtons.BUTTON_CROP, BuildVars.DEBUG_PRIVATE_VERSION && outputEntry != null && !outputEntry.isRepostMessage && !outputEntry.isCollage());
             previewButtons.setShareEnabled(!videoError && !captionEdit.isCaptionOverLimit() && (!MessagesController.getInstance(currentAccount).getStoriesController().hasStoryLimit(getCount()) || (outputEntry != null && (outputEntry.isEdit || outputEntry.botId != 0))));
             muteButton.setImageResource(outputEntry != null && outputEntry.muted ? R.drawable.media_unmute : R.drawable.media_mute);
+        muteButton.setContentDescription(getString(outputEntry != null && outputEntry.muted ? R.string.Unmute : R.string.Mute));
             previewView.setVisibility(View.VISIBLE);
             timelineView.setVisibility(View.VISIBLE);
             titleTextView.setVisibility(View.VISIBLE);
@@ -7693,6 +7697,7 @@ public class StoryRecorder implements NotificationCenter.NotificationCenterDeleg
             themeButton.setScaleType(ImageView.ScaleType.CENTER);
             themeButton.setColorFilter(new PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.MULTIPLY));
             themeButton.setBackground(Theme.createSelectorDrawable(0x20ffffff));
+            themeButton.setContentDescription(getString(R.string.Theme));
             themeButton.setOnClickListener(e -> {
                 toggleTheme();
             });

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/StoryThemeSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/StoryThemeSheet.java
@@ -47,6 +47,7 @@ public class StoryThemeSheet extends FrameLayout {
         backButtonView.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_listSelector, resourcesProvider), Theme.RIPPLE_MASK_CIRCLE_20DP));
         backButtonDrawable = new BackDrawable(true);
         backButtonView.setImageDrawable(backButtonDrawable);
+        backButtonView.setContentDescription(LocaleController.getString(R.string.AccDescrGoBack));
         backButtonView.setOnClickListener(v -> {
             dismiss();
         });

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5072,6 +5072,17 @@
     <string name="AccDescrBrushType">Brush type</string>
     <string name="AccDescrPaint">Paint</string>
     <string name="AccDescrPlaceText">Place text</string>
+    <string name="AccDescrPaintColors">Colors</string>
+    <string name="AccDescrPaintColor">Color</string>
+    <string name="AccDescrPaintPen">Pen</string>
+    <string name="AccDescrPaintMarker">Marker</string>
+    <string name="AccDescrPaintNeon">Neon</string>
+    <string name="AccDescrPaintBlur">Blur</string>
+    <string name="AccDescrPaintEraser">Eraser</string>
+    <string name="AccDescrPaintShapes">Shapes</string>
+    <string name="AccDescrPaintSize">Brush size</string>
+    <string name="AccDescrTextAlignment">Text alignment</string>
+    <string name="AccDescrTextStyle">Text style</string>
     <string name="AccDescrPhotoEditor">Photo editor</string>
     <string name="AccDescrPhotoAdjust">Adjustments</string>
     <string name="AccDescrPhotoViewer">Photo viewer</string>


### PR DESCRIPTION
## Summary

Going through the making of a story with a screen reader arrives at button after button that is called nothing but a button: the ones that draw themselves an icon and say nothing of it.

Where the app already has a word for what a button does, it is the word used. The sound of a video is muted and unmuted, the preview is played and paused, what was made is saved to the gallery, the wallpaper of a text story is a theme, the pictures are put in a collage or selected, the sheets are gone back from, and what was drawn is undone, cancelled or done with.

The rest are the tools of the drawing and the text, which have no name anywhere in the app: the colours, the pen, the marker, the neon, the blur, the eraser, the shapes, the size a brush draws at, the alignment of a text and the style it is drawn in. Those are named here, beside the rest of the accessibility strings.

Nothing is moved, and nothing that was not said before is done differently: every one of these only says what it already was.

## Checking it

With TalkBack on, go through the making of a story: the camera, the preview, the drawing tools and the text tools.

Before, button after button was called nothing but "button". Now each of them says what it is, using the word the app already has for it where there is one.
