### PR TITLE
Say what a checklist is and how much of it is done

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -27204,6 +27204,20 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         }
                         sb.append(title);
                     }
+                    // a checklist is drawn with the same two lines a poll is: what kind of list it
+                    // is, under the title, and how much of it is done, under the items. Neither was
+                    // ever spoken, because the block above is only entered for a poll, so all a
+                    // checklist said was its title
+                    if (currentMessageObject.isTodo()) {
+                        if (docTitleLayout != null && !TextUtils.isEmpty(docTitleLayout.getText())) {
+                            sb.append(", ");
+                            sb.append(docTitleLayout.getText());
+                        }
+                        if (animatedInfoLayout != null && !TextUtils.isEmpty(animatedInfoLayout.getText())) {
+                            sb.append(", ");
+                            sb.append(animatedInfoLayout.getText());
+                        }
+                    }
                     if (documentAttach != null) {
                         if (documentAttachType == DOCUMENT_ATTACH_TYPE_VIDEO) {
                             sb.append(", ");


### PR DESCRIPTION
## Summary

A checklist is drawn with the same two lines a poll is: what kind of list it is under the title, and how far along it is under the items, in a count of how many are done and by whom. A screen reader hears neither, because the only place either is spoken from is entered for a poll alone, and a checklist is not one. All a checklist said was its own title.

Say both, from the very layouts that are drawn, in the order the card has them.

## Checking it

With TalkBack on, send a checklist and swipe onto the message.

Before, all it said was its own title. Now it says what kind of list it is and how far along it is, in the order the card draws them.
