### PR TITLE
Let the options of a poll be put in order

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollEditTextCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollEditTextCell.java
@@ -21,6 +21,7 @@ import android.graphics.Canvas;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.Rect;
+import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -30,6 +31,7 @@ import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.widget.FrameLayout;
@@ -86,6 +88,57 @@ public class PollEditTextCell extends FrameLayout implements SuggestEmojiView.An
     private AnimatorSet checkBoxAnimation;
     private boolean alwaysShowText2;
     private ChatActivityEnterViewAnimatedIconView emojiButton;
+    private ReorderDelegate reorderDelegate;
+
+    /** What a row of a poll can be asked to do besides being typed into. */
+    public interface ReorderDelegate {
+        boolean canMoveUp(PollEditTextCell cell);
+        boolean canMoveDown(PollEditTextCell cell);
+        void moveUp(PollEditTextCell cell);
+        void moveDown(PollEditTextCell cell);
+    }
+
+    /**
+     * Rows are put in order by holding a press and dragging, which leaves a screen reader with no
+     * way to do it at all. The two actions here do the same thing a drag does, and they go on the
+     * field rather than on the handle beside it, because the field is what is stopped at.
+     */
+    public void setReorderDelegate(ReorderDelegate delegate) {
+        reorderDelegate = delegate;
+        if (delegate == null) {
+            return;
+        }
+        textView.setAccessibilityDelegate(new AccessibilityDelegate() {
+            @Override
+            public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfo info) {
+                super.onInitializeAccessibilityNodeInfo(host, info);
+                if (reorderDelegate == null) {
+                    return;
+                }
+                if (reorderDelegate.canMoveUp(PollEditTextCell.this)) {
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_move_up, LocaleController.getString(R.string.AccActionMoveUp)));
+                }
+                if (reorderDelegate.canMoveDown(PollEditTextCell.this)) {
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_move_down, LocaleController.getString(R.string.AccActionMoveDown)));
+                }
+            }
+
+            @Override
+            public boolean performAccessibilityAction(View host, int action, Bundle args) {
+                if (reorderDelegate != null) {
+                    if (action == R.id.acc_action_move_up && reorderDelegate.canMoveUp(PollEditTextCell.this)) {
+                        reorderDelegate.moveUp(PollEditTextCell.this);
+                        return true;
+                    }
+                    if (action == R.id.acc_action_move_down && reorderDelegate.canMoveDown(PollEditTextCell.this)) {
+                        reorderDelegate.moveDown(PollEditTextCell.this);
+                        return true;
+                    }
+                }
+                return super.performAccessibilityAction(host, action, args);
+            }
+        });
+    }
 
     public PollEditTextCell(Context context, OnClickListener onDelete) {
         this(context, false, TYPE_DEFAULT, onDelete);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPollLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPollLayout.java
@@ -1376,6 +1376,53 @@ public class ChatAttachAlertPollLayout extends ChatAttachAlert.AttachAlertLayout
         }
     }
 
+    // dragging a row into place is the only way the screen has of putting the options in order,
+    // so the same move is offered as two actions on the field of every option
+    private final PollEditTextCell.ReorderDelegate reorderDelegate = new PollEditTextCell.ReorderDelegate() {
+        private int indexOf(PollEditTextCell cell) {
+            final RecyclerView.ViewHolder holder = listView.findContainingViewHolder(cell);
+            if (holder == null) {
+                return -1;
+            }
+            final int position = holder.getAdapterPosition();
+            if (position == RecyclerView.NO_POSITION || answerStartRow < 0) {
+                return -1;
+            }
+            final int index = position - answerStartRow;
+            return index >= 0 && index < answersCount ? index : -1;
+        }
+
+        @Override
+        public boolean canMoveUp(PollEditTextCell cell) {
+            return indexOf(cell) > 0;
+        }
+
+        @Override
+        public boolean canMoveDown(PollEditTextCell cell) {
+            final int index = indexOf(cell);
+            return index >= 0 && index < answersCount - 1;
+        }
+
+        @Override
+        public void moveUp(PollEditTextCell cell) {
+            move(indexOf(cell), -1);
+        }
+
+        @Override
+        public void moveDown(PollEditTextCell cell) {
+            move(indexOf(cell), 1);
+        }
+
+        private void move(int index, int by) {
+            if (index < 0 || index + by < 0 || index + by >= answersCount) {
+                return;
+            }
+            listView.setItemAnimator(itemAnimator);
+            listAdapter.swapElements(answerStartRow + index, answerStartRow + index + by);
+            listView.announceForAccessibility(LocaleController.formatString(R.string.AccDescrPollOptionMoved, index + 1 + by, answersCount));
+        }
+    };
+
     private void addNewField() {
         resetSuggestEmojiPanel();
         listView.setItemAnimator(itemAnimator);
@@ -2538,6 +2585,7 @@ public class ChatAttachAlertPollLayout extends ChatAttachAlert.AttachAlertLayout
                         });
                     }
                     cell.setIconsColor(Theme.key_pollCreateIcons);
