### PR TITLE
Tell the options of a poll apart

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollEditTextCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollEditTextCell.java
@@ -21,6 +21,7 @@ import android.graphics.Canvas;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.Rect;
+import android.os.Build;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -30,6 +31,7 @@ import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.widget.FrameLayout;
@@ -86,6 +88,61 @@ public class PollEditTextCell extends FrameLayout implements SuggestEmojiView.An
     private AnimatorSet checkBoxAnimation;
     private boolean alwaysShowText2;
     private ChatActivityEnterViewAnimatedIconView emojiButton;
+    private CharSequence fieldLabel;
+    private int charactersLeft = -1;
+
+    /**
+     * Every field of a poll is drawn with the same hint, so one option reads exactly like the next
+     * and there is no telling which of them is being typed into. The label given here is the place
+     * of the field among the others, and it is put on the field as a hint for the screen reader,
+     * where it does not get in the way of what has been typed.
+     */
+    public void setFieldLabel(CharSequence label) {
+        fieldLabel = label;
+        installFieldAccessibilityDelegate();
+    }
+
+    /**
+     * How many characters are still allowed, or -1 while the count is not being drawn. The count is
+     * drawn beside the field as a bare number, which on its own is a stop that says nothing, so it
+     * is said as part of the field instead.
+     */
+    public void setAccessibilityCharactersLeft(int left) {
+        charactersLeft = left;
+        installFieldAccessibilityDelegate();
+    }
+
+    private boolean fieldAccessibilityDelegateInstalled;
+
+    private void installFieldAccessibilityDelegate() {
+        if (fieldAccessibilityDelegateInstalled) {
+            return;
+        }
+        fieldAccessibilityDelegateInstalled = true;
+        textView.setAccessibilityDelegate(new AccessibilityDelegate() {
+            @Override
+            public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfo info) {
+                super.onInitializeAccessibilityNodeInfo(host, info);
+                final CharSequence label = fieldAccessibilityLabel();
+                if (TextUtils.isEmpty(label)) {
+                    return;
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    info.setHintText(label);
+                } else if (textView.length() == 0) {
+                    info.setContentDescription(label);
+                }
+            }
+        });
+    }
+
+    private CharSequence fieldAccessibilityLabel() {
+        if (charactersLeft < 0) {
+            return fieldLabel;
+        }
+        final CharSequence left = LocaleController.formatString(R.string.AccDescrPollCharactersLeft, LocaleController.formatPluralString("Characters", charactersLeft));
+        return TextUtils.isEmpty(fieldLabel) ? left : TextUtils.concat(fieldLabel, ", ", left);
+    }
 
     public PollEditTextCell(Context context, OnClickListener onDelete) {
         this(context, false, TYPE_DEFAULT, onDelete);
@@ -213,6 +270,7 @@ public class PollEditTextCell extends FrameLayout implements SuggestEmojiView.An
             addView(deleteImageView, LayoutHelper.createFrame(48, 50, (LocaleController.isRTL ? Gravity.LEFT : Gravity.RIGHT) | Gravity.TOP, LocaleController.isRTL ? 3 : 0, 0, LocaleController.isRTL ? 0 : 3, 0));
 
             textView2 = new SimpleTextView(context);
+            textView2.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
             textView2.setTextSize(13);
             textView2.setGravity((LocaleController.isRTL ? Gravity.LEFT : Gravity.RIGHT) | Gravity.TOP);
             addView(textView2, LayoutHelper.createFrame(48, 24, (LocaleController.isRTL ? Gravity.LEFT : Gravity.RIGHT) | Gravity.TOP, LocaleController.isRTL ? 20 : 0, 43, LocaleController.isRTL ? 0 : 20, 0));
@@ -302,6 +360,7 @@ public class PollEditTextCell extends FrameLayout implements SuggestEmojiView.An
     public void createErrorTextView() {
         alwaysShowText2 = true;
         textView2 = new SimpleTextView(getContext());
+        textView2.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
         textView2.setTextSize(13);
         textView2.setGravity((LocaleController.isRTL ? Gravity.LEFT : Gravity.RIGHT) | Gravity.TOP);
         addView(textView2, LayoutHelper.createFrame(48, 24, (LocaleController.isRTL ? Gravity.LEFT : Gravity.RIGHT) | Gravity.TOP, LocaleController.isRTL ? 20 : 0, 17, LocaleController.isRTL ? 0 : 20, 0));

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPollLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPollLayout.java
@@ -1367,12 +1367,14 @@ public class ChatAttachAlertPollLayout extends ChatAttachAlert.AttachAlertLayout
         }
         if (left <= max - max * 0.7f) {
             textCell.setText2(String.format("%d", left));
+            textCell.setAccessibilityCharactersLeft(left);
             SimpleTextView textView = textCell.getTextView2();
             int key = left < 0 ? Theme.key_text_RedRegular : Theme.key_windowBackgroundWhiteGrayText3;
             textView.setTextColor(getThemedColor(key));
             textView.setTag(key);
         } else {
             textCell.setText2("");
+            textCell.setAccessibilityCharactersLeft(-1);
         }
     }
 
