### PR TITLE
Let a reaction already on a message be given back

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatActionCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatActionCell.java
@@ -34,6 +34,7 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.os.Bundle;
 import android.text.Layout;
 import android.text.Spannable;
 import android.text.SpannableString;
@@ -3963,6 +3964,15 @@ public class ChatActionCell extends BaseCell implements DownloadController.FileD
             info.setText(accessibilityText);
         }
         info.setEnabled(true);
+        reactionsLayoutInBubble.addAccessibilityActions(info);
+    }
+
+    @Override
+    public boolean performAccessibilityAction(int action, Bundle arguments) {
+        if (reactionsLayoutInBubble.performAccessibilityAction(action)) {
+            return true;
+        }
+        return super.performAccessibilityAction(action, arguments);
     }
 
     public void setInvalidateColors(boolean invalidate) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -26590,6 +26590,8 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             return true;
         } else if (action == R.id.acc_action_small_button) {
             didPressMiniButton(true);
+        } else if (reactionsLayoutInBubble != null && reactionsLayoutInBubble.performAccessibilityAction(action)) {
+            return true;
         } else if (action == R.id.acc_action_msg_options) {
             if (delegate != null) {
                 if (currentMessageObject.type == MessageObject.TYPE_PHONE_CALL) {
@@ -27469,6 +27471,12 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
                 if (forwardedNameLayout[0] != null && forwardedNameLayout[1] != null) {
                     info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_open_forwarded_origin, getString("AccActionOpenForwardedOrigin", R.string.AccActionOpenForwardedOrigin)));
+                }
+                // the reactions come after everything else a message offers: answering one is the
+                // last thing wanted of a message, and the actions before them are the ones reached
+                // for first
+                if (reactionsLayoutInBubble != null) {
+                    reactionsLayoutInBubble.addAccessibilityActions(info);
                 }
                 if (drawSelectionBackground || getBackground() != null) {
                     info.setSelected(true);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Reactions/ReactionsLayoutInBubble.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Reactions/ReactionsLayoutInBubble.java
@@ -21,6 +21,7 @@ import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
+import android.view.accessibility.AccessibilityNodeInfo;
 
 import androidx.annotation.NonNull;
 import androidx.core.graphics.ColorUtils;
@@ -62,6 +63,7 @@ import org.telegram.ui.Components.RLottieDrawable;
 import org.telegram.ui.Stars.StarsReactionsSheet;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -579,6 +581,78 @@ public class ReactionsLayoutInBubble {
         }
     }
 
+    // a reaction already on a message is given by touching it, which touch exploration cannot do:
+    // the reactions are drawn here and are no views of their own, so there is nothing to land on
+    // and nothing to press. Each is offered as an action of the message that carries it instead.
+    //
+    // an action needs an id that belongs to no other view. The framework hands those out, and they
+    // are kept so that a reaction keeps the same id for as long as the app runs.
+    private static int[] accessibilityActionIds = new int[0];
+
+    private static int getAccessibilityActionId(int index) {
+        if (index >= accessibilityActionIds.length) {
+            final int from = accessibilityActionIds.length;
+            accessibilityActionIds = Arrays.copyOf(accessibilityActionIds, index + 1);
+            for (int i = from; i <= index; ++i) {
+                accessibilityActionIds[i] = View.generateViewId();
+            }
+        }
+        return accessibilityActionIds[index];
+    }
+
+    // a custom reaction is drawn and never written: the plain emoji it was made after is the only
+    // thing there is to say of it, and where even that is missing it is called what the app calls
+    // it. A paid one is not an emoji at all and goes by its own name.
+    private CharSequence getReactionText(TLRPC.Reaction reaction) {
+        if (reaction instanceof TLRPC.TL_reactionEmoji) {
+            return ((TLRPC.TL_reactionEmoji) reaction).emoticon;
+        } else if (reaction instanceof TLRPC.TL_reactionCustomEmoji) {
+            final long documentId = ((TLRPC.TL_reactionCustomEmoji) reaction).document_id;
+            return MessageObject.findAnimatedEmojiEmoticon(AnimatedEmojiDrawable.findDocument(currentAccount, documentId), LocaleController.getString(R.string.AccDescrCustomEmoji));
+        } else if (reaction instanceof TLRPC.TL_reactionPaid) {
+            return LocaleController.getString(R.string.StarsReactionTitle);
+        }
+        return "";
+    }
+
+    private CharSequence getAccessibilityActionLabel(ReactionButton button) {
+        final TLRPC.ReactionCount reactionCount = button.getReactionCount();
+        final CharSequence text = getReactionText(reactionCount.reaction);
+        // stars given to a message stay given, so a paid reaction is only ever offered to be sent,
+        // however many have been sent already
+        final boolean given = reactionCount.chosen && !(reactionCount.reaction instanceof TLRPC.TL_reactionPaid);
+        if (reactionCount.count <= 0) {
+            return LocaleController.formatString(given ? R.string.AccActionUnreactWith : R.string.AccActionReactWith, text);
+        }
+        return LocaleController.formatPluralString(given ? "AccActionUnreactWithCount" : "AccActionReactWithCount", reactionCount.count, text);
+    }
+
+    public void addAccessibilityActions(AccessibilityNodeInfo info) {
+        for (int i = 0; i < reactionButtons.size(); ++i) {
+            final ReactionButton button = reactionButtons.get(i);
+            if (button.getReactionCount() == null) {
+                continue;
+            }
+            info.addAction(new AccessibilityNodeInfo.AccessibilityAction(getAccessibilityActionId(i), getAccessibilityActionLabel(button)));
+        }
+    }
+
+    public boolean performAccessibilityAction(int action) {
+        for (int i = 0; i < reactionButtons.size(); ++i) {
+            final ReactionButton button = reactionButtons.get(i);
+            if (button.getReactionCount() == null) {
+                continue;
+            }
+            if (action == getAccessibilityActionId(i)) {
+                // where a reaction was given is where its animation is played from, so the middle
+                // of it is passed, as a touch on it would have been
+                didPressReaction(button.getReactionCount(), false, x + button.x + button.width / 2f, y + button.y + button.height / 2f);
+                return true;
+            }
+        }
+        return false;
+    }
+
     public void recordDrawingState() {
         lastDrawingReactionButtons.clear();
         for (int i = 0; i < reactionButtons.size(); i++) {
@@ -831,6 +905,10 @@ public class ReactionsLayoutInBubble {
         public int lastDrawnBackgroundColor;
         public int lastDrawnTagDotColor;
         boolean isSelected;
+
+        public TLRPC.ReactionCount getReactionCount() {
+            return reactionCount;
+        }
 
         public boolean inGroup;
         public boolean isTag;

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5000,6 +5000,12 @@
     <string name="AccActionMessageOptions">Message options</string>
     <string name="AccActionOpenForwardedOrigin">Forwarded origin</string>
     <string name="AccActionEnterSelectionMode">Enter selection mode</string>
+    <string name="AccActionReactWith">React with %1$s</string>
+    <string name="AccActionUnreactWith">Remove your reaction %1$s</string>
+    <string name="AccActionReactWithCount_one">React with %2$s, %1$d person</string>
+    <string name="AccActionReactWithCount_other">React with %2$s, %1$d people</string>
+    <string name="AccActionUnreactWithCount_one">Remove your reaction %2$s, %1$d person</string>
+    <string name="AccActionUnreactWithCount_other">Remove your reaction %2$s, %1$d people</string>
     <string name="AccActionChatPreview">Chat Preview</string>
     <string name="AccActionOpenTranscription">Open Voice Transcription</string>
     <string name="AccActionCloseTranscription">Close Transcription</string>


### PR DESCRIPTION
## Summary

A reaction that is already on a message is given by touching it. Touch
exploration cannot: the reactions are drawn by the cell and are no views
of their own, so nothing can be landed on and nothing can be pressed.
Everyone else answers a message with the reaction it already carries by
tapping it once; with a screen reader the only way is the panel, where
that reaction has to be found again among all the others.

Each reaction on a message is now an action of the message, alongside the
options it already offers. The action says which reaction it is, how many
have given it, and, by whether it offers to give or to take back, whether
it is one of ours. Choosing it does what touching the reaction does, from
the middle of it, so the animation plays where it would have.

They come after everything else the message offers. Answering a message
with a reaction is the last thing wanted of it, and a message can carry
many, which would otherwise have to be walked past to reach opening what
it holds or keeping it.

It is the layout that draws the reactions that offers them, so a message
and a service message both come by it the same way, as both are answered
the same way by everyone else.

Stars given to a message stay given, so a paid reaction is only ever
offered to be sent, however many have been sent already.

The reactions are drawn, not laid out, so their actions have no ids in the
resources; the framework hands out ids that belong to no other view, and
those are kept so a reaction keeps its id while the app runs.


## Checking it

With TalkBack on, swipe onto a message that already carries reactions and open the actions.

Before, the reactions could not be reached at all, and answering with one of them meant opening the panel and finding it again among the rest. Now each is an action saying which reaction it is, how many have given it, and whether it is ours; using it does what tapping the reaction does.

They come after the actions the message already had.
