### PR TITLE
Give a video and a piece of music a download of their own

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -17237,6 +17237,52 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         }
     }
 
+    // a video and a piece of music are the two that are worth having on the phone before they are
+    // wanted, and the two whose downloads are long enough to be worth stopping. Everything else
+    // arrives before there is anything to say about it.
+    private boolean hasMediaDownloadAction() {
+        if (currentMessageObject == null || documentAttach == null) {
+            return false;
+        }
+        if (documentAttachType != DOCUMENT_ATTACH_TYPE_VIDEO && documentAttachType != DOCUMENT_ATTACH_TYPE_MUSIC) {
+            return false;
+        }
+        if (currentMessageObject.isSending() || currentMessageObject.isEditing() || currentMessageObject.isSendError()) {
+            return false;
+        }
+        // what is already on the phone has nothing left to download
+        return !currentMessageObject.mediaExists && !currentMessageObject.attachPathExists;
+    }
+
+    private boolean isMediaDownloading() {
+        return FileLoader.getInstance(currentAccount).isLoadingFile(FileLoader.getAttachFileName(documentAttach));
+    }
+
+    // pressing the message plays what it holds, and streams it where it can, which is not the same
+    // as keeping it: this only fetches the file, and stops fetching it, and says which of the two
+    // it is about to do. A download taken up again carries on from where it was stopped, as it
+    // does for the button that is drawn.
+    private void performMediaDownloadAction() {
+        if (!hasMediaDownloadAction()) {
+            return;
+        }
+        if (isMediaDownloading()) {
+            currentMessageObject.loadingCancelled = true;
+            FileLoader.getInstance(currentAccount).cancelLoadFile(documentAttach);
+        } else {
+            currentMessageObject.loadingCancelled = false;
+            currentMessageObject.putInDownloadsStore = true;
+            if (documentAttachType == DOCUMENT_ATTACH_TYPE_MUSIC) {
+                FileLoader.getInstance(currentAccount).loadFile(documentAttach, currentMessageObject, FileLoader.PRIORITY_NORMAL_UP, 0);
+            } else {
+                FileLoader.getInstance(currentAccount).loadFile(documentAttach, currentMessageObject, FileLoader.PRIORITY_NORMAL, currentMessageObject.shouldEncryptPhotoOrVideo() ? 2 : 0);
+            }
+            createLoadingProgressLayout(documentAttach);
+        }
+        updateButtonState(false, true, false);
+        invalidate();
+    }
+
     private int getIconForCurrentState() {
         if (currentMessageObject == null || currentMessageObject.hasExtendedMedia()) {
             return MediaActionDrawable.ICON_NONE;
@@ -26590,6 +26636,8 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             return true;
         } else if (action == R.id.acc_action_small_button) {
             didPressMiniButton(true);
+        } else if (action == R.id.acc_action_download) {
+            performMediaDownloadAction();
         } else if (action == R.id.acc_action_msg_options) {
             if (delegate != null) {
                 if (currentMessageObject.type == MessageObject.TYPE_PHONE_CALL) {
@@ -27363,6 +27411,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
                 info.addAction(new AccessibilityNodeInfo.AccessibilityAction(AccessibilityNodeInfo.ACTION_CLICK, actionLabel));
                 info.addAction(new AccessibilityNodeInfo.AccessibilityAction(AccessibilityNodeInfo.ACTION_LONG_CLICK, getString("AccActionEnterSelectionMode", R.string.AccActionEnterSelectionMode)));
+                if (hasMediaDownloadAction()) {
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_download, getString(isMediaDownloading() ? R.string.AccActionCancelDownload : R.string.AccActionDownload)));
+                }
                 int smallIcon = getMiniIconForCurrentState();
                 if (smallIcon == MediaActionDrawable.ICON_DOWNLOAD) {
                     info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_small_button, getString("AccActionDownload", R.string.AccActionDownload)));

--- a/TMessagesProj/src/main/res/values/ids.xml
+++ b/TMessagesProj/src/main/res/values/ids.xml
@@ -25,6 +25,7 @@
     <item name="sheet_attached_to_fragment_tag" type="id"/>
     <item name="current_animation" type="id"/>
     <item name="acc_action_small_button" type="id"/>
+    <item name="acc_action_download" type="id"/>
     <item name="acc_action_msg_options" type="id"/>
     <item name="acc_action_open_photo" type="id"/>
     <item name="acc_action_chat_preview" type="id"/>


### PR DESCRIPTION
## Summary

A video and a piece of music are the two worth having on the phone before
they are wanted, and the two whose downloads run long enough to be worth
stopping. Neither could be asked for on its own.

Pressing the message is all there was, and pressing it does something
else: it opens the viewer, and streams what has not arrived, or it starts
playing. Keeping the file was only ever a side effect of watching or
listening to it, and stopping the download was reachable only in the
states where pressing the message happened to mean cancel.

Both are now an action of their own, on a video and on a piece of music
that is not already on the phone. While the file is on its way the action
cancels it; where it was never started, or was stopped part of the way
through, the action fetches it, and only fetches it: nothing is opened and
nothing is played. A download taken up again carries on from where it was
stopped, as it does for the button that is drawn.

The action is not offered for what is already here, nor for a message
still on its way out.


## Checking it

With TalkBack on, swipe onto a video or a piece of music that is not on the device and open the actions.

Before, the only way to fetch it was to activate the message, which opens the viewer or starts playing. Now there is a download action that only fetches it. While it is on its way the same action cancels it, and using it again carries on from where it stopped.

Nothing is offered for a file that is already here.
