### PR TITLE
Open the message a reply was made to

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -27762,7 +27762,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 } else if (virtualViewId == REPLY) {
                     info.setEnabled(true);
                     StringBuilder sb = new StringBuilder();
-                    sb.append(getString("Reply", R.string.Reply));
+                    // the same place over a message holds a reply or, on a forwarded message, where
+                    // it was forwarded from: it was called a reply either way
+                    sb.append(getString(replyPanelIsForward ? R.string.AccDescrForwarding : R.string.Reply));
                     sb.append(", ");
                     if (replyNameLayout != null) {
                         sb.append(replyNameLayout.getText());
@@ -27932,7 +27934,20 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                             delegate.didPressSideButton(ChatMessageCell.this);
                         }
                     } else if (virtualViewId == REPLY) {
-                        if (delegate != null && (!isThreadChat || isMonoForum || currentMessageObject.getReplyTopMsgId() != 0) && (currentMessageObject.hasValidReplyMessageObject() || hasReplyQuote || currentMessageObject.messageOwner != null && currentMessageObject.messageOwner.reply_to != null && currentMessageObject.messageOwner.reply_to.reply_from != null)) {
+                        // what is drawn over a message is not always a reply: where it is a
+                        // forward, touching it goes to where the message came from, and that is
+                        // what is done here as well
+                        if (replyPanelIsForward) {
+                            if (delegate != null) {
+                                if (currentForwardChannel != null) {
+                                    delegate.didPressChannelAvatar(ChatMessageCell.this, currentForwardChannel, currentMessageObject.messageOwner.fwd_from.channel_post, lastTouchX, lastTouchY, false);
+                                } else if (currentForwardUser != null) {
+                                    delegate.didPressUserAvatar(ChatMessageCell.this, currentForwardUser, lastTouchX, lastTouchY, false);
+                                } else if (currentForwardName != null) {
+                                    delegate.didPressHiddenForward(ChatMessageCell.this);
+                                }
+                            }
+                        } else if (delegate != null && (currentMessageObject.hasValidReplyMessageObject() || currentMessageObject.isReplyToStory() || hasReplyQuote || currentMessageObject.messageOwner != null && currentMessageObject.messageOwner.reply_to != null && currentMessageObject.messageOwner.reply_to.reply_from != null)) {
                             delegate.didPressReplyMessage(ChatMessageCell.this, currentMessageObject.getReplyMsgId(), 0, 0, false);
                         }
                     } else if (virtualViewId == FORWARD) {


### PR DESCRIPTION
## Summary

Touching what is drawn over a message goes to the message it answers.
Doing the same with a screen reader did nothing at all, on every message
in a topic and in the comments under a channel post, and on some messages
elsewhere.

Three conditions stood between the two. A thread was refused outright
unless the message carried the id of the one the thread was started from,
which a topic and a comment thread do not always have; a reply to a story
was left out; and where the message was a forward, the same place holds
where it came from rather than a reply, and touching it goes there, which
was not done.

The touch is one place and this was another, and they had drifted. What
happens now is what happens on a touch, asked for in the same order.

What is drawn there is also named for what it is: a forward said it was a
reply, whatever it went on to open.


## Checking it

With TalkBack on, in a forum topic or in the comments under a channel post, swipe onto the reply shown above a message and double tap it.

Before, nothing happened at all. Now it goes to the message being replied to, as tapping it does.

A reply to a story, and a forwarded message, where the same place holds where it came from, are the other cases this covers.
