### PR TITLE
Reach the menu behind the avatar of a sender

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -577,6 +577,11 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         default void didPressUserAvatar(ChatMessageCell cell, TLRPC.User user, float touchX, float touchY, boolean asForward) {
         }
 
+        /** Whether holding the avatar of a sender opens anything in this chat. */
+        default boolean canLongPressAvatar(ChatMessageCell cell) {
+            return false;
+        }
+
         default boolean didLongPressUserAvatar(ChatMessageCell cell, TLRPC.User user, float touchX, float touchY) {
             return false;
         }
@@ -17237,6 +17242,45 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         }
     }
 
+    // the avatar of whoever sent a message opens a menu when it is held down: their profile, a
+    // chat with them, a mention of them, and a search of what they have said here. The avatar is
+    // drawn by the cell and is no view of its own, so touch exploration had nothing to hold, and
+    // none of it could be reached.
+    private boolean hasSenderAvatarMenu() {
+        if (!isAvatarVisible || currentMessageObject == null || delegate == null) {
+            return false;
+        }
+        // whether holding the avatar leads anywhere is for the chat to answer: it opens in a
+        // group and in a chat with yourself, and nowhere else. A sender with no picture still has
+        // the menu, only without the picture drawn above it
+        if (!delegate.canLongPressAvatar(this)) {
+            return false;
+        }
+        return currentUser != null && currentUser.id != 0 || currentChat != null;
+    }
+
+    // held down is what it is asked to be, so that whatever the menu comes to hold is come by the
+    // same way it is by everyone else
+    private boolean performSenderAvatarMenu() {
+        if (!hasSenderAvatarMenu()) {
+            return false;
+        }
+        if (currentUser != null) {
+            return delegate.didLongPressUserAvatar(this, currentUser, lastTouchX, lastTouchY);
+        }
+        final int id;
+        if (currentMessageObject.messageOwner.fwd_from != null) {
+            if ((currentMessageObject.messageOwner.fwd_from.flags & 16) != 0) {
+                id = currentMessageObject.messageOwner.fwd_from.saved_from_msg_id;
+            } else {
+                id = currentMessageObject.messageOwner.fwd_from.channel_post;
+            }
+        } else {
+            id = 0;
+        }
+        return delegate.didLongPressChannelAvatar(this, currentChat, id, lastTouchX, lastTouchY);
+    }
+
     private int getIconForCurrentState() {
         if (currentMessageObject == null || currentMessageObject.hasExtendedMedia()) {
             return MediaActionDrawable.ICON_NONE;
@@ -26590,6 +26634,8 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             return true;
         } else if (action == R.id.acc_action_small_button) {
             didPressMiniButton(true);
+        } else if (action == R.id.acc_action_sender_avatar_menu) {
+            performSenderAvatarMenu();
         } else if (action == R.id.acc_action_msg_options) {
             if (delegate != null) {
                 if (currentMessageObject.type == MessageObject.TYPE_PHONE_CALL) {
@@ -27338,6 +27384,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     info.setCollectionItemInfo(AccessibilityNodeInfo.CollectionItemInfo.obtain(itemInfo.getRowIndex(), 1, 0, 1, false));
                 }
                 info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_msg_options, getString("AccActionMessageOptions", R.string.AccActionMessageOptions)));
+                if (hasSenderAvatarMenu()) {
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_sender_avatar_menu, getString(R.string.AccActionSenderOptions)));
+                }
                 int icon = getIconForCurrentState();
                 CharSequence actionLabel = null;
                 switch (icon) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -39686,6 +39686,11 @@ public class ChatActivity extends BaseFragment implements
         }
 
         @Override
+        public boolean canLongPressAvatar(ChatMessageCell cell) {
+            return isAvatarPreviewerEnabled();
+        }
+
+        @Override
         public boolean didLongPressUserAvatar(ChatMessageCell cell, TLRPC.User user, float touchX, float touchY) {
             if (isAvatarPreviewerEnabled()) {
                 final boolean enableMention = currentChat != null && (bottomChannelButtonsLayout == null || bottomChannelButtonsLayout.getVisibility() != View.VISIBLE) && (bottomOverlay == null || bottomOverlay.getVisibility() != View.VISIBLE);

--- a/TMessagesProj/src/main/res/values/ids.xml
+++ b/TMessagesProj/src/main/res/values/ids.xml
@@ -26,6 +26,7 @@
     <item name="current_animation" type="id"/>
     <item name="acc_action_small_button" type="id"/>
     <item name="acc_action_msg_options" type="id"/>
+    <item name="acc_action_sender_avatar_menu" type="id"/>
     <item name="acc_action_open_photo" type="id"/>
     <item name="acc_action_chat_preview" type="id"/>
     <item name="acc_action_open_forwarded_origin" type="id"/>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -4998,6 +4998,7 @@
     <string name="AccActionCancelDownload">Cancel download</string>
     <string name="AccActionOpenFile">Open file</string>
     <string name="AccActionMessageOptions">Message options</string>
+    <string name="AccActionSenderOptions">Sender options</string>
     <string name="AccActionOpenForwardedOrigin">Forwarded origin</string>
     <string name="AccActionEnterSelectionMode">Enter selection mode</string>
     <string name="AccActionChatPreview">Chat Preview</string>


### PR DESCRIPTION
## Summary

The avatar of whoever sent a message opens a menu when it is held down:
their profile, a chat with them, a mention of them, and a search of what
they have said here. The avatar is drawn by the cell and is no view of its
own, so touch exploration had nothing to hold, and none of the four could
be reached at all.

The message now offers that menu as an action of its own. Holding the
avatar is what it asks for, so the menu is come by the same way it is by
everyone else, and whatever it grows to hold is come by that way too.

The menu is drawn around the picture the avatar stands for and does not
come up without one, so it is not offered for a sender who has none.

Nothing else about the message changes: holding the message itself still
selects it, as it did.


## Checking it

With TalkBack on, in a supergroup, swipe onto a message from someone else who has a profile photo and open the actions.

Before, the menu behind their avatar could not be reached at all. Now there is an action that opens it, with the same entries a long press gives: open profile, send message, mention, and search their messages.

Long pressing the message itself still selects it, as before.
