### PR TITLE
Say why a poll cannot be sent yet

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlert.java
@@ -769,6 +769,10 @@ public class ChatAttachAlert extends BottomSheet implements NotificationCenter.N
 
     public void updateDoneItemEnabled() {
         doneItem.setEnabled(currentAttachLayout == null ? false : currentAttachLayout.isDoneItemEnabled());
+        // a dimmed button says it is disabled and nothing more. What is missing is written on the
+        // screen, in a red count or an unmarked answer, and a screen reader is left to guess
+        final CharSequence why = currentAttachLayout == null ? null : currentAttachLayout.getDoneItemAccessibilityText();
+        doneItem.setContentDescription(TextUtils.isEmpty(why) ? null : TextUtils.concat(doneItem.getText(), ", ", why));
         float alpha = 0.0f;
         if (currentAttachLayout != null) {
             alpha += (currentAttachLayout.isDoneItemEnabled() ? 1.0f : 0.5f) * (nextAttachLayout == null ? 1.0f : translationProgress);
@@ -824,6 +828,11 @@ public class ChatAttachAlert extends BottomSheet implements NotificationCenter.N
 
         public boolean isDoneItemEnabled() {
             return false;
+        }
+
+        /** Why the done button cannot be pressed yet, for a screen reader that cannot see it. */
+        public CharSequence getDoneItemAccessibilityText() {
+            return null;
         }
 
         public boolean hasDoneItem() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPollLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPollLayout.java
@@ -1107,6 +1107,7 @@ public class ChatAttachAlertPollLayout extends ChatAttachAlert.AttachAlertLayout
     }
 
     private boolean doneItemEnabled;
+    private CharSequence doneItemDisabledReason;
     private void checkDoneButton() {
         boolean enabled = true;
         int checksCount = 0;
@@ -1148,12 +1149,64 @@ public class ChatAttachAlertPollLayout extends ChatAttachAlert.AttachAlertLayout
         }
         parentAlert.setAllowNestedScroll(allowNesterScroll);
         doneItemEnabled = enabled;
+        doneItemDisabledReason = enabled ? null : disabledReason();
         parentAlert.updateDoneItemEnabled();
     }
 
     @Override
     public boolean isDoneItemEnabled() {
         return doneItemEnabled;
+    }
+
+    @Override
+    public CharSequence getDoneItemAccessibilityText() {
+        return doneItemDisabledReason;
+    }
+
+    /**
+     * The first thing standing in the way of sending, in the order the screen is filled in. What is
+     * missing is only ever shown: a count turning red, an answer left unmarked, a hint that fades
+     * away. A dimmed button on its own says nothing about which of them it is.
+     */
+    private CharSequence disabledReason() {
+        final int maxQuestionLength = todo ? getMessagesController().todoTitleLengthMax : MAX_QUESTION_LENGTH;
+        final int maxAnswerLength = todo ? getMessagesController().todoItemLengthMax : MAX_ANSWER_LENGTH;
+        if (TextUtils.isEmpty(getFixedString(questionString))) {
+            return getString(todo ? R.string.AccDescrTodoNoTitle : R.string.AccDescrPollNoQuestion);
+        }
+        if (questionString.length() > maxQuestionLength) {
+            return getString(todo ? R.string.AccDescrTodoTitleTooLong : R.string.AccDescrPollQuestionTooLong);
+        }
+        if (!TextUtils.isEmpty(getFixedString(descriptionString)) && descriptionString.length() > MAX_CAPTION_LENGTH) {
+            return getString(R.string.AccDescrPollDescriptionTooLong);
+        }
+        if (!TextUtils.isEmpty(getFixedString(solutionString)) && solutionString.length() > MAX_SOLUTION_LENGTH) {
+            return getString(R.string.AccDescrPollExplanationTooLong);
+        }
+        int count = 0;
+        for (int a = 0; a < answers.length; a++) {
+            if (!TextUtils.isEmpty(getFixedString(answers[a]))) {
+                if (answers[a].length() > maxAnswerLength) {
+                    return getString(todo ? R.string.AccDescrTodoTaskTooLong : R.string.AccDescrPollOptionTooLong);
+                }
+                count++;
+            }
+        }
+        if (count < 1) {
+            return getString(todo ? R.string.AccDescrTodoNoTasks : R.string.AccDescrPollNoOptions);
+        }
+        if (quizPoll) {
+            int checksCount = 0;
+            for (int a = 0; a < answersChecks.length; a++) {
+                if (!TextUtils.isEmpty(getFixedString(answers[a])) && answersChecks[a]) {
+                    checksCount++;
+                }
+            }
+            if (checksCount < 1) {
+                return getString(R.string.PollTapToSelect);
+            }
+        }
+        return null;
     }
 
     @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/HintView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/HintView.java
