### PR TITLE
Reach what the avatar of a chat leads to

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
@@ -5457,10 +5457,32 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
         }
     }
 
+    // the avatar of a chat answers to a touch of its own, which touch exploration has no way of
+    // giving it: it holds a story to be watched, or it leads to the community the chat belongs to.
+    // Where it answers to nothing, the touch goes through to the chat, and so there is nothing to
+    // offer here either.
+    private boolean hasAvatarAction() {
+        // the archive comes by it too: its avatar holds the stories that were put away
+        return !isTopic && !isShareToStoryCell && storyParams.isAvatarActionable();
+    }
+
+    // a chat that leads to a community leads there whether or not it also holds a story, as a
+    // touch on it would
+    private boolean avatarOpensCommunity() {
+        final MessagesController messagesController = MessagesController.getInstance(currentAccount);
+        final TLRPC.User user = currentDialogId > 0 ? messagesController.getUser(currentDialogId) : null;
+        final TLRPC.Chat chat = currentDialogId > 0 ? null : messagesController.getChat(-currentDialogId);
+        return storyParams.isAvatarClickable(currentDialogId, chat, user);
+    }
+
     @Override
     public boolean performAccessibilityAction(int action, Bundle arguments) {
         if (action == R.id.acc_action_chat_preview && parentFragment != null) {
             parentFragment.showChatPreview(this);
+            return true;
+        }
+        if (action == R.id.acc_action_open_avatar && hasAvatarAction()) {
+            storyParams.performAvatarAction(this);
             return true;
         }
         return super.performAccessibilityAction(action, arguments);
@@ -5476,6 +5498,9 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
             info.addAction(AccessibilityNodeInfo.ACTION_LONG_CLICK);
             if (!isFolderCell() && parentFragment != null) {
                 info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_chat_preview, getString(R.string.AccActionChatPreview)));
+            }
+            if (hasAvatarAction()) {
+                info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_open_avatar, getString(avatarOpensCommunity() ? R.string.AccActionOpenCommunity : R.string.ViewStory)));
             }
         }
         if (checkBox != null && checkBox.isChecked()) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/StoriesUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/StoriesUtilities.java
@@ -1289,31 +1289,45 @@ public class StoriesUtilities {
             return false;
         }
 
