### PR TITLE
Stop a row of the chat list reading out the chat it used to hold

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
@@ -2941,6 +2941,7 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
             }
         }
         updateThumbsPosition();
+        updateAccessibilityText();
     }
 
     public void setTitleOverride(String s) {
@@ -5488,6 +5489,29 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
     @Override
     public void onPopulateAccessibilityEvent(AccessibilityEvent event) {
         super.onPopulateAccessibilityEvent(event);
+        final CharSequence text = buildAccessibilityText();
+        event.setContentDescription(text);
+        setContentDescription(text);
+    }
+
+    /**
+     * The text of a row is kept on the row itself as well as put on the event, because a screen
+     * reader handed nothing but an event stops at the first symbol it meets and says no more.
+     *
+     * What is kept has to be kept true. The rows of the list are used again for other chats as it
+     * is scrolled and as folders are switched, and this was only ever called while an event was
+     * being filled in, so a row used again for another chat went on carrying the text of the one
+     * before it. A reader that looks at the row before the event reaches it reads that older text
+     * first, breaks off partway when the right one arrives, and reads the right one after.
+     */
+    private void updateAccessibilityText() {
+        if (!AndroidUtilities.isAccessibilityScreenReaderEnabled()) {
+            return;
+        }
+        setContentDescription(buildAccessibilityText());
+    }
+
+    private CharSequence buildAccessibilityText() {
         StringBuilder sb = new StringBuilder();
         if (titleOverride != null) {
             sb.append(titleOverride);
@@ -5558,9 +5582,7 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
             sb.append(". ");
         }
         if (message == null || currentDialogFolderId != 0) {
-            event.setContentDescription(sb);
-            setContentDescription(sb);
-            return;
+            return sb;
         }
         int lastDate = lastMessageDate;
         if (lastMessageDate == 0) {
@@ -5606,8 +5628,7 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
                 sb.append(messageString);
             }
         }
-        event.setContentDescription(sb);
-        setContentDescription(sb);
+        return sb;
     }
 
     private MessageObject getCaptionMessage() {


### PR DESCRIPTION
## Summary

The text of a row is kept on the row itself, and has been since the app was made to stop handing a screen reader a bare event: given only that, some readers break off at the first symbol they meet and say no more of the line.

What is kept has to be kept true, and it was not. It was written only while an event was being filled in, which happens when a row is spoken to somebody, not when a row is given a new chat to hold. The rows of the list are used again for other chats as it is scrolled and as folders are switched, so a row went on carrying the text of the chat it held before, sometimes from an entirely different folder.

A reader that looks at the row before its event arrives reads that older text first, breaks off partway when the right one comes, and reads the right one after. Which of the two is heard first is a matter of timing, which is why it is heard by some readers and not others.

Write it when the row is built, which is when it becomes true, and go on writing it while an event is filled in as before. Building it costs something, so it is only built while a screen reader is running.

## Checking it

With TalkBack on, scroll the chat list up and down quickly, or switch between folders, then swipe over the rows.

Before, a row went on reading out the chat it used to hold, sometimes one from another folder entirely. Now the text is written when the row is given a new chat, so what is read is the chat that is there.
