### PR TITLE
Give the button that adds an answer to a poll a place

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -27025,6 +27025,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         public static final int CONTACT_VIEW = 491;
         public static final int CONTACT_ADD = 490;
         public static final int CONTACT_MESSAGE = 489;
+        public static final int POLL_ADD_OPTION = 488;
         private Path linkPath = new Path();
         private RectF rectF = new RectF();
         private Rect rect = new Rect();
@@ -27424,6 +27425,15 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     info.addChild(ChatMessageCell.this, POLL_BUTTONS_START + i);
                     i++;
                 }
+                // a poll that lets anyone add an answer has a button under the last one for it.
+                // It is a control of its own, drawn like the answers above it, and there was
+                // nothing of it in the tree at all: it could be neither found nor pressed
+                // whether a poll lets answers be added is worked out for a poll alone, so a cell
+                // used again for a message that is not one keeps the answer of the poll it held
+                // before. The button is drawn for a poll only; ask for one here as well
+                if (pollAllowAdding && pollAddButtonDrawable != null && currentMessageObject.isPoll()) {
+                    info.addChild(ChatMessageCell.this, POLL_ADD_OPTION);
+                }
                 if (drawInstantView && !instantButtonRect.isEmpty()) {
                     info.addChild(ChatMessageCell.this, INSTANT_VIEW);
                 }
@@ -27677,6 +27687,23 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     rect.offset(pos[0], pos[1]);
                     info.setBoundsInScreen(rect);
                     info.setClickable(true);
+                } else if (virtualViewId == POLL_ADD_OPTION) {
+                    if (!getPollAddButtonBounds(rect)) {
+                        return null;
+                    }
+                    info.setClassName("android.widget.Button");
+                    info.setEnabled(true);
+                    info.setText(getString(R.string.PollAddAnOption));
+                    info.addAction(AccessibilityNodeInfo.ACTION_CLICK);
+                    info.setBoundsInParent(rect);
+                    // the bounds go into the map the cell hit tests against, so the button is
+                    // found by a finger on the screen as well as by swiping to it
+                    if (accessibilityVirtualViewBounds.get(virtualViewId) == null || !accessibilityVirtualViewBounds.get(virtualViewId).equals(rect)) {
+                        accessibilityVirtualViewBounds.put(virtualViewId, new Rect(rect));
+                    }
+                    rect.offset(pos[0], pos[1]);
+                    info.setBoundsInScreen(rect);
+                    info.setClickable(true);
                 } else if (virtualViewId == INSTANT_VIEW) {
                     info.setClassName("android.widget.Button");
                     info.setEnabled(true);
@@ -27903,6 +27930,11 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                             ArrayList<TLRPC.PollAnswer> answers = new ArrayList<>();
                             answers.add(button.answer);
                             delegate.didPressVoteButtons(ChatMessageCell.this, answers, -1, 0, 0);
+                        }
+                        sendAccessibilityEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_CLICKED);
+                    } else if (virtualViewId == POLL_ADD_OPTION) {
+                        if (delegate != null && currentMessageObject.isPoll()) {
+                            delegate.didPressAddPollOptionButton(ChatMessageCell.this);
                         }
                         sendAccessibilityEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_CLICKED);
                     } else if (virtualViewId == POLL_HINT) {


### PR DESCRIPTION
## Summary

A poll whose author let anyone add an answer has a button under the last one for it, drawn like the answers above it. Nothing of it was in the tree of the message: it had no place to swipe to, no name, and no press, so an answer could not be added at all.

Make it a child of the message like the answers are, named by the words on it, and put its bounds where the cell hit tests, so a finger moving over the screen finds it as well.

Whether a poll lets answers be added is worked out for a poll alone, so a cell used again for a message that is not one keeps the answer of the poll it held before. The button is drawn for a poll only, so ask for one here as well, or it turns up on messages that are not polls at all.

## Checking it

With TalkBack on, find a poll whose author allowed anyone to add an answer, and swipe through the message.

Before, the button under the last answer was in no part of the tree, so there was no way to reach it, name it or press it. Now it is one of the message's children like the answers are, named by the words on it, and a finger moving over the screen finds it too.

Swipe through a message that is not a poll in the same chat: the button is not offered there, which it was before.
