### PR TITLE
Say which camera a story is being taken with

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/RecordControl.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/RecordControl.java
@@ -34,6 +34,8 @@ import androidx.customview.widget.ExploreByTouchHelper;
 
 import com.google.zxing.common.detector.MathUtils;
 
+import android.text.TextUtils;
+
 import org.telegram.messenger.AndroidUtilities;
 import org.telegram.messenger.ImageLocation;
 import org.telegram.messenger.ImageReceiver;
@@ -866,6 +868,30 @@ public class RecordControl extends View implements FlashViews.Invertable {
         return super.dispatchHoverEvent(event);
     }
 
+    private boolean frontface;
+    private Boolean a11yPrevFrontface;
+
+    /**
+     * Which camera is looking. Turning it around gives a sighted eye the whole picture flipping,
+     * and gives a screen reader nothing at all: the button is named the same before and after, so
+     * there is no telling which camera you ended up on but by guessing.
+     */
+    public void setFrontface(boolean value) {
+        if (frontface == value && a11yPrevFrontface != null) {
+            return;
+        }
+        frontface = value;
+        final boolean first = a11yPrevFrontface == null;
+        notifyAccessibilityIfChanged();
+        if (!first && AndroidUtilities.isAccessibilityScreenReaderEnabled()) {
+            announceForAccessibility(cameraAccessibilityName());
+        }
+    }
+
+    private CharSequence cameraAccessibilityName() {
+        return LocaleController.getString(frontface ? R.string.AccDescrCameraFront : R.string.AccDescrCameraBack);
+    }
+
     private void notifyAccessibilityIfChanged() {
         if (accessibilityHelper == null) return;
         final boolean check = hasCheck();
@@ -874,7 +900,9 @@ public class RecordControl extends View implements FlashViews.Invertable {
             || a11yPrevDual != dual
             || a11yPrevStartIsVideo != startModeIsVideo
             || a11yPrevLoading != recordingLoading
-            || a11yPrevShowLock != showLock) {
+            || a11yPrevShowLock != showLock
+            || a11yPrevFrontface == null || a11yPrevFrontface != frontface) {
+            a11yPrevFrontface = frontface;
             a11yPrevRecording = recording;
             a11yPrevCheck = check;
             a11yPrevDual = dual;
@@ -969,7 +997,7 @@ public class RecordControl extends View implements FlashViews.Invertable {
                     final int r = dp(22);
                     tmpRect.set((int) (rightCx - r), (int) (cy - r), (int) (rightCx + r), (int) (cy + r));
                     info.setBoundsInParent(tmpRect);
-                    info.setContentDescription(LocaleController.getString(R.string.AccDescrSwitchCamera));
+                    info.setContentDescription(TextUtils.concat(LocaleController.getString(R.string.AccDescrSwitchCamera), ", ", cameraAccessibilityName()));
                     final boolean enabled = !recordingLoading && !hasCheck();
                     info.setEnabled(enabled);
                     if (enabled) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/StoryRecorder.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/StoryRecorder.java
@@ -2944,6 +2944,7 @@ public class StoryRecorder implements NotificationCenter.NotificationCenterDeleg
         recordControl = new RecordControl(context);
         recordControl.setDelegate(recordControlDelegate);
         recordControl.startAsVideo(mode == MODE_VIDEO);
+        recordControl.setFrontface(getCameraFace());
         controlContainer.addView(recordControl, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 100, Gravity.BOTTOM | Gravity.FILL_HORIZONTAL));
         flashViews.add(recordControl);
         recordControl.setCollageProgress(collageLayoutView.hasLayout() ? collageLayoutView.getFilledProgress() : 0.0f, true);
@@ -7391,6 +7392,10 @@ public class StoryRecorder implements NotificationCenter.NotificationCenterDeleg
 
     private void saveCameraFace(boolean frontface) {
         MessagesController.getGlobalMainSettings().edit().putBoolean("stories_camera", frontface).apply();
+        // every way of turning the camera around comes through here
+        if (recordControl != null) {
+            recordControl.setFrontface(frontface);
+        }
     }
 
     private boolean getCameraFace() {

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5145,6 +5145,8 @@
     <string name="AccDescrQuizCorrectAnswer">Correct answer</string>
     <string name="AccDescrQuizIncorrectAnswer">Incorrect answer</string>
     <string name="AccDescrQuizExplanation">Explanation</string>
+    <string name="AccDescrCameraFront">Front camera</string>
+    <string name="AccDescrCameraBack">Back camera</string>
     <string name="AccDescrPipMode">Picture-in-Picture mode</string>
     <string name="AccDescrVoipMicOn">Microphone is on</string>
     <string name="AccDescrVoipMicOff">Microphone is off</string>


### PR DESCRIPTION
## Summary

Turning the camera around gives a sighted eye the whole picture flipping, which is answer enough. A screen reader was given nothing: the button is named the same before and after, so there is no telling which camera you ended up on except by guessing, and nothing at all is said when it turns.

Put the camera the button is looking through into its name, so it can be had by stopping on the button without pressing it, and say the new one when it changes, which is the moment the picture flips for everybody else.

Every way of turning the camera around — the button, the double tap, the one in the bar — passes through the same place where the choice is remembered, so that is where it is picked up.

## Checking it

With TalkBack on, open the story camera and swipe onto the button that turns the camera around.

Before, it was named the same whichever camera was in use, and nothing was said when it turned. Now the name says which camera it is looking through, and the new one is said as it turns — the moment the picture flips for everybody else.

The double tap and the button in the bar do the same.
