### PR TITLE
Say whether an item of a checklist is done

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -3790,6 +3790,14 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         return result;
     }
 
+    private boolean isTodoItemDone(int index, PollButton button) {
+        // while the tick is still travelling the box holds the newer answer of the two
+        if (pollCheckBox != null && index >= 0 && index < pollCheckBox.length && pollCheckBox[index] != null) {
+            return pollCheckBox[index].isChecked();
+        }
+        return button != null && button.chosen;
+    }
+
     public void didPressVoteHint() {
         /*
         if (delegate != null) {
@@ -27640,7 +27648,27 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     }
                     PollButton button = pollButtons.get(buttonIndex);
                     StringBuilder sb = new StringBuilder(button.title.getText());
-                    if (!pollVoted) {
+                    if (button.task != null) {
+                        // an item of a checklist is ticked or it is not, and that is the whole of
+                        // what it says. Nothing of it reached a screen reader: a list with half of
+                        // it done read exactly like an untouched one. Where the list cannot be
+                        // ticked at all a bullet is drawn instead of a box, so it is not offered
+                        // as one either, and what is done is said in words, as the line through
+                        // the title says it on the screen
+                        if (currentMessageObject.canCompleteTodo()) {
+                            info.setClassName("android.widget.CheckBox");
+                            info.setCheckable(true);
+                            info.setChecked(isTodoItemDone(buttonIndex, button));
+                            if (button.author != null && isTodoItemDone(buttonIndex, button)) {
+                                sb.append(", ").append(formatString(R.string.AccDescrTodoDoneBy, button.author.getText()));
+                            }
+                        } else {
+                            info.setClassName("android.widget.TextView");
+                            if (isTodoItemDone(buttonIndex, button)) {
+                                sb.append(", ").append(getString(R.string.AccDescrTodoDone));
+                            }
+                        }
+                    } else if (!pollVoted) {
                         info.setClassName("android.widget.Button");
                     } else {
                         info.setSelected(button.chosen);

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5145,6 +5145,8 @@
     <string name="AccDescrQuizCorrectAnswer">Correct answer</string>
     <string name="AccDescrQuizIncorrectAnswer">Incorrect answer</string>
     <string name="AccDescrQuizExplanation">Explanation</string>
+    <string name="AccDescrTodoDone">Done</string>
+    <string name="AccDescrTodoDoneBy">Done by %s</string>
     <string name="AccDescrPipMode">Picture-in-Picture mode</string>
     <string name="AccDescrVoipMicOn">Microphone is on</string>
     <string name="AccDescrVoipMicOff">Microphone is off</string>


### PR DESCRIPTION
## Summary

Every item of a checklist is drawn with a box beside it, and the box is the whole of what the item says. None of it reached a screen reader: the state is kept in the same field a poll answer keeps its own in, and the two tests that would have read it out both fail for a checklist. One asks for a poll answer, which an item is not; the other asks whether the poll has been voted in, and that is answered by looking at the media, which for a checklist is never a poll. So a list with half of it done reads exactly like an untouched one.

Give an item the kind of a check box and its state, so a screen reader says it in its own words, and say who ticked it, which is drawn under the title once it is.

Where the list cannot be ticked at all, a bullet is drawn in place of the box and the title is struck through. Do not offer a box there either, and say in words what the line through the title says on the screen.

## Checking it

With TalkBack on, send a checklist, tick some of its items, and swipe through them.

Before, a list with half of it done read exactly like an untouched one. Now each item reads as a check box with its state, and a ticked one says who ticked it.

On a list that cannot be ticked, where a bullet is drawn in place of the box and the title is struck through, no check box is offered and the line through the title is said in words.
