### PR TITLE
Open the viewer of a video that is still downloading

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -17237,6 +17237,20 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         }
     }
 
+    // a video that can be streamed draws two buttons: one in the middle, which opens the viewer
+    // and plays what is there while the rest arrives, and a small one of its own that carries the
+    // download. The state of the button speaks for the small one, so a message that was left while
+    // it was still downloading offered to cancel that download and, being asked to, did nothing at
+    // all: the press it was turned into is only taken while the small button is not drawn.
+    //
+    // touching the middle is what touching the message does, and it is what is done here.
+    private int getIconForAccessibilityClick() {
+        if (drawVideoImageButton) {
+            return autoPlayingMedia ? MediaActionDrawable.ICON_NONE : MediaActionDrawable.ICON_PLAY;
+        }
+        return getIconForCurrentState();
+    }
+
     private int getIconForCurrentState() {
         if (currentMessageObject == null || currentMessageObject.hasExtendedMedia()) {
             return MediaActionDrawable.ICON_NONE;
@@ -26579,8 +26593,10 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             return false;
         }
         if (action == AccessibilityNodeInfo.ACTION_CLICK) {
-            int icon = getIconForCurrentState();
-            if (icon != MediaActionDrawable.ICON_NONE && icon != MediaActionDrawable.ICON_FILE) {
+            int icon = getIconForAccessibilityClick();
+            if (drawVideoImageButton) {
+                didClickedImage();
+            } else if (icon != MediaActionDrawable.ICON_NONE && icon != MediaActionDrawable.ICON_FILE) {
                 didPressButton(true, false);
             } else if (currentMessageObject.type == MessageObject.TYPE_PHONE_CALL) {
                 delegate.didPressOther(this, otherX, otherY);
@@ -27338,7 +27354,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     info.setCollectionItemInfo(AccessibilityNodeInfo.CollectionItemInfo.obtain(itemInfo.getRowIndex(), 1, 0, 1, false));
                 }
                 info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_msg_options, getString("AccActionMessageOptions", R.string.AccActionMessageOptions)));
-                int icon = getIconForCurrentState();
+                int icon = getIconForAccessibilityClick();
                 CharSequence actionLabel = null;
                 switch (icon) {
                     case MediaActionDrawable.ICON_PLAY:


### PR DESCRIPTION
## Summary

A video that can be streamed draws two buttons: one in the middle, which
opens the viewer and plays what has arrived while the rest comes in, and a
small one of its own that carries the download.

A screen reader was given the small one. The state of the button says
"cancel", because that is what the small button does while the file is on
its way, so the message offered to cancel the download; and being asked
to, it did nothing at all, since the press it was turned into is only
taken while that small button is not drawn. So a video left while it was
downloading could not be opened again, and could not be cancelled either.
Nothing happened, and nothing said why, until the file had arrived.

The middle button is what a touch on the message lands on, and it is what
is followed now: the viewer opens, and plays what is there, as it does for
everyone else. What the message offers to do is named after that same
button, so it no longer offers to cancel what it will not cancel.


## Checking it

With TalkBack on, activate a video that is not downloaded, so the viewer opens and streams it, then go back while it is still downloading and activate the message again.

Before, the message said it would cancel the download, and doing so did nothing at all: the video could neither be opened nor cancelled until the file had arrived. Now the viewer opens again, and what the message offers is named for the button a tap actually lands on.
