### PR TITLE
Say which emoji a custom one stands for

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -10670,6 +10670,36 @@ public class MessageObject {
         return null;
     }
 
+    // a custom emoji is drawn and never written, so a screen reader is left with nothing to read
+    // of it: what it stands for is the plain emoji the document carries beside it, which is said
+    // here, together with the word that keeps it apart from that plain emoji itself
+    public static CharSequence describeCustomEmoji(TLRPC.Document document) {
+        final String emoticon = findAnimatedEmojiEmoticon(document, null);
+        if (TextUtils.isEmpty(emoticon)) {
+            return getString(R.string.AccDescrCustomEmoji);
+        }
+        return formatString(R.string.AccDescrCustomEmojiNamed, emoticon);
+    }
+
+    // the document of a custom emoji is only ever read from the cache: this runs while a node is
+    // being filled in for a screen reader, which is no place to wait on the network, and an emoji
+    // that is drawn on screen has been fetched already
+    public static CharSequence describeCustomEmoji(int currentAccount, long documentId) {
+        return describeCustomEmoji(AnimatedEmojiDrawable.findDocument(currentAccount, documentId));
+    }
+
+    // reactions come in three kinds, and only the plain one carries something to read as it is
+    public static CharSequence describeReaction(int currentAccount, TLRPC.Reaction reaction) {
+        if (reaction instanceof TLRPC.TL_reactionEmoji) {
+            return ((TLRPC.TL_reactionEmoji) reaction).emoticon;
+        } else if (reaction instanceof TLRPC.TL_reactionCustomEmoji) {
+            return describeCustomEmoji(currentAccount, ((TLRPC.TL_reactionCustomEmoji) reaction).document_id);
+        } else if (reaction instanceof TLRPC.TL_reactionPaid) {
+            return getString(R.string.StarsReactionTitle);
+        }
+        return "";
+    }
+
     public static String findAnimatedEmojiEmoticon(TLRPC.Document document) {
         return findAnimatedEmojiEmoticon(document, "\uD83D\uDE00");
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -27255,7 +27255,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     if (currentMessageObject.messageOwner.reactions != null && currentMessageObject.messageOwner.reactions.results != null) {
                         if (currentMessageObject.messageOwner.reactions.results.size() == 1) {
                             TLRPC.ReactionCount reaction = currentMessageObject.messageOwner.reactions.results.get(0);
-                            String emoticon = reaction.reaction instanceof TLRPC.TL_reactionEmoji ? ((TLRPC.TL_reactionEmoji) reaction.reaction).emoticon : "";
+                            CharSequence emoticon = MessageObject.describeReaction(currentAccount, reaction.reaction);
                             if (reaction.count == 1) {
                                 sb.append("\n");
                                 boolean isMe = false;
@@ -27284,7 +27284,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                             final int count = currentMessageObject.messageOwner.reactions.results.size();
                             for (int i = 0; i < count; ++i) {
                                 TLRPC.ReactionCount reactionCount = currentMessageObject.messageOwner.reactions.results.get(i);
-                                String emoticon = reactionCount.reaction instanceof TLRPC.TL_reactionEmoji ? ((TLRPC.TL_reactionEmoji) reactionCount.reaction).emoticon : "";
+                                CharSequence emoticon = MessageObject.describeReaction(currentAccount, reactionCount.reaction);
                                 if (reactionCount != null) {
                                     sb.append(emoticon).append(" ").append(reactionCount.count + "");
                                     if (i + 1 < count) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ReactedUserHolderView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ReactedUserHolderView.java
@@ -239,7 +239,7 @@ public class ReactedUserHolderView extends FrameLayout {
                 }
                 hasReactImage = true;
             }
-            contentDescription = LocaleController.formatString("AccDescrReactedWith", R.string.AccDescrReactedWith, titleView.getText(), visibleReaction.emojicon != null ? visibleReaction.emojicon : reaction);
+            contentDescription = LocaleController.formatString("AccDescrReactedWith", R.string.AccDescrReactedWith, titleView.getText(), MessageObject.describeReaction(currentAccount, reaction));
         } else {
             if (reactView != null) {
                 reactView.setAnimatedEmojiDrawable(null);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactionsContainerLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactionsContainerLayout.java
@@ -1839,11 +1839,10 @@ public class ReactionsContainerLayout extends FrameLayout implements Notificatio
             if (currentReaction != null) {
                 if (currentReaction.emojicon != null) {
                     info.setText(currentReaction.emojicon);
-                    info.setEnabled(true);
                 } else {
-                    info.setText(LocaleController.getString(R.string.AccDescrCustomEmoji));
-                    info.setEnabled(true);
+                    info.setText(MessageObject.describeCustomEmoji(currentAccount, currentReaction.documentId));
                 }
+                info.setEnabled(true);
             }
         }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/SelectAnimatedEmojiDialog.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SelectAnimatedEmojiDialog.java
@@ -3261,9 +3261,9 @@ public class SelectAnimatedEmojiDialog extends FrameLayout implements Notificati
                         doc = AnimatedEmojiDrawable.findDocument(currentAccount, span.getDocumentId());
                     }
                 }
-                if (doc != null) {
-                    desc = MessageObject.findAnimatedEmojiEmoticon(doc, null);
-                }
+                // a cell whose document has not been fetched yet is still a custom emoji, and
+                // saying so is better than leaving it as an unnamed button
+                desc = MessageObject.describeCustomEmoji(doc);
             }
             if (desc != null) {
                 info.setContentDescription(desc);

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5833,6 +5833,7 @@
     <string name="BanUserMonoforum">Ban User From Channel</string>
     <string name="UnbanUserMonoforum">Ban User From Channel</string>
     <string name="AccDescrCustomEmoji">Custom emoji</string>
+    <string name="AccDescrCustomEmojiNamed">%1$s, custom emoji</string>
     <string name="RecentlyUsed">Recently Used</string>
     <string name="PopularReactions">Popular</string>
     <string name="EmojiPackCollectibles">Collectibles</string>


### PR DESCRIPTION
## Summary

A custom emoji is drawn, never written, so a screen reader has nothing of
it to read. The app knows what it stands for: every custom emoji document
carries the plain emoji it was made after, which is what is drawn in its
place while it loads.

That emoji is now said, together with a word that keeps it apart from the
plain one of the same face, wherever a custom emoji is put to a screen
reader on its own: the reactions panel, which said no more than that a
reaction was custom and never which; the sheet that picks an emoji, used
for the icon of a topic and for a status as well as for reactions, which
said the emoji but never that it was custom, and said nothing at all for
one whose document was not fetched yet; and the list of who reacted to a
message.

The reactions read out on a message were worse off: a custom one was left
out of the reading entirely, as an empty string, and a paid one with it.
Those are now named as well, the paid one by the name the app already
gives it.

The document behind a custom emoji is only ever read from the cache here.
Filling in a node for a screen reader is no place to wait on the network,
and an emoji that is on the screen has been fetched to be drawn; where it
is somehow missing, the reading falls back to what was said before.


## Checking it

With TalkBack on, long press a message to open the reactions panel, in a chat that offers custom reactions, and swipe through it.

Before, every custom one read as "Custom emoji". Now each reads as the plain emoji it stands for, followed by "custom emoji".

Swiping onto a message that already carries a custom or a paid reaction is the other half of it: before, those were left out of the reading entirely.
