### PR TITLE
Fix chat list dates from other years rendering without a year

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/LocaleController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/LocaleController.java
@@ -2916,22 +2916,40 @@ public class LocaleController {
     public static String stringForMessageListDate(long date) {
         try {
             date *= 1000;
-            if (Math.abs(System.currentTimeMillis() - date) >= 31536000000L) {
-                return getInstance().getFormatterYear().format(new Date(date));
-            } else {
-                Calendar rightNow = Calendar.getInstance();
-                int day = rightNow.get(Calendar.DAY_OF_YEAR);
-                rightNow.setTimeInMillis(date);
-                int dateDay = rightNow.get(Calendar.DAY_OF_YEAR);
+            long now = System.currentTimeMillis();
 
-                int dayDiff = dateDay - day;
-                if (dayDiff == 0 || dayDiff == -1 && System.currentTimeMillis() - date < 60 * 60 * 8 * 1000) {
-                    return getInstance().getFormatterDay().format(new Date(date));
-                } else if (dayDiff > -7 && dayDiff <= -1) {
-                    return getInstance().getFormatterWeek().format(new Date(date));
-                } else {
-                    return getInstance().getFormatterDayMonth().format(new Date(date));
-                }
+            Calendar rightNow = Calendar.getInstance();
+
+            rightNow.setTimeInMillis(now);
+            int currentYear = rightNow.get(Calendar.YEAR);
+            rightNow.set(Calendar.HOUR_OF_DAY, 0);
+            rightNow.set(Calendar.MINUTE, 0);
+            rightNow.set(Calendar.SECOND, 0);
+            rightNow.set(Calendar.MILLISECOND, 0);
+            long todayStart = rightNow.getTimeInMillis();
+
+            rightNow.setTimeInMillis(date);
+            int dateYear = rightNow.get(Calendar.YEAR);
+            rightNow.set(Calendar.HOUR_OF_DAY, 0);
+            rightNow.set(Calendar.MINUTE, 0);
+            rightNow.set(Calendar.SECOND, 0);
+            rightNow.set(Calendar.MILLISECOND, 0);
+            long dateStart = rightNow.getTimeInMillis();
+
+            // Whole calendar days between the two dates. Rounding keeps this exact
+            // across DST transitions, where a local day is not 24h long.
+            long dayDiff = Math.round((dateStart - todayStart) / 86400000.0);
+
+            if (dayDiff == 0 || dayDiff == -1 && now - date < 60 * 60 * 8 * 1000) {
+                return getInstance().getFormatterDay().format(new Date(date));
+            } else if (dayDiff > -7 && dayDiff <= -1) {
+                return getInstance().getFormatterWeek().format(new Date(date));
+            } else if (dateYear == currentYear) {
+                return getInstance().getFormatterDayMonth().format(new Date(date));
+            } else {
+                // A different calendar year must never be rendered as a bare
+                // "MMM dd" - without the year that label is ambiguous.
+                return getInstance().getFormatterYear().format(new Date(date));
             }
         } catch (Exception e) {
             FileLog.e(e);


### PR DESCRIPTION
### Problem

`LocaleController.stringForMessageListDate` decides whether to show the year using a rolling 365-day window:

```java
if (Math.abs(System.currentTimeMillis() - date) >= 31536000000L) {
    return getInstance().getFormatterYear().format(new Date(date));      // "dd.MM.yy"
} else {
    ...
    return getInstance().getFormatterDayMonth().format(new Date(date));  // "MMM dd"
}
```

Any message less than 365 days old is formatted as `MMM dd`, which carries no year. On 4 September 2026 a chat whose last message is from 18 December 2025 renders as `Dec 18` - and a chat from 18 December 2026 renders as `Dec 18` as well. The two are a year apart and produce an identical label.

Because the cutoff is 365 days rather than a year boundary, the same column also mixes two formats whose trailing number means different things:

- `Nov 28` - trailing number is the day of the month
- `26.08.19` - trailing number is the year

In a chat list spanning several years this makes a chat's age hard to read at a glance, and the list can look incorrectly sorted when it is not.

### Second issue: day difference across the new year

The day difference was computed from `Calendar.DAY_OF_YEAR`:

```java
int day = rightNow.get(Calendar.DAY_OF_YEAR);
rightNow.setTimeInMillis(date);
int dateDay = rightNow.get(Calendar.DAY_OF_YEAR);

int dayDiff = dateDay - day;
```

Day-of-year values are not comparable across a year boundary. On 2 January, a message from 31 December gives `dayDiff = 365 - 2 = 363` instead of `-2`, so it never matches `dayDiff > -7 && dayDiff <= -1` and the weekday label is skipped. The "last 7 days show a weekday" behaviour quietly breaks every January.

### Change

- Decide the year format by comparing calendar years, so a date outside the current year always uses `formatterYear`.
- Measure the day difference between local midnights, rounded, which stays exact across DST transitions where a local day is not 24 hours long.

Unchanged: today shows the time, yesterday within 8 hours shows the time, the last 7 days show a weekday, and same-year older dates still show `MMM dd`.

| Last message | Before | After |
| --- | --- | --- |
| today 16:45 | `4:45 PM` | `4:45 PM` |
| yesterday | `Thu` | `Thu` |
| 2026-08-06 (same year) | `Aug 06` | `Aug 06` |
| 2025-12-18 | `Dec 18` | `18.12.25` |
| 2025-11-28 | `Nov 28` | `28.11.25` |
| 2019-08-06 | `06.08.19` | `06.08.19` |
| 2025-12-31 viewed on 2026-01-02 | `Dec 31` | `Wed` |
