### PR TITLE
Fix redundant loop calling ConnectionsManager.setLangCode in LocaleController

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/LocaleController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/LocaleController.java
@@ -3341,9 +3341,7 @@ public class LocaleController {
                     }
                 }, ConnectionsManager.RequestFlagWithoutLogin);
             } else {
-                for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
-                    ConnectionsManager.setLangCode(localeInfo.getLangCode());
-                }
+                ConnectionsManager.setLangCode(localeInfo.getLangCode());
                 FileLog.d("applyRemoteLanguage getLangPack");
                 TLRPC.TL_langpack_getLangPack req = new TLRPC.TL_langpack_getLangPack();
                 req.lang_code = localeInfo.getLangCode();


### PR DESCRIPTION
### Summary
In `LocaleController.applyRemoteLanguage()`, `ConnectionsManager.setLangCode(localeInfo.getLangCode())` was being called inside a `for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++)` loop.

However, `ConnectionsManager.setLangCode()` is a static method that already iterates over all accounts internally (`0..UserConfig.MAX_ACCOUNT_COUNT`) and invokes `native_setLangCode(a, langCode)` for each account:

```java
public static void setLangCode(String langCode) {
    langCode = langCode.replace('_', '-').toLowerCase();
    for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
        native_setLangCode(a, langCode);
    }
}
```

Because of this outer loop in `LocaleController`, `native_setLangCode` was being called `MAX_ACCOUNT_COUNT * MAX_ACCOUNT_COUNT` times (16 calls when `MAX_ACCOUNT_COUNT = 4`), triggering redundant JNI string allocations and scheduling redundant native tasks to each account 4 times instead of once.

### Changes
Remove the redundant outer `for` loop in `LocaleController.applyRemoteLanguage()`, aligning with the single invocation pattern used in `LocaleController.applyLanguage()`.