### PR TITLE
Name the button that attaches something to a poll

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/PollAddOptionFieldLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/PollAddOptionFieldLayout.java
@@ -181,6 +181,7 @@ public class PollAddOptionFieldLayout extends FrameLayout implements ViewTreeObs
         });
 
         emojiButton = new EmojiButton(context);
+        emojiButton.setContentDescription(getString(R.string.Emoji));
         emojiButton.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_stickers_menuSelector, resourcesProvider)));
         ScaleStateListAnimator.apply(emojiButton);
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/PollAttachButton.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/PollAttachButton.java
@@ -8,10 +8,13 @@ import android.graphics.Canvas;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
+import android.text.TextUtils;
 import android.view.View;
+import android.view.accessibility.AccessibilityNodeInfo;
 
 import androidx.annotation.NonNull;
 
+import org.telegram.messenger.LocaleController;
 import org.telegram.messenger.R;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.CubicBezierInterpolator;
@@ -74,6 +77,22 @@ public class PollAttachButton extends View {
         attachedMedia = media;
         if (isAttachedToWindow() && attachedMedia != null) {
             attachedMedia.attach(this);
+        }
+    }
+
+    @Override
+    public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
+        super.onInitializeAccessibilityNodeInfo(info);
+        // this is a bare view drawn by hand, so nothing about it was ever spoken: neither what it
+        // does, nor that something is already attached to it, nor what that something is. Once
+        // there is media the icon is replaced by a thumbnail of it, and a press then goes to
+        // replacing it rather than to adding
+        info.setClassName("android.widget.Button");
+        final CharSequence name = attachedMedia == null ? null : attachedMedia.getAccessibilityName();
+        if (TextUtils.isEmpty(name)) {
+            info.setContentDescription(LocaleController.getString(R.string.AccDescrAttachButton));
+        } else {
+            info.setContentDescription(TextUtils.concat(LocaleController.getString(R.string.Change), ", ", name));
         }
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/PollAttachedMedia.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/PollAttachedMedia.java
@@ -6,6 +6,8 @@ import android.view.View;
 import androidx.annotation.CallSuper;
 
 import org.telegram.messenger.ImageReceiver;
