### PR TITLE
Play received voice notes from Android Auto

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/car/CarVoiceAttachment.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/car/CarVoiceAttachment.java
@@ -1,0 +1,70 @@
+package org.telegram.messenger.car;
+
+import android.content.Context;
+import android.net.Uri;
+
+import androidx.annotation.Nullable;
+import androidx.core.content.FileProvider;
+
+import java.io.File;
+
+/**
+ * Resolves the audio attachment that lets Android Auto play a received voice note straight
+ * from the message, rather than only rendering "Voice message" as text.
+ *
+ * Kept separate from {@link HomeScreen} so the decision can be unit tested: it is pure
+ * apart from the FileProvider lookup, and the car host is not involved.
+ */
+final class CarVoiceAttachment {
+
+    /** Telegram records voice notes as Ogg/Opus. */
+    static final String MIME_TYPE = "audio/ogg";
+
+    private CarVoiceAttachment() {
+    }
+
+    /**
+     * Whether the recording may be disclosed to the car at all.
+     *
+     * <p>Separate from {@link #resolveUri} so the caller can tell "not allowed" apart from
+     * "not downloaded yet": the second is worth fetching on demand, the first must not
+     * trigger any work.
+     */
+    static boolean isDisclosureAllowed(boolean previewAllowed, boolean locked) {
+        return previewAllowed && !locked;
+    }
+
+    /**
+     * Resolves a {@code content://} URI for a voice note, or null when it must not or cannot
+     * be attached.
+     *
+     * <p>Attaching audio is a stronger disclosure than the text body: when previews are
+     * suppressed the body already reads as a generic placeholder, so playing the actual
+     * recording aloud in the car would leak precisely what the user asked to hide. Both
+     * privacy flags therefore gate the attachment, mirroring how NotificationsController
+     * guards the equivalent MessagingStyle attachment.
+     *
+     * @param authority      FileProvider authority, i.e. applicationId + ".provider"
+     * @param file           local file for the note, from FileLoader#getPathToMessage
+     * @param previewAllowed preview[0] as reported by getShortStringForMessage
+     * @param locked         passcode is set or pending, so content must stay hidden
+     */
+    @Nullable
+    static Uri resolveUri(Context context, String authority, @Nullable File file,
+                          boolean previewAllowed, boolean locked) {
+        if (!isDisclosureAllowed(previewAllowed, locked)) {
+            return null;
+        }
+        // Not downloaded yet, or a zero-length placeholder from an interrupted download.
+        if (file == null || !file.exists() || file.length() == 0) {
+            return null;
+        }
+        try {
+            return FileProvider.getUriForFile(context, authority, file);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            // The file resolved outside every configured provider path, or the authority
+            // is not registered. Fall back to text-only rather than failing the message.
+            return null;
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/org/telegram/messenger/car/HomeScreen.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/car/HomeScreen.java
@@ -83,6 +83,9 @@ public class HomeScreen extends Screen
      */
     private final HashSet<String> pendingVoiceLoads = new HashSet<>();
 
+    /** Voice-note URIs the host was granted read access to, so they can be revoked later. */
+    private final HashSet<Uri> grantedUris = new HashSet<>();
+
     private String activeTabId = TAB_NOTIFICATIONS;
     private boolean musicLoadKicked;
 
@@ -112,11 +115,19 @@ public class HomeScreen extends Screen
     }
 
     @Override
+    public void onDestroy(@NonNull LifecycleOwner owner) {
+        revokeHostGrants();
+    }
+
+    @Override
     public void didReceivedNotification(int id, int account, Object... args) {
         if (id == NotificationCenter.activeAccountChanged) {
             // Unsubscribe from the outgoing account before currentAccount moves, or the
             // observer would be left registered on it forever.
             NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.fileLoaded);
+            // Drop grants before switching: they point at the outgoing account's files, and
+            // the incoming account must not inherit read access to them.
+            revokeHostGrants();
             currentAccount = UserConfig.selectedAccount;
             NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.fileLoaded);
             pendingVoiceLoads.clear();
@@ -377,10 +388,35 @@ public class HomeScreen extends Screen
             }
             getCarContext().grantUriPermission(
                     host.getPackageName(), uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            grantedUris.add(uri);
             return true;
         } catch (Throwable t) {
             return false;
         }
+    }
+
+    /**
+     * Drops the grants handed to the host, so read access does not outlive the drive.
+     *
+     * <p>Deliberately not tied to onPause or to a timer. The host reads the file when the
+     * user presses play, which can be long after the message appeared, so revoking on a
+     * delay -- as the notification code does for images that SystemUI reads immediately --
+     * would risk cutting playback. Bounding the grants to the screen's lifetime and to the
+     * active account keeps them from accumulating without that risk.
+     */
+    private void revokeHostGrants() {
+        if (grantedUris.isEmpty()) {
+            return;
+        }
+        for (Uri uri : grantedUris) {
+            try {
+                ApplicationLoader.applicationContext.revokeUriPermission(
+                        uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            } catch (Throwable ignore) {
+                // Already gone, or never granted; nothing to undo.
+            }
+        }
+        grantedUris.clear();
     }
 
     // ===== Music tab =====

--- a/TMessagesProj/src/main/java/org/telegram/messenger/car/HomeScreen.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/car/HomeScreen.java
@@ -8,10 +8,13 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.RectF;
 import android.graphics.Shader;
+import android.content.Intent;
+import android.net.Uri;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.car.app.CarContext;
+import androidx.car.app.HostInfo;
 import androidx.car.app.Screen;
 import androidx.car.app.model.Action;
 import androidx.car.app.model.CarIcon;
@@ -46,6 +49,7 @@ import org.telegram.messenger.NotificationCenter;
 import org.telegram.messenger.NotificationsController;
 import org.telegram.messenger.R;
 import org.telegram.messenger.SendMessagesHelper;
+import org.telegram.messenger.SharedConfig;
 import org.telegram.messenger.TelegramMediaSession;
 import org.telegram.messenger.UserConfig;
 import org.telegram.messenger.UserObject;
@@ -54,6 +58,7 @@ import org.telegram.tgnet.TLRPC;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +76,13 @@ public class HomeScreen extends Screen
     private final long sessionStartMillis;
     private int currentAccount;
 
+    /**
+     * Voice notes whose download this screen requested, keyed by FileLoader attach name.
+     * Only touched from the main thread: onGetTemplate is called by the host there, and
+     * fileLoaded is delivered there too.
+     */
+    private final HashSet<String> pendingVoiceLoads = new HashSet<>();
+
     private String activeTabId = TAB_NOTIFICATIONS;
     private boolean musicLoadKicked;
 
@@ -86,6 +98,9 @@ public class HomeScreen extends Screen
         NotificationCenter.getGlobalInstance().addObserver(this, NotificationCenter.pushMessagesUpdated);
         NotificationCenter.getGlobalInstance().addObserver(this, NotificationCenter.notificationsCountUpdated);
         NotificationCenter.getGlobalInstance().addObserver(this, NotificationCenter.activeAccountChanged);
+        // fileLoaded is posted per account, not globally, so it has to be observed on the
+        // current account's center and moved whenever that account changes.
+        NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.fileLoaded);
     }
 
     @Override
