### PR TITLE
Say where a poll stands, and say what it is before its question

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -27156,7 +27156,14 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                                 messageText = ssb;
                             }
                         }
-                        sb.append(messageText);
+                        // a poll names itself twice over: once as the kind of message it is, and
+                        // again under its question, where the kind is said in full. Leave the
+                        // first of the two out and let the fuller one stand
+                        final boolean namedByPoll = currentMessageObject.isPoll() && lastPoll != null
+                            && TextUtils.equals(messageText, currentMessageObject.getMediaTitle(MessageObject.getMedia(currentMessageObject.messageOwner)));
+                        if (!namedByPoll) {
+                            sb.append(messageText);
+                        }
                     }
                     if (documentAttach != null && (documentAttachType == DOCUMENT_ATTACH_TYPE_DOCUMENT || documentAttachType == DOCUMENT_ATTACH_TYPE_GIF || documentAttachType == DOCUMENT_ATTACH_TYPE_VIDEO)) {
                         if (buttonState == 1 && loadingProgressLayout != null) {
@@ -27183,9 +27190,8 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         }
                     }
                     if (lastPoll != null) {
-                        sb.append(", ");
-                        sb.append(lastPoll.question.text);
-                        sb.append(", ");
+                        // the kind of poll comes before the question, the way it is drawn: the
+                        // line above the question is what says a poll is a poll
                         String title;
                         if (pollClosed) {
                             title = getString("FinalResults", R.string.FinalResults);
@@ -27202,7 +27208,41 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                                 title = getString("AnonymousPoll", R.string.AnonymousPoll);
                             }
                         }
+                        sb.append(", ");
                         sb.append(title);
+                        sb.append(", ");
+                        sb.append(lastPoll.question.text);
+                        // the counter under a poll, and the state the poll is in. All of it is
+                        // written on the card, so a sighted reader has it without touching
+                        // anything, while nothing here was ever said out loud
+                        sb.append(", ");
+                        if (lastPollResultsVoters == 0) {
+                            sb.append(getString(lastPoll.quiz ? R.string.NoVotesQuiz : R.string.NoVotes));
+                        } else {
+                            sb.append(formatPluralString(lastPoll.quiz ? "Answer" : "Vote", lastPollResultsVoters));
+                        }
+                        if (lastPoll.multiple_choice && !pollVoted && !pollClosed) {
+                            sb.append(", ");
+                            sb.append(getString(R.string.AccDescrPollMultipleChoice));
+                        }
+                        if (pollVoted) {
+                            sb.append(", ");
+                            sb.append(getString(R.string.AccDescrPollVoted));
+                        }
+                        if (!pollClosed) {
+                            if (lastPoll.hide_results_until_close && !lastPoll.creator) {
+                                sb.append(", ");
+                                sb.append(getString(R.string.PollResultsWillLater));
+                            }
+                            final int closeDate = lastPoll.close_date;
+                            if (closeDate > 0 && closeDate > ConnectionsManager.getInstance(currentAccount).getCurrentTime()) {
+                                // the card counts down by the second. Saying when the poll closes
+                                // instead of how long is left keeps this text still, so the message
+                                // is not reported as changed over and over
+                                sb.append(", ");
+                                sb.append(formatString(R.string.AccDescrPollClosesAt, LocaleController.formatDateTime(closeDate, true)));
+                            }
+                        }
                     }
                     if (documentAttach != null) {
                         if (documentAttachType == DOCUMENT_ATTACH_TYPE_VIDEO) {

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5145,6 +5145,9 @@
     <string name="AccDescrQuizCorrectAnswer">Correct answer</string>
     <string name="AccDescrQuizIncorrectAnswer">Incorrect answer</string>
     <string name="AccDescrQuizExplanation">Explanation</string>
+    <string name="AccDescrPollMultipleChoice">Choose more than one</string>
+    <string name="AccDescrPollVoted">You have voted</string>
+    <string name="AccDescrPollClosesAt">Closes at %s</string>
     <string name="AccDescrPipMode">Picture-in-Picture mode</string>
     <string name="AccDescrVoipMicOn">Microphone is on</string>
     <string name="AccDescrVoipMicOff">Microphone is off</string>


### PR DESCRIPTION
## Summary

Under the question of a poll the card carries a counter, and around it the state the poll is in: how many have voted, that more than one answer may be chosen, that this account has already voted, that the results are kept until the poll closes, and how long is left before it does. A screen reader hears the question and the kind of poll and nothing else, so none of it is known without voting and finding out.

Put all of it after the kind of poll, in the order the card has it.

The kind of poll is drawn on the line above the question, and it is what says a poll is a poll at all, so it is said first and the question after it. It was also said twice over, once as the kind of message and again in full under the question; the first of the two is left out.

The counter on the card runs down by the second. Saying when the poll closes instead of how long is left keeps the text of the message still, so a poll on the screen is not reported as changed again and again while it is being read.

## Checking it

With TalkBack on, send a poll that allows multiple answers and has a time limit, then swipe onto the message.

Before, only the question and the kind of poll were said. Now the kind comes first, the question after it, and then everything written under the question: how many have voted, that more than one answer may be chosen, that this account has voted, and when the poll closes.

Leave the poll on the screen and listen: the message is no longer reported as changed every second, because the closing time is said rather than the time left.
