### PR TITLE
Read the chat list the way it is written

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
@@ -5580,6 +5580,44 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
                 sb.append(". ");
             }
         }
+        // what the row shows in place of the last message: somebody typing, a draft left
+        // unfinished, or the topics of a forum. All three are built by the cell and drawn, and all
+        // three were passed over here, because this text is put together again from the message
+        // rather than taken from what is on the screen. So a chat somebody was typing in, a chat
+        // holding a draft, and a forum all read as their last message and nothing else
+        final CharSequence typing = printingStringType >= 0 && typingLayout != null ? typingLayout.getText() : null;
+        if (!TextUtils.isEmpty(typing)) {
+            sb.append(typing);
+            sb.append(". ");
+            event.setContentDescription(sb);
+            setContentDescription(sb);
+            return;
+        }
+        if (draftVoice || draftMessage != null) {
+            final CharSequence draft = messageLayout == null ? null : messageLayout.getText();
+            sb.append(getString(R.string.Draft));
+            if (!TextUtils.isEmpty(draft) && !TextUtils.equals(draft, getString(R.string.Draft))) {
+                sb.append(", ");
+                sb.append(draft);
+            }
+            sb.append(". ");
+            event.setContentDescription(sb);
+            setContentDescription(sb);
+            return;
+        }
+        if (isForumCell() && messageLayout != null && !TextUtils.isEmpty(messageLayout.getText())) {
+            // a forum is drawn on two lines: the topics that have something new in them, and under
+            // them the message that is newest of all
+            sb.append(messageLayout.getText());
+            sb.append(". ");
+            if (buttonLayout != null && !TextUtils.isEmpty(buttonLayout.getText())) {
+                sb.append(buttonLayout.getText());
+                sb.append(". ");
+            }
+            event.setContentDescription(sb);
+            setContentDescription(sb);
+            return;
+        }
         if (encryptedChat == null) {
             StringBuilder messageString = new StringBuilder();
             messageString.append(message.messageText);


### PR DESCRIPTION
## Summary

A row of the chat list does not always show the last message. Where somebody is typing it shows that instead, where a draft was left it shows the draft, and a forum shows the topics that have something new in them with the newest message under them. All of it is built by the cell and drawn on the row.

None of it reached a screen reader. The text it is given is put together again from the message rather than taken from what is on the screen, so a chat somebody is typing in, a chat holding an unfinished draft, and a forum all read as the last message and nothing else. That is not a gap but a wrong answer: what is said is not what is there.

Take them from what is drawn, which is where they already are, both lines of a forum among them.

## Checking it

With TalkBack on, have somebody start typing in a chat and swipe onto its row in the chat list. Leave an unfinished draft in another chat and swipe onto that. Open the list of a forum and swipe over a row with something new in it.

Before, all three read as the last message: not a gap but a wrong answer, since what was said was not what was on the row. Now each is read from what is drawn — typing, the draft, and both lines of a forum row.
