### PR TITLE
Say what appears when a setting of a poll is turned on

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPollLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPollLayout.java
@@ -617,6 +617,7 @@ public class ChatAttachAlertPollLayout extends ChatAttachAlert.AttachAlertLayout
                 } else if (view instanceof PollCreateCheckCell) {
                     ((PollCreateCheckCell) view).setChecked(checked);
                 }
+                announceRowsChanged(position, checked);
                 checkDoneButton();
             }
         });
@@ -1373,6 +1374,31 @@ public class ChatAttachAlertPollLayout extends ChatAttachAlert.AttachAlertLayout
             textView.setTag(key);
         } else {
             textCell.setText2("");
+        }
+    }
+
+    /**
+     * Six of the settings put rows on the screen or take them away, and one of them puts a box
+     * beside every option as well. All a screen reader hears is that a switch was turned: what
+     * appeared under it is found only by going back and looking for it. Say what was added, by the
+     * name of the thing that was added.
+     */
+    private void announceRowsChanged(int position, boolean checked) {
+        if (!AndroidUtilities.isAccessibilityScreenReaderEnabled()) {
+            return;
+        }
+        CharSequence added = null;
+        if (position == poll2vQuizRow && checked) {
+            added = getString(R.string.PollTapToSelect);
+        } else if (position == poll2vLimitDurationRow && checked) {
+            added = getString(R.string.PollV2LimitDuration);
+        } else if (position == poll2vLimitByCountryRow.row && checked) {
+            added = getString(R.string.PollV2AllowedCountries);
+        } else if (position == allowMarkingRow && checked && allowAddingRow >= 0) {
+            added = getString(R.string.TodoAllowAddingTasks);
+        }
+        if (added != null) {
+            listView.announceForAccessibility(added);
         }
     }
 


### PR DESCRIPTION
## Summary

Several of the settings do more than remember a choice. Turning on the quiz brings a whole section for the explanation and puts a box for the right answer beside every option. Turning on the time limit brings three rows under it. Limiting by country brings the list of countries. Allowing tasks to be marked done brings the setting for adding them.

A screen reader hears that a switch was turned and nothing else, so what appeared under it is found only by going back afterwards and looking for it, which means knowing to look.

Say what was added, by the name of the thing that was added.

## Checking it

With TalkBack on, start a poll and turn on the quiz, then the time limit.

Before, all that was heard was that the switch had been turned, and what appeared underneath was found only by going back to look for it. Now what was added is named as it appears.
