### PR TITLE
Fix vibration for incoming calls in background on Android 13+ (Samsung One UI, Xiaomi HyperOS)

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPPreNotificationService.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPPreNotificationService.java
@@ -18,6 +18,8 @@ import android.media.MediaPlayer;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
+import android.os.VibrationAttributes;
+import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.provider.Settings;
 import android.text.SpannableString;
@@ -348,7 +350,18 @@ public class VoIPPreNotificationService { // } extends Service implements AudioM
                     } else if (vibrate == 3) {
                         duration *= 2;
                     }
-                    vibrator.vibrate(new long[]{0, duration, 500}, 0);
+                    final long[] pattern = {0, duration, 500};
+                    if (Build.VERSION.SDK_INT >= 33) {
+                        // Without attributes the vibration is classified as USAGE_UNKNOWN, which
+                        // the system ignores for background apps; USAGE_RINGTONE is allowed in
+                        // background and follows the system call vibration settings.
+                        vibrator.vibrate(
+                            VibrationEffect.createWaveform(pattern, 0),
+                            new VibrationAttributes.Builder().setUsage(VibrationAttributes.USAGE_RINGTONE).build()
+                        );
+                    } else {
+                        vibrator.vibrate(pattern, 0);
+                    }
                 }
             }
         }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPService.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPService.java
@@ -70,6 +70,8 @@ import android.os.IBinder;
 import android.os.Looper;
 import android.os.PowerManager;
 import android.os.SystemClock;
+import android.os.VibrationAttributes;
+import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.provider.Settings;
 import android.telecom.CallAudioState;
@@ -4128,7 +4130,18 @@ public class VoIPService extends Service implements SensorEventListener, AudioMa
 					} else if (vibrate == 3) {
 						duration *= 2;
 					}
-					vibrator.vibrate(new long[]{0, duration, 500}, 0);
+					final long[] pattern = {0, duration, 500};
+					if (Build.VERSION.SDK_INT >= 33) {
+						// Without attributes the vibration is classified as USAGE_UNKNOWN, which
+						// the system ignores for background apps; USAGE_RINGTONE is allowed in
+						// background and follows the system call vibration settings.
+						vibrator.vibrate(
+							VibrationEffect.createWaveform(pattern, 0),
+							new VibrationAttributes.Builder().setUsage(VibrationAttributes.USAGE_RINGTONE).build()
+						);
+					} else {
+						vibrator.vibrate(pattern, 0);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Problem

Incoming Telegram calls do not vibrate when the app is in the background or the screen is locked, even though vibration is enabled both at the OS level and in Telegram settings. The call screen, caller name, and ringtone all work — only vibration is missing. Vibration works only while the app is in the foreground.

Reported repeatedly since 2024 across Samsung (One UI), Xiaomi (HyperOS) and other devices, with a new wave of reports after the One UI 7 (Android 15) rollout:

- https://bugs.telegram.org/c/2569 — POCO X6 Pro, Galaxy A16, Flip 7, S24+, S26 Ultra, OnePlus 12 and others ("ringtone works fine, vibration doesn't work at all")
- https://bugs.telegram.org/c/43817 — Galaxy S23 ("no vibration for incoming calls, resulting in missed calls; message notifications still vibrate normally")

## Root cause

On Android 13+ (SDK 33), incoming calls ring via `VoIPPreNotificationService` — i.e. from a **background** process woken by the push, with no foreground service running while ringing. The `incoming_calls` notification channel deliberately has vibration disabled (the app vibrates manually so it can loop the pattern), so the only vibration source is the app process itself.

That manual vibration uses the deprecated `Vibrator.vibrate(long[], int)` overload with no attributes, which the platform classifies as `VibrationAttributes.USAGE_UNKNOWN`. In AOSP [`VibrationSettings`](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android15-release/services/core/java/com/android/server/vibrator/VibrationSettings.java), `USAGE_UNKNOWN`:

- is **not** in `BACKGROUND_PROCESS_USAGE_ALLOWLIST`, so the request is rejected with `Vibration.Status.IGNORED_BACKGROUND` whenever the app process is not foreground;
- is additionally gated by the *Media* vibration intensity setting rather than the *Call* vibration setting the user expects.

The [`Vibrator` documentation](https://developer.android.com/reference/android/os/Vibrator#vibrate(android.os.VibrationEffect,%20android.os.VibrationAttributes)) is explicit: *"The app should be in the foreground for the vibration to happen. Background apps should specify a ringtone, notification or alarm usage in order to vibrate."*

OEM builds have been enforcing this progressively (Xiaomi HyperOS on Android 14, Samsung One UI 7 on Android 15), which is why the ringtone — a regular audio stream with no such restriction — keeps playing while the vibration silently dies. This can be confirmed on an affected device: `adb shell dumpsys vibrator_manager` shows the call vibration as `IGNORED_BACKGROUND` with `usage = UNKNOWN`.

## Fix

On SDK >= 33, use the recommended API instead:

- `VibrationEffect.createWaveform(pattern, 0)` with
- `VibrationAttributes.Builder().setUsage(VibrationAttributes.USAGE_RINGTONE)` — allowed from background processes and correctly tied to the system call-vibration setting and intensity.

Older SDKs keep the existing behavior. The same vibration pattern and user settings (short/long/vibrate-only modes) are preserved.

The fix is applied to both ringing code paths, so it works regardless of which service handles the ringing:

- `VoIPPreNotificationService.startRinging()` — used on SDK 33+ for private calls and group-call invites
- `VoIPService.startRingtoneAndVibration()`

This supersedes #1833 and #1854 (same approach, approved but never merged and since gone stale), rebased onto current master (v12.10.1) and additionally covering the second code path.

## How to verify

1. Install on an affected device (e.g. Galaxy S24+ with One UI 7 / Android 15).
2. Lock the phone (or keep Telegram in the background) and receive a Telegram call with ringer mode Normal or Vibrate.
3. The phone vibrates continuously while ringing; `adb shell dumpsys vibrator_manager` shows the vibration with `usage = RINGTONE` and status `FINISHED`/`CANCELLED_BY_USER` instead of `IGNORED_BACKGROUND`.
4. Silent mode, Do Not Disturb, and Telegram's per-contact/global vibration settings (default/short/long/disabled/vibrate-only) behave exactly as before.
