### PR TITLE
Fix inverted condition in ChatBackgroundDrawable.onDetachedFromWindow that leaks every destroyed activity

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatBackgroundDrawable.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatBackgroundDrawable.java
@@ -256,9 +256,7 @@ public class ChatBackgroundDrawable extends Drawable {
     }
 
     public void onDetachedFromWindow(View view) {
-        if (!attachedViews.contains(view)) {
-            attachedViews.remove(view);
-        }
+        attachedViews.remove(view);
         if (isAttached() && !attached) {
             attached = true;
             imageReceiver.onAttachedToWindow();


### PR DESCRIPTION
Issues are disabled on this repository, so the report comes as a PR with the fix attached.

### The bug

`ChatBackgroundDrawable.onDetachedFromWindow` negates its `contains` check before removing:

https://github.com/DrKLO/Telegram/blob/62b56a07ca7e30e39f7fd00a6728d6bbd716ca1c/TMessagesProj/src/main/java/org/telegram/ui/ChatBackgroundDrawable.java#L258-L261

```java
public void onDetachedFromWindow(View view) {
    if (!attachedViews.contains(view)) {
        attachedViews.remove(view);
    }
```

The `remove` only runs when the view is not in the list, so it never removes anything. `attachedViews` never shrinks, `isAttached()` never goes back to false, and `imageReceiver.onDetachedFromWindow()` is never called. The `onAttachedToWindow` sibling right above uses the same condition correctly, for the add.

### Why it leaks whole activities

`ImageReceiver.onAttachedToWindow()` registers three observers on the global NotificationCenter:

https://github.com/DrKLO/Telegram/blob/62b56a07ca7e30e39f7fd00a6728d6bbd716ca1c/TMessagesProj/src/main/java/org/telegram/messenger/ImageReceiver.java#L1195-L1197

Because detach never runs, those observers survive the fragment and the activity. The observer is the drawable's anonymous `ImageReceiver`, so the retention chain is:

```
NotificationCenter.globalInstance (static)
  observers -> ChatBackgroundDrawable$1 (the anonymous ImageReceiver)
    this$0 -> ChatBackgroundDrawable
      parent -> SizeNotifierFrameLayout$BackgroundView
        mContext -> destroyed Activity, whole view tree behind it
```

Any screen whose `SizeNotifierFrameLayout` background is a `ChatBackgroundDrawable` (a `TLRPC.WallPaper` from a theme or a per-chat wallpaper) leaks its view tree when the fragment view is destroyed, and each activity recreation leaks the previous activity.

### Measured impact

Heap dump taken at the resulting `OutOfMemoryError` after 75 hours of uptime (512 MB growth limit, Android 16, SM-S938B, three accounts):

- 63 `LaunchActivity`, 62 `DialogsActivity`, 129 `ChatActivity` instances alive
- 1552 `ChatMessageCell`, ~26,000 `ImageReceiver`, ~220,000 `Paint`
- cutting only the observer edge in the reference graph drops the strongly reachable heap from 417 MB to 152 MB, so this one condition held 265 MB
- the dead view trees also pin ~630,000 native cleaner registrations (RenderNodes, bitmaps), which showed up as 2.3 GB of native heap

Before the crash the app degrades into GC storms: with the heap pinned near the ceiling, opening a large channel produced main thread stalls over 1 second and SQLite queries in the storage queue slowed from milliseconds to 0.5-1.4 s.

The dump came from a fork, but every class involved is unmodified upstream code, and the line is unchanged in current master.

### Fix

The one-line change in this PR: drop the negation so the view is actually removed.

### Related, smaller

`ChatMessageCell` updates `animatedEmojiPollQuestion` and `animatedEmojiPollExplanation` in `setPoll` but never passes them to `AnimatedEmojiSpan.release`, so their holders keep dead cells reachable through the static `AnimatedEmojiDrawable.globalEmojiCache`. In the same dump that path held up to 35 MB more.
