### PR TITLE
Fixed video Story uploads failing with FILE_PART_INVALID

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/StoryEntry.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/StoryEntry.java
@@ -1267,7 +1267,6 @@ public class StoryEntry {
             info.backgroundPath = backgroundFile == null ? null : backgroundFile.getPath();
 
             long generalOffset = 0;
-            final int encoderBitrate = MediaController.extractRealEncoderBitrate(info.resultWidth, info.resultHeight, info.bitrate, true);
             if (isVideo && videoPath != null && !isCollage()) {
                 info.originalPath = videoPath;
                 info.isPhoto = false;
@@ -1290,6 +1289,7 @@ public class StoryEntry {
                 info.estimatedDuration = info.endTime - info.startTime;
                 info.volume = videoVolume;
                 info.muted = muted;
+                final int encoderBitrate = MediaController.extractRealEncoderBitrate(info.resultWidth, info.resultHeight, info.bitrate, true);
                 info.estimatedSize = (long) (params[0][AnimatedFileInfo.PARAM_NUM_AUDIO_FRAME_SIZE] + params[0][AnimatedFileInfo.PARAM_NUM_DURATION] / 1000.0f * encoderBitrate / 8);
                 info.estimatedSize = Math.max(file.length(), info.estimatedSize);
                 info.filterState = filterState;
@@ -1350,6 +1350,7 @@ public class StoryEntry {
                 info.volume = 1f;
                 info.bitrate = -1;
                 info.framerate = 30;
+                final int encoderBitrate = MediaController.extractRealEncoderBitrate(info.resultWidth, info.resultHeight, 0, true);
                 info.estimatedSize = (long) (duration / 1000.0f * encoderBitrate / 8);
                 info.filterState = null;
             }


### PR DESCRIPTION
## Bug

Uploading a video Story fails partway through with a low-level, unfriendly
error once the compressed video crosses roughly 10MB (in practice, once a
clip is long enough - users reported it around the ~1 minute mark). Shorter
clips upload fine; the exact same device/network fails consistently once the
video is long/large enough.

## Root cause

`StoryEntry.getVideoEditedInfo()` computes `encoderBitrate` like this:

```java
long generalOffset = 0;
final int encoderBitrate = MediaController.extractRealEncoderBitrate(info.resultWidth, info.resultHeight, info.bitrate, true);
if (isVideo && videoPath != null && !isCollage()) {
    ...
    info.bitrate = Utilities.clamp(info.originalBitrate, 3_000_000, 500_000); // set AFTER encoderBitrate above
    ...
    info.estimatedSize = (long) (params[0][AnimatedFileInfo.PARAM_NUM_AUDIO_FRAME_SIZE] + params[0][AnimatedFileInfo.PARAM_NUM_DURATION] / 1000.0f * encoderBitrate / 8);
```

`encoderBitrate` is derived from `info.bitrate`, but at that point `info` was
just constructed (`new VideoEditedInfo()`) and `bitrate` (an uninitialized
`int`) is still `0`. The real target bitrate (e.g. `3,000,000`) is only
assigned 14 lines later. So `extractRealEncoderBitrate(..., 0, ...)` returns
a bogus near-zero value, and `estimatedSize` collapses to a few hundred bytes
instead of the correct value (~25MB for a 70s clip at 3Mbps).

That bogus estimate flows into `FileUploadOperation` via
`StoriesController.java`:

```java
FileLoader.getInstance(currentAccount).uploadFile(path, false, !entry.isVideo,
    isVideo ? Math.max(1, (int) (info != null ? info.estimatedSize : 0)) : 0, ...);
```

`FileUploadOperation` decides `isBigFile = totalFileSize > 10 * 1024 * 1024`
**once**, before the first upload request, and never revisits it even after
the real encoded size becomes known via `checkNewDataAvailable()`. With the
tiny bogus estimate, `isBigFile` stays `false`, so a video that actually
compresses to well over 10MB keeps being uploaded through the small-file
protocol (`upload.saveFilePart`). The server eventually rejects further parts
once too many have been sent under that protocol:

```
compression completed time=119255 needCompress=true w=720 h=1280 bitrate=3000000 file size=40,0 MB encoder_name=c2.qti.avc.encoder
...
debug_uploading:  send reqId 398 .../cache/-2147483648_-210312.mp4 file_part=240 isBig=false file_id=-8990593480131830715
send request org.telegram.tgnet.TLRPC$TL_upload_saveFilePart@... with token = 398
...
org.telegram.tgnet.TLRPC$TL_upload_saveFilePart@ce134b9 got error 400 FILE_PART_INVALID
java received null error = org.telegram.tgnet.TLRPC$TL_error@...
upload story destroy
org.telegram.tgnet.TLRPC$TL_upload_saveFilePart@504005f got error 400 FILE_PART_INVALID
```

(Full 40MB video, still `isBig=false` the entire time, rejected once too
many small-file parts had been sent.)

`FileUploadOperation` has no retry for a failed part upload, so the whole
operation - and the story send - fails outright once this happens
(`upload story destroy` right after). Since the wrong estimate is roughly
constant while the real encoded size scales with duration/bitrate, this only
surfaces once a clip is long/large enough to cross the part-count limit
implied by the small-file protocol, which matches user reports of uploads
failing past roughly a minute while shorter clips work fine.

## Fix

Move the `encoderBitrate` computation to after `info.bitrate` is assigned in
the `isVideo` branch, so it reflects the real target bitrate and
`estimatedSize` (and therefore `isBigFile`) is computed correctly from the
start. The photo/collage/round branch, which is not affected by this bug,
keeps calling `extractRealEncoderBitrate` with an explicit `0` to preserve
its exact previous behavior - no change in scope beyond the actual bug.

## Testing

This was root-caused from a real device debug log (Settings -> internal
debug logs) captured while reproducing the failure on a ~70s 1080p video
Story upload requiring recompression (excerpt above). The log shows
`isBig=false` for the entire upload and the `FILE_PART_INVALID` failure once
enough small-file parts had been sent for a video that ultimately compressed
to 40MB, which matches the code path described above exactly.

I don't have an Android build/signing environment set up to produce a signed
APK and reproduce this end-to-end myself, so I have not re-run the failing
upload against this patched build. The change itself is a 2-line reordering
with no new logic: `encoderBitrate` is now computed after `info.bitrate` is
assigned instead of before, using the exact same
`MediaController.extractRealEncoderBitrate` call already used elsewhere in
this file. I'd appreciate a maintainer or the original reporter verifying
against a real build before merging.
