### PR TITLE
Keep what a message offers to do up to date

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -17368,6 +17368,19 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     }
 
     public void updateButtonState(boolean ifSame, boolean animated, boolean fromSet) {
+        final int previousButtonState = buttonState;
+        final int previousMiniButtonState = miniButtonState;
+        updateButtonStateInternal(ifSame, animated, fromSet);
+        // what a message offers to do is read off the state of its button: it downloads, or it
+        // cancels what is downloading, or it plays. Nothing said that state had changed, so a
+        // screen reader went on offering to download a file that was already on its way, until
+        // the message was left and returned to.
+        if ((buttonState != previousButtonState || miniButtonState != previousMiniButtonState) && AndroidUtilities.isAccessibilityScreenReaderEnabled()) {
+            sendAccessibilityEvent(AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED);
+        }
+    }
+
+    private void updateButtonStateInternal(boolean ifSame, boolean animated, boolean fromSet) {
         if (currentMessageObject == null) {
             return;
         }


### PR DESCRIPTION
## Summary

What a message offers to do is read off the state of its button: it
downloads, or it cancels what is already downloading, or it plays. That
state changes on its own, as a download starts, finishes or is stopped,
and nothing ever said so.

A screen reader reads the actions of a message when it lands on it and
keeps what it read. So it went on offering to download a file that was
already on its way, and to cancel one that had long since arrived, until
the message was left and returned to. There was no way to tell from the
message which of those was true.

The state is now compared with what it was, and where it has moved the
message says that it changed, which is what has a screen reader read the
actions again. Nothing about the actions themselves is touched: the same
ones are offered, in the same states, doing the same things.


## Checking it

With TalkBack on, swipe onto a message carrying a file that is not downloaded, use its download action, and stay on the message.

Before, the actions went on saying "Download" until the message was left and returned to. Now they follow the file: "Cancel download" while it is on its way, and what the message offers once it has arrived.
