### PR TITLE
Loop emoji statuses forever in group/voice call participant list

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/GroupCallUserCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/GroupCallUserCell.java
@@ -296,8 +296,8 @@ public class GroupCallUserCell extends FrameLayout {
         nameTextView.setDrawablePadding(AndroidUtilities.dp(6));
         nameTextView.setGravity((LocaleController.isRTL ? Gravity.RIGHT : Gravity.LEFT) | Gravity.TOP);
         addView(nameTextView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 20, (LocaleController.isRTL ? Gravity.RIGHT : Gravity.LEFT) | Gravity.TOP, LocaleController.isRTL ? 54 : 67, 10, LocaleController.isRTL ? 67 : 54, 0));
-        leftDrawable =  new AnimatedEmojiDrawable.SwapAnimatedEmojiDrawable(nameTextView, AndroidUtilities.dp(20), AnimatedEmojiDrawable.CACHE_TYPE_ALERT_EMOJI_STATUS);
-        rightDrawable = new AnimatedEmojiDrawable.SwapAnimatedEmojiDrawable(nameTextView, AndroidUtilities.dp(20), AnimatedEmojiDrawable.CACHE_TYPE_ALERT_EMOJI_STATUS);
+        leftDrawable =  new AnimatedEmojiDrawable.SwapAnimatedEmojiDrawable(nameTextView, AndroidUtilities.dp(20), AnimatedEmojiDrawable.CACHE_TYPE_EMOJI_CALL);
+        rightDrawable = new AnimatedEmojiDrawable.SwapAnimatedEmojiDrawable(nameTextView, AndroidUtilities.dp(20), AnimatedEmojiDrawable.CACHE_TYPE_EMOJI_CALL);
 
         speakingDrawable = context.getResources().getDrawable(R.drawable.voice_volume_mini);
         speakingDrawable.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_voipgroup_speakingText), PorterDuff.Mode.MULTIPLY));


### PR DESCRIPTION
## Summary
- Group/voice call participant emoji statuses currently use `CACHE_TYPE_ALERT_EMOJI_STATUS`, which caps animation at **2 loops**, so custom video emoji freeze mid-call while gift overlays keep animating.
- Switch `GroupCallUserCell` left/right status drawables to `CACHE_TYPE_EMOJI_CALL`, which already configures infinite `autoRepeatCount` for call UI.

## Test plan
- [ ] Join a group voice chat with a Premium emoji status set (video custom emoji preferred)
- [ ] Confirm the status next to the name keeps looping for the whole call
- [ ] Confirm verified / premium-star fallbacks still render
- [ ] Confirm chat-list emoji statuses still stop after ~2 loops (unchanged)

Made with [Cursor](https://cursor.com)