### PR TITLE
Say what the card under a link holds

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -26573,6 +26573,44 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         return layoutHeight;
     }
 
+    // the card under a link is made of a site name, a title, an author and a description, each
+    // of them drawn on its own: put together they are what the card says
+    private CharSequence linkPreviewAccessibilityText() {
+        final StringBuilder sb = new StringBuilder();
+        appendLinkPreviewLayout(sb, siteNameLayout);
+        appendLinkPreviewLayout(sb, titleLayout);
+        appendLinkPreviewLayout(sb, authorLayout);
+        appendLinkPreviewLayout(sb, descriptionLayout);
+        return sb;
+    }
+
+    private void appendLinkPreviewLayout(StringBuilder sb, StaticLayout layout) {
+        if (layout == null) {
+            return;
+        }
+        final CharSequence text = layout.getText();
+        if (TextUtils.isEmpty(text)) {
+            return;
+        }
+        if (sb.length() > 0) {
+            sb.append(", ");
+        }
+        sb.append(text);
+    }
+
+    // a card that is only a picture is opened as a picture, which the message already offers, so
+    // the action is for the ones that stand for a page
+    private boolean hasOpenableLinkPreview() {
+        if (currentMessageObject == null || currentMessageObject.preview || !hasLinkPreview) {
+            return false;
+        }
+        if (drawPhotoImage && (documentAttachType == DOCUMENT_ATTACH_TYPE_GIF || documentAttachType == DOCUMENT_ATTACH_TYPE_VIDEO || authorLayout == null && titleLayout == null && descriptionLayout == null && siteNameLayout == null)) {
+            return false;
+        }
+        final TLRPC.MessageMedia media = MessageObject.getMedia(currentMessageObject.messageOwner);
+        return media != null && media.webpage != null;
+    }
+
     @Override
     public boolean performAccessibilityAction(int action, Bundle arguments) {
         if (delegate != null && delegate.onAccessibilityAction(action, arguments)) {
@@ -26596,6 +26634,22 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     delegate.didLongPress(this, 0, 0);
                 } else {
                     delegate.didPressOther(this, otherX, otherY);
+                }
+            }
+        } else if (action == R.id.acc_action_open_link_preview) {
+            if (currentMessageObject != null) {
+                final TLRPC.MessageMedia media = MessageObject.getMedia(currentMessageObject.messageOwner);
+                final TLRPC.WebPage webPage = media == null ? null : media.webpage;
+                if (webPage != null) {
+                    if (!TextUtils.isEmpty(webPage.embed_url)) {
+                        if (delegate != null) {
+                            delegate.needOpenWebView(currentMessageObject, webPage.embed_url, webPage.site_name, webPage.title, webPage.url, webPage.embed_width, webPage.embed_height);
+                        }
+                    } else if (delegate != null) {
+                        delegate.didPressWebPage(this, webPage, webPage.url, media.safe);
+                    } else {
+                        Browser.openUrl(getContext(), webPage.url);
+                    }
                 }
             }
         } else if (action == R.id.acc_action_open_forwarded_origin) {
@@ -27320,6 +27374,17 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         };
                         sb.setSpan(underlineSpan, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                     }
+                    // the card drawn under a link says nothing of itself: what it holds goes at
+                    // the very end of the message, once everything else has been said
+                    if (hasLinkPreview) {
+                        final CharSequence preview = linkPreviewAccessibilityText();
+                        if (!TextUtils.isEmpty(preview)) {
+                            sb.append("\n");
+                            sb.append(getString(R.string.LinkPreview));
+                            sb.append(", ");
+                            sb.append(preview);
+                        }
+                    }
                     accessibilityText = sb;
                     accessibilityTextUnread = unread;
                     accessibilityTextContentUnread = contentUnread;
@@ -27469,6 +27534,15 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
                 if (forwardedNameLayout[0] != null && forwardedNameLayout[1] != null) {
                     info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_open_forwarded_origin, getString("AccActionOpenForwardedOrigin", R.string.AccActionOpenForwardedOrigin)));
+                }
+                if (hasOpenableLinkPreview()) {
+                    // the action carries the card as well, so what the link leads to can be heard
+                    // from the list of actions without going back through the message for it
+                    final CharSequence preview = linkPreviewAccessibilityText();
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(
+                        R.id.acc_action_open_link_preview,
+                        TextUtils.isEmpty(preview) ? getString(R.string.OpenUrlTitle) : TextUtils.concat(getString(R.string.OpenUrlTitle), ", ", preview)
+                    ));
                 }
                 if (drawSelectionBackground || getBackground() != null) {
                     info.setSelected(true);

--- a/TMessagesProj/src/main/res/values/ids.xml
+++ b/TMessagesProj/src/main/res/values/ids.xml
@@ -29,6 +29,7 @@
     <item name="acc_action_open_photo" type="id"/>
     <item name="acc_action_chat_preview" type="id"/>
     <item name="acc_action_open_forwarded_origin" type="id"/>
+    <item name="acc_action_open_link_preview" type="id"/>
     <item name="acc_action_copy_code" type="id"/>
     <item name="acc_action_summarize" type="id"/>
     <item name="shake_animation" type="id"/>


### PR DESCRIPTION
## Summary

A message that carries a link has a card drawn under it with the name of the site, the title of the page, who wrote it and what it says. A screen reader is told none of that: the message ends at its own text, and what the link leads to is never spoken.

Put the card at the very end of the message, after the date and all the rest of it, as the word for a link preview followed by the four things it is made of, whichever of them the card has.

Opening it is an action on the message rather than a stop of its own, so going through a chat does not grow a step for every link, and the action carries the card with it, so what the link leads to can be heard from the list of actions as well. What the action does is what a press on the card does: a page is opened, and one that carries a video of its own is played where it would have been. A card that is only a picture keeps to the action the message already has for opening a picture.

## Checking it

With TalkBack on, swipe onto a message carrying a link that has a card drawn under it.

Before, the message ended at its own text and the card was never spoken. Now it is read at the end of the message, after the date, as "link preview" followed by whichever of the site, the title, the author and the description the card has.

Opening it is an action on the message rather than another stop to swipe onto, and the action carries the text of the card with it.
