### PR TITLE
Read out the two notices that hold no words of their own

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Tooltip.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Tooltip.java
@@ -84,6 +84,10 @@ public class Tooltip extends TextView {
         updateTooltipPosition();
         showing = true;
 
+        // it comes up beside what it is about and takes itself away after two seconds. Nothing
+        // is focused and nothing is said, so the reason a control did nothing was never given
+        AndroidUtilities.makeAccessibilityAnnouncement(getText());
+
         AndroidUtilities.cancelRunOnUIThread(dismissRunnable);
         AndroidUtilities.runOnUIThread(dismissRunnable, 2000);
         if (animator != null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/DraftSavedHint.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/DraftSavedHint.java
@@ -73,6 +73,9 @@ public class DraftSavedHint extends View {
     public void show() {
         showT.set(0, true);
         show(true, true);
+        // the hint is drawn by hand and holds no view, so there was nothing for a screen reader
+        // to find: leaving the camera looked as though it had thrown the story away
+        AndroidUtilities.makeAccessibilityAnnouncement(LocaleController.getString(R.string.StoryDraftSaved));
         if (hideRunnable != null) {
             AndroidUtilities.cancelRunOnUIThread(hideRunnable);
         }


### PR DESCRIPTION
## Summary

Two of the passing notices in the app are drawn by hand rather than built from views a screen reader can read, so nothing about them ever reached one.

The first comes up in the photo viewer to say why the compression setting will not open: without it, pressing the setting looks like a control that simply does nothing.

The second says a story draft has been saved when the camera is left, which is the only thing that says the story was not thrown away.

Say both when they appear, as the rest of the passing notices are said.

## Checking it

With TalkBack on, open a video in the photo viewer where the compression setting cannot be opened, and press it. The notice that comes up saying why is now read out; before it said nothing, so the setting looked like a control that simply does nothing.

Leave the story camera with an unsent story: the notice saying the draft has been saved is read out too, which is the only thing that says the story was not thrown away.
