### PR TITLE
Fix stuck passcode window after unlocking with fingerprint

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/PasscodeView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/PasscodeView.java
@@ -92,6 +92,7 @@ public class PasscodeView extends FrameLayout implements NotificationCenter.Noti
         } else if (id == NotificationCenter.passcodeDismissed) {
             if (args[0] != this) {
                 setVisibility(GONE);
+                onHidden();
             }
         }
     }


### PR DESCRIPTION
## Symptom

After the app auto-locks in the background and is unlocked with a
fingerprint, the UI keeps rendering but stops reacting to touches. It
cannot be closed, and Back merely sends the app to the background. The
interface also stays zoomed at 1.25x. Only killing the app helps.

Reproduced on the official 12.9.0 and 12.10.1 builds and on a debug build
of the current master (12.10.1), on Android 16 (Xiaomi/MIUI, arm64).
A passcode with auto-lock and fingerprint unlock has to be enabled; with
the passcode off the problem never appears.

## Steps to reproduce

Settings -> Privacy and Security -> Passcode: on, auto-lock 1 minute,
unlock by fingerprint.

1. Open a mini app, background the app for two minutes, return, unlock
   with the fingerprint. The mini app is now frozen. This path is
   reproducible every time.
2. Open the attach menu in any chat, background the app for a minute,
   return, unlock with the fingerprint. Same freeze, plus the visibly
   zoomed interface. This path does not always trigger: on resume
   LaunchActivity calls actionBarLayout.dismissDialogs(), and if the
   attach menu closes before the unlock, the overlay is unregistered and
   the unlock takes the normal path. The fix covers this path as well,
   since it is the same code.

## What the window manager shows

In the frozen state the activity has three windows instead of two, and the
top one is the leaked passcode dialog:

    gr=FILL CENTER  ty=APPLICATION  fmt=TRANSPARENT
    wanim=@style/DialogNoAnimation  touchableRegion=[0,0][1220,2712]
    focused

`uiautomator dump` of that window returns four empty FrameLayouts and
nothing else, while `dumpsys input` shows the touch stream being delivered
to it normally (queues empty, connection responsive). The input system is
healthy; the events are consumed by an empty window.

## Root cause

While a mini app sheet or the attach menu is open, BotWebViewSheet.onStart()
and ChatAttachAlert.onStart() register their own PasscodeView through
addOverlayPasscodeView(), so showPasscodeActivity() shows two passcode
views. allowShowFingerprintDialog() then routes the biometric prompt to the
last overlay rather than to PasscodeViewDialog's view.

When the overlay accepts the fingerprint, LaunchActivity posts
passcodeDismissed, and every other view runs:

```java
} else if (id == NotificationCenter.passcodeDismissed) {
    if (args[0] != this) {
        setVisibility(GONE);
    }
}
```

For PasscodeViewDialog's view that is not enough. Its window is removed
only from onHidden(), and dismiss() is overridden to call
moveTaskToBack() instead of closing anything, so the window is left behind
forever. onHidden() also resets drawerLayoutContainer back to scale 1.0,
which is why the interface stays at 1.25x.

This is a regression, not intent. Until 10.13.1 the passcode was a plain
view inside the activity and hiding it was enough. 10.13.1 moved it into
its own window, added the onHidden() hook and wired it into processDone(),
but left this second call site unchanged.

## Fix

One line, restoring the same contract processDone() already follows.

## Testing

Built the current master (12.10.1) unmodified: both paths reproduce, and
the leaked window is visible in dumpsys. Built it again with this change:
the freeze is gone, the sheet responds immediately after unlocking, the
zoom is gone, and the activity is back to two windows.
