### PR TITLE
Say when a setting of a poll cannot be changed

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollCreateCheckCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollCreateCheckCell.java
@@ -40,6 +40,7 @@ public class PollCreateCheckCell extends FrameLayout {
     private final ImageView imageView;
     private final Switch checkBox;
     private boolean animationsEnabled;
+    private CharSequence lockedReason;
     private boolean divider;
     private final Theme.ResourcesProvider resourcesProvider;
 
@@ -97,6 +98,15 @@ public class PollCreateCheckCell extends FrameLayout {
         checkBox.setContentDescription(text);
     }
 
+    /**
+     * Why this setting cannot be changed at the moment, or null while it can. A locked setting is
+     * only marked with a small padlock on its switch, and a press on it does nothing, so a screen
+     * reader offered a switch that would not move and said nothing about why.
+     */
+    public void setLocked(CharSequence reason) {
+        lockedReason = reason;
+    }
+
     public void setDivider(boolean divider) {
         this.divider = divider;
         invalidate();
@@ -141,6 +151,11 @@ public class PollCreateCheckCell extends FrameLayout {
         if (multilineValueTextView != null && !TextUtils.isEmpty(multilineValueTextView.getText())) {
             sb.append("\n");
             sb.append(multilineValueTextView.getText());
+        }
+        if (!TextUtils.isEmpty(lockedReason)) {
+            sb.append("\n");
+            sb.append(lockedReason);
+            info.setEnabled(false);
         }
         info.setContentDescription(sb);
         info.setCheckable(true);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPollLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPollLayout.java
@@ -2086,12 +2086,17 @@ public class ChatAttachAlertPollLayout extends ChatAttachAlert.AttachAlertLayout
                         cell.setDivider(pollLimitDuration != 0 || pollLimitDeadline != 0);
                     }
 
+                    // a setting that cannot be changed is marked only with a padlock on its
+                    // switch, and a press on it does nothing at all
                     if (position == poll2vQuizRow) {
                         cell.getCheckBox().setIconVisible(quizOnly, false);
+                        cell.setLocked(quizOnly ? getString(R.string.AccDescrPollQuizLocked) : null);
                     } else if (position == poll2vAllowAddingRow) {
                         cell.getCheckBox().setIconVisible(quizPoll || anonymousPoll, false);
+                        cell.setLocked(quizPoll || anonymousPoll ? getString(R.string.AccDescrPollAddingOptionsLocked) : null);
                     } else {
                         cell.getCheckBox().setIconVisible(false, false);
+                        cell.setLocked(null);
                     }
                     break;
                 }

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5145,6 +5145,8 @@
     <string name="AccDescrQuizCorrectAnswer">Correct answer</string>
     <string name="AccDescrQuizIncorrectAnswer">Incorrect answer</string>
     <string name="AccDescrQuizExplanation">Explanation</string>
+    <string name="AccDescrPollQuizLocked">This poll was started as a quiz and stays one</string>
+    <string name="AccDescrPollAddingOptionsLocked">Not while the poll is a quiz or shows who voted</string>
     <string name="AccDescrPipMode">Picture-in-Picture mode</string>
     <string name="AccDescrVoipMicOn">Microphone is on</string>
     <string name="AccDescrVoipMicOff">Microphone is off</string>


### PR DESCRIPTION
## Summary

Two of the settings are fixed at times: a poll may not take suggested options while it is a quiz or while it shows who voted, and a poll opened as a quiz stays one. Neither is disabled; each is marked with a small padlock drawn on its switch, and a press on it quietly does nothing.

A screen reader is told none of that. It offers a switch, says whether it is on, and turning it does nothing, over and over, with no reason given.

Say the setting is disabled, and say what would have to change first.

## Checking it

With TalkBack on, start a poll, turn on the quiz, then swipe onto the switch for suggested options.

Before, it offered a switch, said whether it was on, and turning it quietly did nothing, over and over with no reason. Now it says the setting is disabled and says what would have to change first.