+import org.telegram.messenger.LocaleController;
+import org.telegram.messenger.R;
 
 public abstract class PollAttachedMedia {
     protected final ImageReceiver imageReceiver = new ImageReceiver();
@@ -23,5 +25,10 @@ public abstract class PollAttachedMedia {
 
     protected void draw(Canvas canvas, int w, int h) {
 
+    }
+
+    /** What this is, in one word, for a screen reader that cannot see the thumbnail. */
+    public CharSequence getAccessibilityName() {
+        return LocaleController.getString(R.string.AttachDocument);
     }
 }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/attached/PollAttachedMediaFile.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/attached/PollAttachedMediaFile.java
@@ -23,6 +23,8 @@ import org.telegram.messenger.ApplicationLoader;
 import org.telegram.messenger.FileLoader;
 import org.telegram.messenger.MediaController;
 import org.telegram.messenger.MessageObject;
+import org.telegram.messenger.LocaleController;
+import org.telegram.messenger.R;
 import org.telegram.tgnet.TLRPC;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.MediaActionDrawable;
@@ -41,8 +43,8 @@ public class PollAttachedMediaFile extends PollAttachedMedia {
     private final Drawable thumb;
     private final TextPaint tp;
     private final StaticLayout staticLayout;
-
     public PollAttachedMediaFile(@NonNull String path) {
+
         this.path = path;
         this.uri = null;
 
@@ -128,6 +130,12 @@ public class PollAttachedMediaFile extends PollAttachedMedia {
             staticLayout.draw(canvas);
             canvas.restore();
         }
+    }
+
+    @Override
+    public CharSequence getAccessibilityName() {
+        // the name of the file says far more than the word "file" does
+        return TextUtils.isEmpty(name) ? LocaleController.getString(R.string.AttachDocument) : name;
     }
 
     public static Drawable createMessagePreviewDrawable(View view, String title, String subtitle, TLRPC.Document document, MessageObject messageObject) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/attached/PollAttachedMediaGallery.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/attached/PollAttachedMediaGallery.java
@@ -6,8 +6,10 @@ import android.graphics.Canvas;
 
 import org.telegram.messenger.ImageLocation;
 import org.telegram.messenger.ImageReceiver;
+import org.telegram.messenger.LocaleController;
 import org.telegram.messenger.MediaController;
 import org.telegram.messenger.SendMessagesHelper;
+import org.telegram.messenger.R;
 import org.telegram.ui.Components.poll.PollAttachedMedia;
 
 public class PollAttachedMediaGallery extends PollAttachedMedia {
@@ -19,6 +21,11 @@ public class PollAttachedMediaGallery extends PollAttachedMedia {
         this.photoEntry = sendingMediaInfo.originalPhotoEntry;
         imageReceiver.setRoundRadius(dp(7));
         setupImageReceiver(imageReceiver);
+    }
+
+    @Override
+    public CharSequence getAccessibilityName() {
+        return LocaleController.getString(photoEntry != null && photoEntry.isVideo ? R.string.AttachVideo : R.string.AttachPhoto);
     }
 
     private void setupImageReceiver(ImageReceiver imageReceiver) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/attached/PollAttachedMediaLink.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/attached/PollAttachedMediaLink.java
@@ -7,6 +7,7 @@ import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
+import android.text.TextUtils;
 import android.view.Gravity;
 import android.view.View;
 
@@ -24,6 +25,7 @@ import org.telegram.messenger.NotificationCenter;
 import org.telegram.messenger.R;
 import org.telegram.messenger.utils.DrawableUtils;
 import org.telegram.tgnet.TLRPC;
+import org.telegram.messenger.LocaleController;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.CircularProgressDrawable;
 import org.telegram.ui.Components.CubicBezierInterpolator;
@@ -58,6 +60,12 @@ public class PollAttachedMediaLink extends PollAttachedMedia implements Drawable
 
     public TLRPC.WebPage getWebPage() {
         return webPage;
+    }
+
+    @Override
+    public CharSequence getAccessibilityName() {
+        // the address itself is what tells one link from another
+        return TextUtils.isEmpty(url) ? LocaleController.getString(R.string.LinkPreview) : url;
     }
 
     public void setWebPage(TLRPC.WebPage webPage, boolean progress, boolean animated) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/attached/PollAttachedMediaLocation.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/attached/PollAttachedMediaLocation.java
@@ -20,6 +20,7 @@ import org.telegram.messenger.R;
 import org.telegram.messenger.SvgHelper;
 import org.telegram.messenger.WebFile;
 import org.telegram.tgnet.TLRPC;
+import org.telegram.messenger.LocaleController;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.ClipRoundedDrawable;
 import org.telegram.ui.Components.CubicBezierInterpolator;
@@ -32,6 +33,11 @@ public class PollAttachedMediaLocation extends PollAttachedMedia {
         this.media = location;
         imageReceiver.setRoundRadius(dp(7));
         setupImageReceiver(imageReceiver);
+    }
+
+    @Override
+    public CharSequence getAccessibilityName() {
+        return LocaleController.getString(R.string.AttachLocation);
     }
 
     private void setupImageReceiver(ImageReceiver imageReceiver) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/attached/PollAttachedMediaMusic.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/attached/PollAttachedMediaMusic.java
@@ -9,6 +9,8 @@ import android.view.View;
 import org.telegram.messenger.FileLoader;
 import org.telegram.messenger.ImageReceiver;
 import org.telegram.messenger.MessageObject;
+import org.telegram.messenger.R;
+import org.telegram.messenger.LocaleController;
 import org.telegram.tgnet.TLRPC;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.MediaActionDrawable;
@@ -39,6 +41,11 @@ public class PollAttachedMediaMusic extends PollAttachedMedia {
         }
 
         radialProgress.setColorKeys(Theme.key_chat_inLoader, Theme.key_chat_inLoaderSelected, Theme.key_chat_inMediaIcon, Theme.key_chat_inMediaIconSelected);
+    }
+
+    @Override
+    public CharSequence getAccessibilityName() {
+        return LocaleController.getString(R.string.AttachMusic);
     }
 
     @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/attached/PollAttachedMediaSticker.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/attached/PollAttachedMediaSticker.java
@@ -10,6 +10,8 @@ import org.telegram.messenger.ImageLocation;
 import org.telegram.messenger.ImageReceiver;
 import org.telegram.messenger.MediaController;
 import org.telegram.messenger.MessageObject;
+import org.telegram.messenger.LocaleController;
+import org.telegram.messenger.R;
 import org.telegram.tgnet.TLRPC;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.EmojiView;
@@ -25,6 +27,11 @@ public class PollAttachedMediaSticker extends PollAttachedMedia {
         this.parent = parent;
         this.isEmoji = MessageObject.isAnimatedEmoji(sticker);
         setupImageReceiver(imageReceiver);
+    }
+
+    @Override
+    public CharSequence getAccessibilityName() {
+        return LocaleController.getString(isEmoji ? R.string.Emoji : R.string.AttachSticker);
     }
 
     private void setupImageReceiver(ImageReceiver imageReceiver) {


### PR DESCRIPTION
## Summary

Beside the description of a poll, beside its explanation and beside every option there is a button for attaching a picture, a sticker, a place, a piece of music, a link or a file. It is a bare view drawn by hand with no text and no description, so a screen reader stops on it and says only that there is a button, without saying what it does.

Once something is attached the icon is replaced by a thumbnail of it, and a press then goes to changing it rather than to adding. None of that was said either: nothing told you an option already carried a picture, or which one.

Name the button after what a press on it does, and where something is already attached, say what it is. Every kind of attachment names itself, by its kind, or by the file name or the address where that says more. All of the words are ones the app already has.

The button of the field that adds an option to a poll already sent is the same view, so it is named too, along with the emoji button beside it, which had no name either.

## Checking it

With TalkBack on, start a poll and swipe onto the button beside the description, then beside an option.

Before, each said only that there was a button. Now each is named after what pressing it does. Attach a picture to an option and swipe back onto it: it says what is attached and that pressing it now changes it.
