### PR TITLE
Read out the answer a bot gives to a button

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -28170,6 +28170,12 @@ public class ChatActivity extends BaseFragment implements
         topPanelLayout.setViewVisible(alertView, true);
         alertNameTextView.setText(name);
         alertTextView.setText(Emoji.replaceEmoji(message.replace('\n', ' '), alertTextView.getPaint().getFontMetricsInt(), false));
+        // this is the whole of what a bot can answer a press on one of its buttons with
+        // without asking for a dialog. It is put at the top of the chat for three seconds and
+        // then taken away; nothing is focused and nothing is said, so the answer never reached
+        // a screen reader at all
+        AndroidUtilities.makeAccessibilityAnnouncement(name + ", " + message.replace('\n', ' '));
+
         if (hideAlertViewRunnable != null) {
             AndroidUtilities.cancelRunOnUIThread(hideAlertViewRunnable);
         }


### PR DESCRIPTION
## Summary

A bot that answers a press on one of its buttons without asking for a dialog has its answer put at the top of the chat for three seconds and then taken away again. It is a plain view holding two lines of text: nothing is focused, nothing is said, and three seconds is not long enough to go looking for it.

So the only answer a bot can give without interrupting never reached a screen reader at all, while the same answer sent with the alert flag set opens a dialog and is read. Which of the two a bot sends is its own choice, not the reader's.

Say it when it appears, the way the rest of the passing notices in the app are said.

## Checking it

With TalkBack on, press a bot button whose answer is sent without the alert flag, so it appears at the top of the chat rather than as a dialog.

Before, it came and went in three seconds without a word. Now it is read out as it appears, the way the rest of the passing notices in the app are.