@@ -93,14 +108,27 @@ public class HomeScreen extends Screen
         NotificationCenter.getGlobalInstance().removeObserver(this, NotificationCenter.pushMessagesUpdated);
         NotificationCenter.getGlobalInstance().removeObserver(this, NotificationCenter.notificationsCountUpdated);
         NotificationCenter.getGlobalInstance().removeObserver(this, NotificationCenter.activeAccountChanged);
+        NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.fileLoaded);
     }
 
     @Override
     public void didReceivedNotification(int id, int account, Object... args) {
         if (id == NotificationCenter.activeAccountChanged) {
+            // Unsubscribe from the outgoing account before currentAccount moves, or the
+            // observer would be left registered on it forever.
+            NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.fileLoaded);
             currentAccount = UserConfig.selectedAccount;
+            NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.fileLoaded);
+            pendingVoiceLoads.clear();
             musicLoadKicked = false;
             invalidate();
+        } else if (id == NotificationCenter.fileLoaded) {
+            if (args.length > 0 && args[0] instanceof String
+                    && pendingVoiceLoads.remove(args[0])
+                    && TAB_NOTIFICATIONS.equals(activeTabId)) {
+                // The note is on disk now; rebuilding attaches it as playable audio.
+                invalidate();
+            }
         } else if ((id == NotificationCenter.pushMessagesUpdated || id == NotificationCenter.notificationsCountUpdated)
                 && TAB_NOTIFICATIONS.equals(activeTabId)) {
             invalidate();
@@ -271,12 +299,88 @@ public class HomeScreen extends Screen
             senderBuilder.setName("");
         }
 
-        return new CarMessage.Builder()
+        CarMessage.Builder builder = new CarMessage.Builder()
                 .setBody(CarText.create(body))
                 .setReceivedTimeEpochMillis(((long) mo.messageOwner.date) * 1000L)
                 .setSender(senderBuilder.build())