+        // whether a touch on the avatar is a touch on anything: an avatar that neither holds a
+        // story nor leads to a community lets the touch through to whatever is underneath it.
+        // The touch asks this as the finger goes down; anything that reaches the avatar another
+        // way has to ask it too.
+        public boolean isAvatarActionable() {
+            if (dialogId == UserConfig.getInstance(UserConfig.selectedAccount).clientUserId) {
+                return false;
+            }
+            final MessagesController messagesController = MessagesController.getInstance(UserConfig.selectedAccount);
+            final StoriesController storiesController = messagesController.getStoriesController();
+            TLRPC.User user = null;
+            TLRPC.Chat chat = null;
+            if (dialogId > 0) {
+                user = messagesController.getUser(dialogId);
+            } else {
+                chat = messagesController.getChat(-dialogId);
+            }
+            if (isAvatarClickable(dialogId, chat, user)) {
+                return true;
+            }
+            if (drawHiddenStoriesAsSegments) {
+                return storiesController.hasHiddenStories();
+            }
+            if (dialogId > 0) {
+                return storiesController.hasStories(dialogId) || user != null && !user.stories_unavailable && user.stories_max_id != null && user.stories_max_id.max_id > 0;
+            }
+            return storiesController.hasStories(dialogId) || chat != null && !chat.stories_unavailable && chat.stories_max_id != null && chat.stories_max_id.max_id > 0;
+        }
+
+        // what the touch does once the finger comes up again
+        public void performAvatarAction(View view) {
+            child = view;
+            processOpenStory(view);
+        }
+
         public boolean checkOnTouchEvent(MotionEvent event, View view) {
             child = view;
-            StoriesController storiesController = MessagesController.getInstance(UserConfig.selectedAccount).getStoriesController();
             if (event.getAction() == MotionEvent.ACTION_DOWN && originalAvatarRect.contains(event.getX(), event.getY())) {
-                TLRPC.User user = null;
-                TLRPC.Chat chat = null;
-                if (dialogId > 0) {
-                    user = MessagesController.getInstance(UserConfig.selectedAccount).getUser(dialogId);
-                } else {
-                    chat = MessagesController.getInstance(UserConfig.selectedAccount).getChat(-dialogId);
-                }
-                boolean hasStories;
-
-                if (isAvatarClickable(dialogId, chat, user)) {
-                    hasStories = true;
-                } else if (drawHiddenStoriesAsSegments) {
-                    hasStories = storiesController.hasHiddenStories();
-                } else {
-                    if (dialogId > 0) {
-                        hasStories = (MessagesController.getInstance(UserConfig.selectedAccount).getStoriesController().hasStories(dialogId) || user != null && !user.stories_unavailable && user.stories_max_id != null && user.stories_max_id.max_id > 0);
-                    } else {
-                        hasStories = (MessagesController.getInstance(UserConfig.selectedAccount).getStoriesController().hasStories(dialogId) || chat != null && !chat.stories_unavailable && chat.stories_max_id != null && chat.stories_max_id.max_id > 0);
-                    }
-                }
-                if (dialogId != UserConfig.getInstance(UserConfig.selectedAccount).clientUserId && hasStories) {
+                if (isAvatarActionable()) {
                     if (buttonBounce == null) {
                         buttonBounce = new ButtonBounce(view, 1.5f, 5f);
                     } else {

--- a/TMessagesProj/src/main/res/values/ids.xml
+++ b/TMessagesProj/src/main/res/values/ids.xml
@@ -28,6 +28,7 @@
     <item name="acc_action_msg_options" type="id"/>
     <item name="acc_action_open_photo" type="id"/>
     <item name="acc_action_chat_preview" type="id"/>
+    <item name="acc_action_open_avatar" type="id"/>
     <item name="acc_action_open_forwarded_origin" type="id"/>
     <item name="acc_action_copy_code" type="id"/>
     <item name="acc_action_summarize" type="id"/>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5001,6 +5001,7 @@
     <string name="AccActionOpenForwardedOrigin">Forwarded origin</string>
     <string name="AccActionEnterSelectionMode">Enter selection mode</string>
     <string name="AccActionChatPreview">Chat Preview</string>
+    <string name="AccActionOpenCommunity">Open community</string>
     <string name="AccActionOpenTranscription">Open Voice Transcription</string>
     <string name="AccActionCloseTranscription">Close Transcription</string>
     <string name="AccDescrEmojiButton">Emoji, stickers, and GIFs</string>


### PR DESCRIPTION
## Summary

The avatar of a chat in the list answers to a touch of its own. It holds a
story to be watched, and where the chat belongs to a community it leads
there instead. The archive carries the stories that were put away the same
way.

None of it could be reached with a screen reader: the avatar is drawn by
the cell and is no view of its own, so there was nothing to land on. The
chat opened, as it does when the avatar answers to nothing, and the story
stayed where it was.

The chat now offers it as an action of its own, and only where a touch
would have found something: an avatar that holds no story and leads to no
community offers nothing, as the touch on it does nothing.

Which of the two it is is worked out as the touch works it out, and said
so, since a chat that leads to a community leads there whether or not it
also holds a story.

The question the touch asks as the finger goes down is now asked in one
place, so both come by the answer the same way.

Long pressing the avatar shows the preview of the chat, which the chat
already offers.


## Checking it

With TalkBack on, swipe onto a chat in the list that has an unseen story, and open the actions.

Before, there was nothing there for it, and the story could only be reached by tapping the avatar. Now there is an action for it, doing what that tap does. A chat that belongs to a community offers that instead.

A chat whose avatar answers to nothing offers no such action.
