### PR TITLE
Read the explanation a quiz gives

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -3802,6 +3802,11 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             if (delegate != null) {
                 delegate.forceUpdate(this, true);
             }
+            // the explanation is part of what the message says, so opening or closing it leaves a
+            // screen reader on a message whose text is no longer the one it read
+            if (AndroidUtilities.isAccessibilityScreenReaderEnabled()) {
+                sendAccessibilityEvent(AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED);
+            }
         }
     }
 
@@ -27203,6 +27208,15 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                             }
                         }
                         sb.append(title);
+                        // the explanation of a quiz is drawn under the poll once its button has
+                        // been pressed. It was never spoken: the button could be pressed, and
+                        // what it opened stayed unread
+                        if (currentMessageObject.expandedExplanation && !TextUtils.isEmpty(currentExplanation)) {
+                            sb.append("\n");
+                            sb.append(getString(R.string.QuizExplanationTitle));
+                            sb.append(", ");
+                            sb.append(currentExplanation);
+                        }
                     }
                     if (documentAttach != null) {
                         if (documentAttachType == DOCUMENT_ATTACH_TYPE_VIDEO) {
@@ -27667,8 +27681,18 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 } else if (virtualViewId == POLL_HINT) {
                     info.setClassName("android.widget.Button");
                     info.setEnabled(true);
-                    info.setText(getString(R.string.AccDescrQuizExplanation));
-                    info.addAction(AccessibilityNodeInfo.ACTION_CLICK);
+                    // the same button opens the explanation and closes it again, so which of the
+                    // two it is now has to be said on the button itself: a name alone leaves no
+                    // way of knowing whether pressing it will open or close
+                    final boolean explanationOpen = currentMessageObject != null && currentMessageObject.expandedExplanation;
+                    info.setText(TextUtils.concat(
+                        getString(R.string.AccDescrQuizExplanation), ", ",
+                        getString(explanationOpen ? R.string.AccDescrExpanded : R.string.AccDescrCollapsed)
+                    ));
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(
+                        AccessibilityNodeInfo.ACTION_CLICK,
+                        getString(explanationOpen ? R.string.PollCollapse : R.string.PollExpand)
+                    ));
                     rect.set(pollHintX - dp(8), pollHintY - dp(8), pollHintX + dp(32), pollHintY + dp(32));
                     info.setBoundsInParent(rect);
                     if (accessibilityVirtualViewBounds.get(virtualViewId) == null || !accessibilityVirtualViewBounds.get(virtualViewId).equals(rect)) {


### PR DESCRIPTION
## Summary

A quiz that was answered wrongly offers a button that opens the reason for the right answer. A screen reader could reach the button and press it, and then nothing: the explanation is drawn under the poll and was never part of what the message says, so the press appeared to do nothing at all.

Put the explanation at the end of the message once it is open, under its own heading, and say that the message changed when the button is pressed, so the words that just appeared are read instead of waiting for the message to be left and come back to.

The one button both opens and closes it, so say on the button which of the two it is now, and name the press after whichever of the two it does. A name on its own leaves no way of knowing whether pressing will open the explanation or put it away again.

## Checking it

With TalkBack on, answer a quiz wrongly and press the button that opens the reason.

Before, the press appeared to do nothing: the explanation was drawn but was never part of what the message said. Now the words that appear are read out as they appear, and the message carries the explanation under its own heading.

Press the button again: it says whether it will open or close the explanation, and the name of the press follows.