-                .setRead(false)
-                .build();
+                .setRead(false);
+
+        attachVoiceNote(builder, mo, preview[0]);
+
+        return builder.build();
+    }
+
+    /**
+     * Offers a received voice note to the car as playable audio. Without this the host only
+     * gets the text body, which for a voice note is just a placeholder label.
+     */
+    private void attachVoiceNote(CarMessage.Builder builder, MessageObject mo, boolean previewAllowed) {
+        if (!mo.isVoice()) {
+            return;
+        }
+        boolean locked = AndroidUtilities.needShowPasscode() || SharedConfig.isWaitingForPasscodeEnter;
+        if (!CarVoiceAttachment.isDisclosureAllowed(previewAllowed, locked)) {
+            return;
+        }
+        File file = FileLoader.getInstance(currentAccount).getPathToMessage(mo.messageOwner);
+        Uri uri = CarVoiceAttachment.resolveUri(
+                ApplicationLoader.applicationContext,
+                ApplicationLoader.getApplicationId() + ".provider",
+                file,
+                previewAllowed,
+                locked);
+        if (uri == null) {
+            // Not on disk yet. Auto-download is off by default for voice notes, and in the
+            // car this is the common case: the message usually arrives mid-drive.
+            requestVoiceDownload(mo);
+            return;
+        }
+        if (!grantReadToHost(uri)) {
+            return;
+        }
+        builder.setMultimediaMimeType(CarVoiceAttachment.MIME_TYPE).setMultimediaUri(uri);
+    }
+
+    /**
+     * Fetches a voice note that is not cached yet. The template is rebuilt once the download
+     * lands, via the fileLoaded observer, so the message gains its player without the user
+     * touching anything.
+     */
+    private void requestVoiceDownload(MessageObject mo) {
+        TLRPC.Document document = mo.getDocument();
+        if (document == null) {
+            return;
+        }
+        String fileName = FileLoader.getAttachFileName(document);
+        // add() also deduplicates: onGetTemplate runs on every invalidate, so without this
+        // the same note would be queued again on each rebuild.
+        if (TextUtils.isEmpty(fileName) || !pendingVoiceLoads.add(fileName)) {
+            return;
+        }
+        FileLoader.getInstance(currentAccount).loadFile(document, mo, FileLoader.PRIORITY_HIGH, 0);
+    }
+
+    /**
+     * The car host reads the URI from its own process, so a FileProvider grant is required.
+     * CarMessage crosses Binder rather than travelling in an Intent, so the usual
+     * FLAG_GRANT_READ_URI_PERMISSION on an Intent does not apply and the grant has to be
+     * issued explicitly against the host package.
+     *
+     * @return whether the attachment may be offered; false means fall back to text only,
+     *         since an unreadable URI would surface as a broken control in the car.
+     */
+    private boolean grantReadToHost(Uri uri) {
+        try {
+            HostInfo host = getCarContext().getHostInfo();
+            if (host == null || TextUtils.isEmpty(host.getPackageName())) {
+                return false;
+            }
+            getCarContext().grantUriPermission(
+                    host.getPackageName(), uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
     }
 
     // ===== Music tab =====


### PR DESCRIPTION
Android Auto only ever receives the text body of a message. For a voice note that is the placeholder `"Voice message"`, so the recording is unreachable without picking up the phone — which is exactly what should not happen while driving.

`CarMessage` has carried `setMultimediaMimeType`/`setMultimediaUri` since `androidx.car.app` 1.4.0, the version already pinned in `TMessagesProj/build.gradle`, so this needs **no dependency bump** and is independent of #2008.

## What it does

`buildCarMessage()` resolves the note through `FileLoader`, exposes it via the `.provider` `FileProvider` the app already declares, and sets it on the builder with `audio/ogg`. When the file is not cached yet it is fetched and the template rebuilt, so the player appears on its own — voice notes are not auto-downloaded by default and in the car the message typically arrives mid-drive, so without this it would almost always fall back to text.

This reuses the exact pattern `NotificationsController` already applies to the equivalent `MessagingStyle` attachment (`setData("audio/ogg", uri)` with `pendingVoiceLoads`), so the FileProvider paths involved are already exercised in production by the notification path.

## Notes for review

**Privacy.** `buildCarMessage()` already asked `getShortStringForMessage()` for `preview[0]` and then ignored it. Harmless while only redacted text was sent, but attaching audio changes it: with previews off the body reads as a placeholder while the recording would play aloud in the car, leaking exactly what the user chose to hide. The attachment honours `preview[0]` and the passcode state, matching the existing notification guard. Encrypted chats were already excluded in `collectUnreadDuringDrive()`.

**`fileLoaded` is per-account.** `HomeScreen` uses the global `NotificationCenter` for its other events, but `fileLoaded` is posted on `NotificationCenter.getInstance(account)`. Observing it globally registers fine and never fires, so the observer lives on the current account and moves on `activeAccountChanged`, detaching from the outgoing account first.

**URI permission.** The host reads the URI from its own process and `CarMessage` crosses Binder rather than riding an `Intent`, so `FLAG_GRANT_READ_URI_PERMISSION` cannot be attached to one. The grant is issued explicitly against `getHostInfo().getPackageName()`, falling back to text when it fails, since an unreadable URI would surface as a broken control in the car.

## Testing

Developed and verified in a Nagram-based fork, first on the Desktop Head Unit and then **confirmed working in a real car**: a voice note arriving mid-drive appears with a play control and plays through the car audio.

The gating is isolated in `CarVoiceAttachment` so it can be unit tested without a car host. I kept the tests out of this PR because the project has no JVM unit-test setup (`src/test`, Robolectric and `testOptions` are all absent) and adding one felt out of scope here — happy to include them, or the test scaffolding, if you would like it.