+                    cell.setReorderDelegate(reorderDelegate);
                     cell.supportMultiselect();
                     cell.getCheckBox().setColor(-1, Theme.key_pollCreateIcons, Theme.key_checkboxCheck);
                     // cell.getCheckBox().setCirclePaintProvider(obj -> checkboxPaint);

--- a/TMessagesProj/src/main/java/org/telegram/ui/PollCreateActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PollCreateActivity.java
@@ -1080,6 +1080,61 @@ public class PollCreateActivity extends BaseFragment implements NotificationCent
         }
     }
 
+    // dragging a row into place is the only way the screen has of putting the items in order, so
+    // the same move is offered as two actions on the field of every item
+    private final PollEditTextCell.ReorderDelegate reorderDelegate = new PollEditTextCell.ReorderDelegate() {
+        private int indexOf(PollEditTextCell cell) {
+            final RecyclerView.ViewHolder holder = listView.findContainingViewHolder(cell);
+            if (holder == null) {
+                return -1;
+            }
+            final int position = holder.getAdapterPosition();
+            if (position == RecyclerView.NO_POSITION || answerStartRow < 0) {
+                return -1;
+            }
+            final int index = position - answerStartRow;
+            if (index < 0 || index >= answersCount) {
+                return -1;
+            }
+            // when only new items are being added, the ones already sent stay where they are
+            return onlyAdding && index < oldAnswersCount ? -1 : index;
+        }
+
+        private boolean movable(int index) {
+            return index >= 0 && index < answersCount && (!onlyAdding || index >= oldAnswersCount);
+        }
+
+        @Override
+        public boolean canMoveUp(PollEditTextCell cell) {
+            final int index = indexOf(cell);
+            return index > 0 && movable(index - 1);
+        }
+
+        @Override
+        public boolean canMoveDown(PollEditTextCell cell) {
+            final int index = indexOf(cell);
+            return index >= 0 && movable(index + 1);
+        }
+
+        @Override
+        public void moveUp(PollEditTextCell cell) {
+            move(indexOf(cell), -1);
+        }
+
+        @Override
+        public void moveDown(PollEditTextCell cell) {
+            move(indexOf(cell), 1);
+        }
+
+        private void move(int index, int by) {
+            if (!movable(index) || !movable(index + by)) {
+                return;
+            }
+            listAdapter.swapElements(answerStartRow + index, answerStartRow + index + by);
+            listView.announceForAccessibility(LocaleController.formatString(R.string.AccDescrPollOptionMoved, index + 1 + by, answersCount));
+        }
+    };
+
     private void addNewField() {
         resetSuggestEmojiPanel();
         answersChecks[answersCount] = false;
@@ -2037,6 +2092,7 @@ public class PollCreateActivity extends BaseFragment implements NotificationCent
                         }
                         return false;
                     });
+                    cell.setReorderDelegate(reorderDelegate);
                     view = cell;
                     break;
                 }

--- a/TMessagesProj/src/main/res/values/ids.xml
+++ b/TMessagesProj/src/main/res/values/ids.xml
@@ -29,6 +29,8 @@
     <item name="acc_action_open_photo" type="id"/>
     <item name="acc_action_chat_preview" type="id"/>
     <item name="acc_action_open_forwarded_origin" type="id"/>
+    <item name="acc_action_move_up" type="id"/>
+    <item name="acc_action_move_down" type="id"/>
     <item name="acc_action_copy_code" type="id"/>
     <item name="acc_action_summarize" type="id"/>
     <item name="shake_animation" type="id"/>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5145,6 +5145,9 @@
     <string name="AccDescrQuizCorrectAnswer">Correct answer</string>
     <string name="AccDescrQuizIncorrectAnswer">Incorrect answer</string>
     <string name="AccDescrQuizExplanation">Explanation</string>
+    <string name="AccActionMoveUp">Move up</string>
+    <string name="AccActionMoveDown">Move down</string>
+    <string name="AccDescrPollOptionMoved">Now %1$d of %2$d</string>
     <string name="AccDescrPipMode">Picture-in-Picture mode</string>
     <string name="AccDescrVoipMicOn">Microphone is on</string>
     <string name="AccDescrVoipMicOff">Microphone is off</string>


### PR DESCRIPTION
## Summary

The order of the options is set by holding a press on a row and dragging it up or down. That is the only way the screen has. The handle drawn beside each row is not focusable, carries no name and has no press of its own, so a screen reader never reaches it, and there is no action anywhere that moves a row: the order a poll is written in cannot be changed at all.

Put two actions on the field of every option, for moving it up and moving it down, offered only where there is somewhere to move to. They do what a drag does, through the same swap the drag goes through, and say where the option has landed afterwards.

The actions go on the field rather than on the handle beside it, because the field is what is stopped at when going through the rows.

Both the screen that makes a poll and the one that makes a checklist do this the same way, so both get it.

## Checking it

With TalkBack on, start a poll and fill in three options, then swipe onto the second field.

Before, the handle drawn beside the row could not be reached and there was no action anywhere that moved a row, so the order could not be changed at all. Now the field offers moving the option up and moving it down, each only where there is somewhere to move to, and says where the option has landed.

The screen that makes a checklist behaves the same way.