@@ -2121,6 +2123,8 @@ public class ChatAttachAlertPollLayout extends ChatAttachAlert.AttachAlertLayout
                 textCell.setCheckboxMultiselect(multipleChoise, false);
                 int index = position - answerStartRow;
                 textCell.setTextAndHint(answers[index], getString(todo ? R.string.TodoTaskPlaceholder : R.string.OptionHint), true);
+                // every option is drawn with the same hint, so one reads exactly like the next
+                textCell.setFieldLabel(LocaleController.formatString(todo ? R.string.AccDescrTodoTaskNumber : R.string.AccDescrPollOptionNumber, index + 1, answersCount));
                 textCell.setTag(null);
                 if (requestFieldFocusAtPosition == position) {
                     EditTextBoldCursor editText = textCell.getTextView();

--- a/TMessagesProj/src/main/java/org/telegram/ui/PollCreateActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PollCreateActivity.java
@@ -1071,12 +1071,14 @@ public class PollCreateActivity extends BaseFragment implements NotificationCent
         }
         if (left <= max - max * 0.7f) {
             textCell.setText2(String.format("%d", left));
+            textCell.setAccessibilityCharactersLeft(left);
             SimpleTextView textView = textCell.getTextView2();
             int key = left < 0 ? Theme.key_text_RedRegular : Theme.key_windowBackgroundWhiteGrayText3;
             textView.setTextColor(Theme.getColor(key));
             textView.setTag(key);
         } else {
             textCell.setText2("");
+            textCell.setAccessibilityCharactersLeft(-1);
         }
     }
 
@@ -1624,6 +1626,8 @@ public class PollCreateActivity extends BaseFragment implements NotificationCent
                 textCell.textView.setEnabled(enabled);
                 textCell.textView.setTextColor(Theme.multAlpha(getThemedColor(Theme.key_windowBackgroundWhiteBlackText), enabled ? 1.0f : 0.6f));
                 textCell.setTextAndHint(answers[index], getString(todo ? R.string.TodoTaskPlaceholder : R.string.OptionHint), true);
+                // every item is drawn with the same hint, so one reads exactly like the next
+                textCell.setFieldLabel(LocaleController.formatString(todo ? R.string.AccDescrTodoTaskNumber : R.string.AccDescrPollOptionNumber, index + 1, answersCount));
                 textCell.setTag(null);
                 if (textCell.deleteImageView != null) {
                     textCell.deleteImageView.setVisibility(enabled ? View.VISIBLE : View.GONE);

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5145,6 +5145,9 @@
     <string name="AccDescrQuizCorrectAnswer">Correct answer</string>
     <string name="AccDescrQuizIncorrectAnswer">Incorrect answer</string>
     <string name="AccDescrQuizExplanation">Explanation</string>
+    <string name="AccDescrPollOptionNumber">Option %1$d of %2$d</string>
+    <string name="AccDescrTodoTaskNumber">Task %1$d of %2$d</string>
+    <string name="AccDescrPollCharactersLeft">%s left</string>
     <string name="AccDescrPipMode">Picture-in-Picture mode</string>
     <string name="AccDescrVoipMicOn">Microphone is on</string>
     <string name="AccDescrVoipMicOff">Microphone is off</string>


### PR DESCRIPTION
## Summary

Every option is drawn with the same hint, the one word "Option". A screen reader reads an empty option as that one word, so one reads exactly like the next and there is no telling which of them is being typed into, nor how far down the list it is. What is seen on the screen carries the place of a row; what is heard does not.

Give each field the place it holds as its hint, so it is spoken as the label of the field without getting in the way of what has been typed.

The number of characters still allowed is drawn beside the field. On its own it is a stop of its own that says a bare number and nothing else, and because it is faded rather than removed it is said even when it is not drawn. Take it out of the tree and say it as part of the field instead, where it means something.

The screen that makes a checklist is the same, and gets the same.

## Checking it

With TalkBack on, start a poll and swipe through the empty option fields.

Before, each read as the one word "Option", so one was indistinguishable from the next and the count of characters left was a stop of its own saying a bare number. Now each field is named by the place it holds, and the characters left are read as part of the field, only while they are drawn.
