### PR TITLE
Let an option of a poll be removed

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollEditTextCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollEditTextCell.java
@@ -21,6 +21,7 @@ import android.graphics.Canvas;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.Rect;
+import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -30,6 +31,7 @@ import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.widget.FrameLayout;
@@ -383,6 +385,37 @@ public class PollEditTextCell extends FrameLayout implements SuggestEmojiView.An
             return;
         }
         deleteImageView.callOnClick();
+    }
+
+    /**
+     * On a poll the button for removing an option is hidden to make room for the one that attaches
+     * something, and the only way left of removing it is to empty the field and then press back
+     * once more on an empty field. There is nothing on the screen that says so. Put the same
+     * removal on the field as an action, but only where the button itself is not there to be
+     * pressed, so it is not offered twice.
+     */
+    public void setupRemoveAccessibilityAction() {
+        if (deleteImageView == null) {
+            return;
+        }
+        textView.setAccessibilityDelegate(new AccessibilityDelegate() {
+            @Override
+            public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfo info) {
+                super.onInitializeAccessibilityNodeInfo(host, info);
+                if (deleteImageView != null && deleteImageView.getVisibility() != VISIBLE && isEnabled()) {
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_remove_option, LocaleController.getString(R.string.Delete)));
+                }
+            }
+
+            @Override
+            public boolean performAccessibilityAction(View host, int action, Bundle args) {
+                if (action == R.id.acc_action_remove_option) {
+                    callOnDelete();
+                    return true;
+                }
+                return super.performAccessibilityAction(host, action, args);
+            }
+        });
     }
 
     public void setShowNextButton(boolean value) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPollLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPollLayout.java
@@ -2538,6 +2538,7 @@ public class ChatAttachAlertPollLayout extends ChatAttachAlert.AttachAlertLayout
                         });
                     }
                     cell.setIconsColor(Theme.key_pollCreateIcons);
+                    cell.setupRemoveAccessibilityAction();
                     cell.supportMultiselect();
                     cell.getCheckBox().setColor(-1, Theme.key_pollCreateIcons, Theme.key_checkboxCheck);
                     // cell.getCheckBox().setCirclePaintProvider(obj -> checkboxPaint);

--- a/TMessagesProj/src/main/java/org/telegram/ui/PollCreateActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PollCreateActivity.java
@@ -2037,6 +2037,7 @@ public class PollCreateActivity extends BaseFragment implements NotificationCent
                         }
                         return false;
                     });
+                    cell.setupRemoveAccessibilityAction();
                     view = cell;
                     break;
                 }

--- a/TMessagesProj/src/main/res/values/ids.xml
+++ b/TMessagesProj/src/main/res/values/ids.xml
@@ -29,6 +29,7 @@
     <item name="acc_action_open_photo" type="id"/>
     <item name="acc_action_chat_preview" type="id"/>
     <item name="acc_action_open_forwarded_origin" type="id"/>
+    <item name="acc_action_remove_option" type="id"/>
     <item name="acc_action_copy_code" type="id"/>
     <item name="acc_action_summarize" type="id"/>
     <item name="shake_animation" type="id"/>


### PR DESCRIPTION
## Summary

On a poll the button that removes an option is hidden to make room for the one that attaches something to it. What is left is a gesture nothing on the screen mentions: empty the field, then press back once more on the empty field, and the option goes.

Put the same removal on the field as an action, and only where the button itself is not there to be pressed, so a checklist, which keeps its button, is not offered the same thing twice.

## Checking it

With TalkBack on, start a poll, fill in three options, and swipe onto the second field.

Before, removing an option meant emptying the field and pressing back once more on the empty field, which nothing on the screen mentions. Now the field offers removing the option, and only on a poll, where the button that would do it is hidden to make room for the one that attaches something. A checklist keeps its button and is not offered the same thing twice.
