### PR TITLE
Let every piece of monospace text on a message be copied

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -5990,6 +5990,129 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     }
 
 
+    /**
+     * A run of monospace text, or a block of code with a copy button under it. A press held on the
+     * one and a press on the other put it on the clipboard, and a screen reader could reach
+     * neither: what it had was a single action named after nothing in particular, which copied
+     * whichever block of code came first and left every other one out of reach.
+     */
+    private static class CopyableText {
+        final CharSequence text;
+        final URLSpanMono span;
+        final MessageObject.TextLayoutBlock block;
+
+        CopyableText(CharSequence text, URLSpanMono span, MessageObject.TextLayoutBlock block) {
+            this.text = text;
+            this.span = span;
+            this.block = block;
+        }
+    }
+
+    // an action carries an id of its own, so there are as many of them as there are ids here. A
+    // message with more separately copyable runs than this is not one anybody would want to walk
+    // an action menu of
+    private static final int[] COPY_TEXT_ACTION_IDS = {
+        R.id.acc_action_copy_text_1, R.id.acc_action_copy_text_2, R.id.acc_action_copy_text_3,
+        R.id.acc_action_copy_text_4, R.id.acc_action_copy_text_5, R.id.acc_action_copy_text_6,
+        R.id.acc_action_copy_text_7, R.id.acc_action_copy_text_8, R.id.acc_action_copy_text_9,
+        R.id.acc_action_copy_text_10, R.id.acc_action_copy_text_11, R.id.acc_action_copy_text_12,
+        R.id.acc_action_copy_text_13, R.id.acc_action_copy_text_14, R.id.acc_action_copy_text_15,
+        R.id.acc_action_copy_text_16,
+    };
+
+    private final ArrayList<CopyableText> copyableTexts = new ArrayList<>();
+
+    private static boolean isCopyTextAction(int action) {
+        for (int id : COPY_TEXT_ACTION_IDS) {
+            if (id == action) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int copyTextActionIndex(int action) {
+        for (int i = 0; i < COPY_TEXT_ACTION_IDS.length; i++) {
+            if (COPY_TEXT_ACTION_IDS[i] == action) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private boolean canCopyFromMessage() {
+        if (currentMessageObject == null) {
+            return false;
+        }
+        if (currentMessageObject.getDialogId() == UserObject.VERIFY) {
+            return true;
+        }
+        // where copying is not allowed the copy button under a block of code is not drawn either,
+        // and a press held on a run of monospace text quietly does nothing
+        return !(MessagesController.getInstance(currentAccount).isPeerNoForwards(currentMessageObject.getDialogId())
+            || currentMessageObject.messageOwner != null && currentMessageObject.messageOwner.noforwards);
+    }
+
+    private void collectCopyableTexts() {
+        copyableTexts.clear();
+        if (!canCopyFromMessage()) {
+            return;
+        }
+        addCopyableMonoRuns(currentMessageObject.messageText);
+        addCopyableCodeBlocks(currentMessageObject.textLayoutBlocks);
+        addCopyableMonoRuns(currentMessageObject.caption);
+        addCopyableCodeBlocks(captionLayout == null ? null : captionLayout.textLayoutBlocks);
+    }
+
+    private void addCopyableMonoRuns(CharSequence text) {
+        if (!(text instanceof Spanned)) {
+            return;
+        }
+        final Spanned spanned = (Spanned) text;
+        final URLSpanMono[] spans = spanned.getSpans(0, spanned.length(), URLSpanMono.class);
+        if (spans == null || spans.length == 0) {
+            return;
+        }
+        // what order they come back in is not promised, and the order they are read in should be
+        // the order they are written in
+        Arrays.sort(spans, (a, b) -> spanned.getSpanStart(a) - spanned.getSpanStart(b));
+        for (URLSpanMono span : spans) {
+            if (copyableTexts.size() >= COPY_TEXT_ACTION_IDS.length) {
+                return;
+            }
+            final int start = spanned.getSpanStart(span);
+            final int end = spanned.getSpanEnd(span);
+            if (start < 0 || end <= start) {
+                continue;
+            }
+            copyableTexts.add(new CopyableText(spanned.subSequence(start, end), span, null));
+        }
+    }
+
+    private void addCopyableCodeBlocks(ArrayList<MessageObject.TextLayoutBlock> blocks) {
+        if (blocks == null) {
+            return;
+        }
+        for (MessageObject.TextLayoutBlock block : blocks) {
+            if (copyableTexts.size() >= COPY_TEXT_ACTION_IDS.length) {
+                return;
+            }
+            if (!block.hasCodeCopyButton || block.textLayout == null || block.textLayout.getText() == null) {
+                continue;
+            }
+            copyableTexts.add(new CopyableText(block.textLayout.getText(), null, block));
+        }
+    }
+
+    private CharSequence copyActionLabel(CharSequence text) {
+        // a block of code is many lines, and the name of an action is one
+        CharSequence label = AndroidUtilities.replaceNewLines(text);
+        if (label.length() > 64) {
+            label = label.subSequence(0, 64) + "…";
+        }
+        return label;
+    }
+
     private void didClickedPollImage(ChatMessageCell cell, ImageReceiver imageReceiver, TLRPC.PollAnswer answer, TLRPC.MessageMedia media, float x, float y, int unshuffledIndex) {
         /*if (unshuffledIndex == PollAttachedMediaPack.INDEX_DESCRIPTION) {
             if (pollContentDrawable != null && pollContentDrawable.getMedia() != null && pollContentDrawable.getMedia().document != null && (pollContentDrawable.isFile() || pollContentDrawable.isMusic())) {
@@ -26612,13 +26735,17 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             if (delegate != null) {
                 delegate.didPressSummarize(this, drawSummaryReply);
             }
-        } else if (action == R.id.acc_action_copy_code) {
-            if (delegate != null && currentMessageObject.textLayoutBlocks != null) {
-                for (MessageObject.TextLayoutBlock block : currentMessageObject.textLayoutBlocks) {
-                    if (block.hasCodeCopyButton) {
-                        delegate.didPressCodeCopy(this, block);
-                        break;
-                    }
+        } else if (isCopyTextAction(action)) {
+            collectCopyableTexts();
+            final int index = copyTextActionIndex(action);
+            if (delegate != null && index >= 0 && index < copyableTexts.size()) {
+                final CopyableText copyable = copyableTexts.get(index);
+                if (copyable.span != null) {
+                    // the very path a press held on the run takes, so the same thing is put on the
+                    // clipboard and the same word said back about it
+                    delegate.didPressUrl(this, copyable.span, true);
+                } else if (copyable.block != null) {
+                    delegate.didPressCodeCopy(this, copyable.block);
                 }
             }
         }
@@ -27370,14 +27497,6 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 if (drawSummarizeButton || drawSummaryReply) {
                     info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_summarize, getString("SummaryTitle", R.string.SummaryTitle)));
                 }
-                if (currentMessageObject.textLayoutBlocks != null) {
-                    for (MessageObject.TextLayoutBlock block : currentMessageObject.textLayoutBlocks) {
-                        if (block.hasCodeCopyButton) {
-                            info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_copy_code, getString("CopyCode", R.string.CopyCode)));
-                            break;
-                        }
-                    }
-                }
 
                 if ((currentMessageObject.isVoice() || currentMessageObject.isRoundVideo() || currentMessageObject.isMusic()) && MediaController.getInstance().isPlayingMessage(currentMessageObject)) {
                     seekBarAccessibilityDelegate.onInitializeAccessibilityNodeInfoInternal(info);
@@ -27469,6 +27588,16 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
                 if (forwardedNameLayout[0] != null && forwardedNameLayout[1] != null) {
                     info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_open_forwarded_origin, getString("AccActionOpenForwardedOrigin", R.string.AccActionOpenForwardedOrigin)));
+                }
+                // every run of monospace text and every block of code that can be copied gets an
+                // action of its own, and the action carries what it would copy, so which of them
+                // is which is known without having to try one and look at the clipboard after
+                collectCopyableTexts();
+                for (int c = 0; c < copyableTexts.size(); c++) {
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(
+                        COPY_TEXT_ACTION_IDS[c],
+                        formatString(R.string.AccActionCopyText, copyActionLabel(copyableTexts.get(c).text))
+                    ));
                 }
                 if (drawSelectionBackground || getBackground() != null) {
                     info.setSelected(true);

--- a/TMessagesProj/src/main/res/values/ids.xml
+++ b/TMessagesProj/src/main/res/values/ids.xml
@@ -29,7 +29,22 @@
     <item name="acc_action_open_photo" type="id"/>
     <item name="acc_action_chat_preview" type="id"/>
     <item name="acc_action_open_forwarded_origin" type="id"/>
-    <item name="acc_action_copy_code" type="id"/>
+    <item name="acc_action_copy_text_1" type="id"/>
+    <item name="acc_action_copy_text_2" type="id"/>
+    <item name="acc_action_copy_text_3" type="id"/>
+    <item name="acc_action_copy_text_4" type="id"/>
+    <item name="acc_action_copy_text_5" type="id"/>
+    <item name="acc_action_copy_text_6" type="id"/>
+    <item name="acc_action_copy_text_7" type="id"/>
+    <item name="acc_action_copy_text_8" type="id"/>
+    <item name="acc_action_copy_text_9" type="id"/>
+    <item name="acc_action_copy_text_10" type="id"/>
+    <item name="acc_action_copy_text_11" type="id"/>
+    <item name="acc_action_copy_text_12" type="id"/>
+    <item name="acc_action_copy_text_13" type="id"/>
+    <item name="acc_action_copy_text_14" type="id"/>
+    <item name="acc_action_copy_text_15" type="id"/>
+    <item name="acc_action_copy_text_16" type="id"/>
     <item name="acc_action_summarize" type="id"/>
     <item name="shake_animation" type="id"/>
 

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5145,6 +5145,7 @@
     <string name="AccDescrQuizCorrectAnswer">Correct answer</string>
     <string name="AccDescrQuizIncorrectAnswer">Incorrect answer</string>
     <string name="AccDescrQuizExplanation">Explanation</string>
+    <string name="AccActionCopyText">Copy %s</string>
     <string name="AccDescrPipMode">Picture-in-Picture mode</string>
     <string name="AccDescrVoipMicOn">Microphone is on</string>
     <string name="AccDescrVoipMicOff">Microphone is off</string>


### PR DESCRIPTION
## Summary

A run of monospace text is copied by holding a press on it, and a block of code long enough to be given a copy button is copied by pressing that. A message can carry any number of both, in its text and in its caption.

What a screen reader had was a single action called "Copy code", which copied whichever block of code came first in the text of the message. Every other block, every run of monospace text, and everything in a caption could not be copied at all, and the one action that did work did not say what it would copy.

Give each of them an action of its own and put what it would copy in the name of the action, so which is which is known without pressing one and looking at the clipboard afterwards. They come after everything else the message offers.

Copying goes through the very paths a press takes, so the same thing is put on the clipboard and the same word is said back about it. Where copying is not allowed nothing is offered, which is what the screen does: the button under a block of code is not drawn, and a press held on a run of monospace text quietly does nothing.

## Checking it

With TalkBack on, send yourself a message holding two blocks of code and a run of monospace text, and swipe onto it.

Before, there was one action called "Copy code" which copied whichever block came first and said nothing about which it was. Now each block and each run has an action of its own, naming what it would copy, and a caption is covered as well.

Where copying is not allowed nothing is offered, as on the screen.