@@ -14,6 +14,7 @@ import android.graphics.Path;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
+import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
@@ -303,6 +304,7 @@ public class HintView extends FrameLayout {
 
         setTag(1);
         setVisibility(VISIBLE);
+        announceForAccessibility();
         if (visibleListener != null) {
             visibleListener.onVisible(true);
         }
@@ -350,6 +352,7 @@ public class HintView extends FrameLayout {
 
         setTag(1);
         setVisibility(VISIBLE);
+        announceForAccessibility();
         if (visibleListener != null) {
             visibleListener.onVisible(true);
         }
@@ -500,6 +503,19 @@ public class HintView extends FrameLayout {
                 setTranslationX(getTranslationX() + diff);
                 arrowImageView.setTranslationX(arrowX - diff);
             }
+        }
+    }
+
+    // a hint appears beside what it is about and takes itself away again after a couple of
+    // seconds. Nothing is focused and nothing is said, so what it holds — often the reason a
+    // button did nothing — never reaches a screen reader at all
+    private void announceForAccessibility() {
+        if (textView == null || !AndroidUtilities.isAccessibilityScreenReaderEnabled()) {
+            return;
+        }
+        final CharSequence text = textView.getText();
+        if (!TextUtils.isEmpty(text)) {
+            announceForAccessibility(text);
         }
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/PollCreateActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PollCreateActivity.java
@@ -89,6 +89,7 @@ import androidx.recyclerview.widget.RecyclerView;
 public class PollCreateActivity extends BaseFragment implements NotificationCenter.NotificationCenterDelegate, SizeNotifierFrameLayout.SizeNotifierFrameLayoutDelegate {
 
     private ActionBarMenuItem doneItem;
+    private CharSequence doneItemText;
     private ListAdapter listAdapter;
     private RecyclerListView listView;
     private RecyclerView.LayoutManager layoutManager;
@@ -516,7 +517,8 @@ public class PollCreateActivity extends BaseFragment implements NotificationCent
         });
 
         ActionBarMenu menu = actionBar.createMenu();
-        doneItem = menu.addItem(done_button, todo ? getString(onlyAdding ? R.string.TodoAddTasksButton : R.string.TodoEditTasksButton) : getString(R.string.Create).toUpperCase());
+        doneItemText = todo ? getString(onlyAdding ? R.string.TodoAddTasksButton : R.string.TodoEditTasksButton) : getString(R.string.Create).toUpperCase();
+        doneItem = menu.addItem(done_button, doneItemText);
 
         listAdapter = new ListAdapter(context);
 
@@ -932,6 +934,53 @@ public class PollCreateActivity extends BaseFragment implements NotificationCent
         }
         doneItem.setEnabled(quizPoll && checksCount == 0 || enabled);
         doneItem.setAlpha(enabled ? 1.0f : 0.5f);
