### PR TITLE
Fix expanding bio on own profile

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
@@ -7496,10 +7496,10 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
             if (position == bioRow && (userInfo == null || TextUtils.isEmpty(userInfo.about))) {
                 return false;
             }
-            if (editRow(view, position)) return true;
             if (view instanceof AboutLinkCell && ((AboutLinkCell) view).onClick()) {
                 return false;
             }
+            if (editRow(view, position)) return true;
             String text;
             if (position == locationRow) {
                 text = chatInfo != null && chatInfo.location instanceof TLRPC.TL_channelLocation ? ((TLRPC.TL_channelLocation) chatInfo.location).address : null;


### PR DESCRIPTION
## Summary

- expand a collapsed bio before handling self-profile edit actions
- keep the Copy/Edit menu available after the bio is expanded

## Cause

`editRow()` handled taps on the self-profile bio before `AboutLinkCell.onClick()` could expand the collapsed text.

## Reproduction

[Video (phone number blurred)](https://raw.githubusercontent.com/abdullaabdullazade/Telegram-X/pr-assets-profile-bio-more/docs/profile-bio-more-reproduction-blurred.mp4)

Before this change, tapping **more** on the owner profile opens the Copy/Edit menu instead of expanding the bio.