### PR TITLE
Say where your own last message got to in the chat list

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
@@ -5548,6 +5548,10 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
         if (unreadCount > 0) {
             sb.append(LocaleController.formatPluralString("NewMessages", unreadCount));
             sb.append(". ");
+        } else if (markUnread) {
+            // a chat marked unread by hand carries the same badge with nothing written in it
+            sb.append(getString(R.string.AccDescrChatMarkedUnread));
+            sb.append(". ");
         }
         if (mentionCount > 0) {
             sb.append(LocaleController.formatPluralString("AccDescrMentionCount", mentionCount));
@@ -5573,6 +5577,19 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
             sb.append(LocaleController.formatString("AccDescrReceivedDate", R.string.AccDescrReceivedDate, date));
         }
         sb.append(". ");
+        // how far your own last message got is drawn beside the time, as a clock, one tick, two
+        // ticks or a mark in red, and none of it was ever said. A message that failed to send
+        // looked no different from one that arrived
+        if (drawError) {
+            sb.append(getString(R.string.AccDescrMsgSendingError));
+            sb.append(". ");
+        } else if (drawClock) {
+            sb.append(getString(R.string.AccDescrMsgSending));
+            sb.append(". ");
+        } else if (drawCheck2) {
+            sb.append(getString(drawCheck1 ? R.string.AccDescrMsgRead : R.string.AccDescrMsgUnread));
+            sb.append(". ");
+        }
         if (chat != null && !message.isOut() && message.isFromUser() && message.messageOwner.action == null) {
             TLRPC.User fromUser = MessagesController.getInstance(currentAccount).getUser(message.messageOwner.from_id.user_id);
             if (fromUser != null) {

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5145,6 +5145,7 @@
     <string name="AccDescrQuizCorrectAnswer">Correct answer</string>
     <string name="AccDescrQuizIncorrectAnswer">Incorrect answer</string>
     <string name="AccDescrQuizExplanation">Explanation</string>
+    <string name="AccDescrChatMarkedUnread">Marked as unread</string>
     <string name="AccDescrPipMode">Picture-in-Picture mode</string>
     <string name="AccDescrVoipMicOn">Microphone is on</string>
     <string name="AccDescrVoipMicOff">Microphone is off</string>


### PR DESCRIPTION
## Summary

Beside the time on a row of the chat list, a message you sent carries how far it got: a clock while it is on its way, one tick once it has arrived, two once it has been seen, and a mark in red when it failed to send.

A screen reader was told none of it, so a message that never left the phone read exactly like one that had been seen. Say it after the time, which is where it is drawn.

A chat marked unread by hand carries the same badge the unread count does, with nothing written in it. That was passed over too, because the count it is read from is zero.

## Checking it

With TalkBack on, send a message, turn the network off, send another, and swipe over both rows in the chat list.

Before, a message that never left the phone read exactly like one that had been seen. Now the row says how far your last message got, after the time where it is drawn: on its way, arrived, seen, or failed.

Mark a chat unread by hand and swipe onto it: that badge is now said too, which it was not, because the count it is read from is zero.