+        // a dimmed button says it is disabled and nothing more. What is missing is written on the
+        // screen, in a red count or an unmarked answer, and a screen reader is left to guess
+        final CharSequence why = enabled ? null : disabledReason();
+        doneItem.setContentDescription(TextUtils.isEmpty(why) ? doneItem.getContentDescription() : TextUtils.concat(doneItemText, ", ", why));
+    }
+
+    /**
+     * The first thing standing in the way of sending, in the order the screen is filled in. What is
+     * missing is only ever shown: a count turning red, an answer left unmarked, a hint that fades
+     * away. A dimmed button on its own says nothing about which of them it is.
+     */
+    private CharSequence disabledReason() {
+        final int maxQuestionLength = todo ? getMessagesController().todoTitleLengthMax : ChatAttachAlertPollLayout.MAX_QUESTION_LENGTH;
+        final int maxAnswerLength = todo ? getMessagesController().todoItemLengthMax : ChatAttachAlertPollLayout.MAX_ANSWER_LENGTH;
+        if (TextUtils.isEmpty(ChatAttachAlertPollLayout.getFixedString(questionString))) {
+            return getString(todo ? R.string.AccDescrTodoNoTitle : R.string.AccDescrPollNoQuestion);
+        }
+        if (questionString.length() > maxQuestionLength) {
+            return getString(todo ? R.string.AccDescrTodoTitleTooLong : R.string.AccDescrPollQuestionTooLong);
+        }
+        if (!TextUtils.isEmpty(ChatAttachAlertPollLayout.getFixedString(solutionString)) && solutionString.length() > ChatAttachAlertPollLayout.MAX_SOLUTION_LENGTH) {
+            return getString(R.string.AccDescrPollExplanationTooLong);
+        }
+        int count = 0;
+        for (int a = 0; a < answers.length; a++) {
+            if (!TextUtils.isEmpty(ChatAttachAlertPollLayout.getFixedString(answers[a]))) {
+                if (answers[a].length() > maxAnswerLength) {
+                    return getString(todo ? R.string.AccDescrTodoTaskTooLong : R.string.AccDescrPollOptionTooLong);
+                }
+                count++;
+            }
+        }
+        if (count < (todo ? 1 : 2)) {
+            return getString(todo ? R.string.AccDescrTodoNoTasks : R.string.AccDescrPollNoOptions);
+        }
+        if (quizPoll) {
+            int checksCount = 0;
+            for (int a = 0; a < answersChecks.length; a++) {
+                if (!TextUtils.isEmpty(ChatAttachAlertPollLayout.getFixedString(answers[a])) && answersChecks[a]) {
+                    checksCount++;
+                }
+            }
+            if (checksCount < 1) {
+                return getString(R.string.PollTapToSelect);
+            }
+        }
+        return null;
     }
 
     private void updateRows() {

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5145,6 +5145,16 @@
     <string name="AccDescrQuizCorrectAnswer">Correct answer</string>
     <string name="AccDescrQuizIncorrectAnswer">Incorrect answer</string>
     <string name="AccDescrQuizExplanation">Explanation</string>
+    <string name="AccDescrPollNoQuestion">Ask a question first</string>
+    <string name="AccDescrPollNoOptions">Add an option first</string>
+    <string name="AccDescrPollQuestionTooLong">The question is too long</string>
+    <string name="AccDescrPollOptionTooLong">An option is too long</string>
+    <string name="AccDescrPollDescriptionTooLong">The description is too long</string>
+    <string name="AccDescrPollExplanationTooLong">The explanation is too long</string>
+    <string name="AccDescrTodoNoTitle">Give the checklist a title first</string>
+    <string name="AccDescrTodoNoTasks">Add a task first</string>
+    <string name="AccDescrTodoTitleTooLong">The title is too long</string>
+    <string name="AccDescrTodoTaskTooLong">A task is too long</string>
     <string name="AccDescrPipMode">Picture-in-Picture mode</string>
     <string name="AccDescrVoipMicOn">Microphone is on</string>
     <string name="AccDescrVoipMicOff">Microphone is off</string>


### PR DESCRIPTION
## Summary

Pressing Create on a quiz with no answer marked right does nothing at all: a bubble appears beside the answers saying to mark one, and takes itself away again after a couple of seconds. The same happens for an option that carries a picture but no words. A bubble is not focused and says nothing, so what it holds � which here is the reason a press did nothing � never reaches a screen reader.

Read a hint out when it appears. That is what it is for, and every hint in the app is put on the screen through the same two places, so all of them are read.

Before that, the button is simply dimmed, and a dimmed button says it is disabled and nothing more. What is missing is only ever shown: a count turning red, an answer left unmarked. Say the first thing standing in the way as part of the button, in the order the screen is filled in.

The screen that makes a checklist has the same button and the same silence, and gets the same.

## Checking it

With TalkBack on, start a quiz, fill in a question and two options, mark none of them right, and press Create.

Before, the press did nothing and the bubble that appeared beside the answers was never read, so there was no reason given. Now the bubble is read out when it appears, and before that the button itself says the first thing standing in the way.

The screen that makes a checklist behaves the same way.
