### PR TITLE
Stop giving a screen reader a way into a profile nobody else has

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -1234,7 +1234,6 @@ public class ChatActivity extends BaseFragment implements
     public final static int OPTION_SEND_NOW = 100;
     public final static int OPTION_EDIT_SCHEDULE_TIME = 102;
     public final static int OPTION_SPEED_PROMO = 103;
-    public final static int OPTION_OPEN_PROFILE = 104;
     public final static int OPTION_FACT_CHECK = 106;
     public final static int OPTION_EDIT_PRICE = 107;
     public final static int OPTION_GIFT = 108;
@@ -30883,12 +30882,6 @@ public class ChatActivity extends BaseFragment implements
             final ArrayList<Integer> options = new ArrayList<>();
             View optionsView = null;
 
-            if (AndroidUtilities.isAccessibilityScreenReaderEnabled() && message.messageOwner != null && message.messageOwner.from_id != null && message.messageOwner.from_id.user_id != getUserConfig().clientUserId && chatMode != MODE_SAVED) {
-                items.add(LocaleController.getString(R.string.OpenProfile));
-                options.add(OPTION_OPEN_PROFILE);
-                icons.add(R.drawable.msg_user_search);
-            }
-
             if (!getUserConfig().isPremium() && !getMessagesController().premiumFeaturesBlocked() && message.getDocument() != null && message.getDocument().size >= 150 * 1024 * 1024 && FileLoader.getInstance(currentAccount).isLoadingFile(FileLoader.getAttachFileName(message.getDocument())) && chatMode != MODE_SAVED) {
                 items.add(LocaleController.getString(R.string.PremiumSpeedPromo));
                 options.add(OPTION_SPEED_PROMO);
@@ -34248,11 +34241,6 @@ public class ChatActivity extends BaseFragment implements
             }
             case OPTION_SPEED_PROMO: {
                 showDialog(new PremiumFeatureBottomSheet(ChatActivity.this, PremiumPreviewFragment.PREMIUM_FEATURE_DOWNLOAD_SPEED, true));
-                break;
-            }
-            case OPTION_OPEN_PROFILE: {
-                TLRPC.Peer from = selectedObject.messageOwner.from_id;
-                openUserProfile(from.user_id != 0 ? from.user_id : from.channel_id != 0 ? from.channel_id : from.chat_id);
                 break;
             }
             case OPTION_FACT_CHECK: {


### PR DESCRIPTION
## Summary

The menu that opens on a message carries an entry for opening the sender's profile, and it is put there only when a screen reader is running. Nobody else sees it, and nothing else in the app works that way.

Where a profile can be opened from a message, it is opened by holding the sender's picture beside it, which is a group or a chat with yourself and nowhere else. The menu entry was there in every chat, including a channel and a one to one chat, where holding anything gives nobody a profile.

So a screen reader was given its own way in, in its own places, and the two ways read differently: one entry against a menu of four. Take it away and leave the picture beside the message, which is where everyone finds it and which a screen reader now reaches as well.

## Checking it

With TalkBack on, open the menu on a message in a one to one chat.

Before, the menu carried an entry for opening the sender's profile that nobody without a screen reader could see, and it was there even in chats where holding the sender's picture gives nobody a profile. Now the menu is the same one everyone else gets.

Where a profile can be opened from a message, which is a group or a chat with yourself, it is opened by holding the sender's picture beside it, as everyone else does.


## Depends on #2045

This takes away the entry a screen reader had for opening a sender's profile, on the grounds that everyone opens it by holding the picture beside the message. Holding that picture only reaches a screen reader with #2045, which gives the picture a place in the tree and a press of its own.

Merged on its own and before #2045, this would leave a screen reader with no way into a profile from a message at all. Merged after it, the two ways become one, which is the point of both.
