### PR TITLE
Read a giveaway out, and let the chats it names be opened

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -6008,6 +6008,61 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         }
     }
 
+    private CharSequence giveawayAccessibilityText() {
+        if (currentMessageObject == null) {
+            return null;
+        }
+        if (currentMessageObject.isGiveaway()) {
+            return giveawayMessageCell.getAccessibilityText();
+        }
+        if (currentMessageObject.isGiveawayResults()) {
+            return giveawayResultsMessageCell.getAccessibilityText();
+        }
+        return null;
+    }
+
+    // the chats a giveaway runs in, and the winners it ended with, are drawn as a row of buttons
+    // that open them. They are drawn by hand and are no views of their own, so touch exploration
+    // had nothing to land on and nothing to press
+    private int giveawayAccessibilityButtonCount() {
+        if (currentMessageObject == null) {
+            return 0;
+        }
+        if (currentMessageObject.isGiveaway()) {
+            return giveawayMessageCell.getChatCount();
+        }
+        if (currentMessageObject.isGiveawayResults()) {
+            return giveawayResultsMessageCell.getUserCount();
+        }
+        return 0;
+    }
+
+    private CharSequence giveawayAccessibilityButtonTitle(int index) {
+        if (currentMessageObject == null) {
+            return null;
+        }
+        if (currentMessageObject.isGiveaway()) {
+            return giveawayMessageCell.getChatTitle(index);
+        }
+        if (currentMessageObject.isGiveawayResults()) {
+            return giveawayResultsMessageCell.getUserTitle(index);
+        }
+        return null;
+    }
+
+    private Rect giveawayAccessibilityButtonBounds(int index) {
+        if (currentMessageObject == null) {
+            return null;
+        }
+        if (currentMessageObject.isGiveaway()) {
+            return giveawayMessageCell.getChatBounds(index);
+        }
+        if (currentMessageObject.isGiveawayResults()) {
+            return giveawayResultsMessageCell.getUserBounds(index);
+        }
+        return null;
+    }
+
     private void didClickedImage() {
         if (currentMessageObject.hasMediaSpoilers() && !currentMessageObject.needDrawBluredPreview() && !currentMessageObject.isMediaSpoilersRevealed) {
             if (delegate != null && currentMessageObject.isSensitive()) {
@@ -27025,6 +27080,10 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         public static final int CONTACT_VIEW = 491;
         public static final int CONTACT_ADD = 490;
         public static final int CONTACT_MESSAGE = 489;
+        // well clear of the ids that stand for one button each, which run down from 499: a range
+        // that reached up into them would answer for every one of them and hide the lot
+        public static final int GIVEAWAY_BUTTONS_START = 300;
+        public static final int GIVEAWAY_BUTTONS_END = 400;
         private Path linkPath = new Path();
         private RectF rectF = new RectF();
         private Rect rect = new Rect();
@@ -27157,6 +27216,15 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                             }
                         }
                         sb.append(messageText);
+                        // a giveaway is a card drawn by hand: the prize, who can take part, the
+                        // chats it runs in, the countries it is open to and the day the winners
+                        // are picked. None of it is text of the message, so none of it was said
+                        // and the message was as good as empty
+                        final CharSequence giveaway = giveawayAccessibilityText();
+                        if (!TextUtils.isEmpty(giveaway)) {
+                            sb.append(", ");
+                            sb.append(giveaway);
+                        }
                     }
                     if (documentAttach != null && (documentAttachType == DOCUMENT_ATTACH_TYPE_DOCUMENT || documentAttachType == DOCUMENT_ATTACH_TYPE_GIF || documentAttachType == DOCUMENT_ATTACH_TYPE_VIDEO)) {
                         if (buttonState == 1 && loadingProgressLayout != null) {
@@ -27424,6 +27492,11 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     info.addChild(ChatMessageCell.this, POLL_BUTTONS_START + i);
                     i++;
                 }
+                for (int g = 0; g < giveawayAccessibilityButtonCount(); g++) {
+                    if (!TextUtils.isEmpty(giveawayAccessibilityButtonTitle(g))) {
+                        info.addChild(ChatMessageCell.this, GIVEAWAY_BUTTONS_START + g);
+                    }
+                }
                 if (drawInstantView && !instantButtonRect.isEmpty()) {
                     info.addChild(ChatMessageCell.this, INSTANT_VIEW);
                 }
@@ -27677,6 +27750,27 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     rect.offset(pos[0], pos[1]);
                     info.setBoundsInScreen(rect);
                     info.setClickable(true);
+                } else if (virtualViewId >= GIVEAWAY_BUTTONS_START && virtualViewId < GIVEAWAY_BUTTONS_END) {
+                    final int index = virtualViewId - GIVEAWAY_BUTTONS_START;
+                    final CharSequence title = giveawayAccessibilityButtonTitle(index);
+                    final Rect bounds = giveawayAccessibilityButtonBounds(index);
+                    if (TextUtils.isEmpty(title) || bounds == null || bounds.isEmpty()) {
+                        return null;
+                    }
+                    info.setClassName("android.widget.Button");
+                    info.setEnabled(true);
+                    info.setText(title);
+                    info.addAction(AccessibilityNodeInfo.ACTION_CLICK);
+                    rect.set(bounds);
+                    info.setBoundsInParent(rect);
+                    // the bounds go into the map the cell hit tests against, so a finger on the
+                    // screen finds them as well as a swipe
+                    if (accessibilityVirtualViewBounds.get(virtualViewId) == null || !accessibilityVirtualViewBounds.get(virtualViewId).equals(rect)) {
+                        accessibilityVirtualViewBounds.put(virtualViewId, new Rect(rect));
+                    }
+                    rect.offset(pos[0], pos[1]);
+                    info.setBoundsInScreen(rect);
+                    info.setClickable(true);
                 } else if (virtualViewId == INSTANT_VIEW) {
                     info.setClassName("android.widget.Button");
                     info.setEnabled(true);
@@ -27907,6 +28001,11 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         sendAccessibilityEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_CLICKED);
                     } else if (virtualViewId == POLL_HINT) {
                         didPressVoteHint();
+                    } else if (virtualViewId >= GIVEAWAY_BUTTONS_START && virtualViewId < GIVEAWAY_BUTTONS_END) {
+                        if (delegate != null) {
+                            delegate.didPressGiveawayChatButton(ChatMessageCell.this, virtualViewId - GIVEAWAY_BUTTONS_START);
+                        }
+                        sendAccessibilityEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_CLICKED);
                     } else if (virtualViewId == INSTANT_VIEW) {
                         if (delegate != null) {
                             delegate.didPressInstantButton(ChatMessageCell.this, drawInstantViewType);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/boosts/cells/msg/GiveawayMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/boosts/cells/msg/GiveawayMessageCell.java
@@ -179,6 +179,53 @@ public class GiveawayMessageCell {
         textDividerPaint.setTextAlign(Paint.Align.CENTER);
     }
 
+
+    /** Everything the card holds, in the order it is drawn. */
+    public CharSequence getAccessibilityText() {
+        final StringBuilder sb = new StringBuilder();
+        appendLayout(sb, titleLayout);
+        appendLayout(sb, additionPrizeLayout);
+        appendLayout(sb, topLayout);
+        for (int a = 0; a < chatTitles.length; a++) {
+            if (!TextUtils.isEmpty(chatTitles[a])) {
+                append(sb, chatTitles[a]);
+            }
+        }
+        appendLayout(sb, countriesLayout);
+        appendLayout(sb, bottomLayout);
+        return sb;
+    }
+
+    private static void appendLayout(StringBuilder sb, StaticLayout layout) {
+        if (layout != null) {
+            append(sb, layout.getText());
+        }
+    }
+
+    private static void append(StringBuilder sb, CharSequence text) {
+        if (TextUtils.isEmpty(text)) {
+            return;
+        }
+        if (sb.length() > 0) {
+            sb.append(", ");
+        }
+        // the card is laid out in lines, and a line break is nothing to say
+        sb.append(AndroidUtilities.replaceNewLines(text));
+    }
+
+    /** How many of the chats it names can be opened, and what each of them is called. */
+    public int getChatCount() {
+        return chats == null ? 0 : chats.length;
+    }
+
+    public CharSequence getChatTitle(int index) {
+        return chatTitles != null && index >= 0 && index < chatTitles.length ? chatTitles[index] : null;
+    }
+
+    public Rect getChatBounds(int index) {
+        return clickRect != null && index >= 0 && index < clickRect.length ? clickRect[index] : null;
+    }
+
     public boolean checkMotionEvent(MotionEvent event) {
         if (messageObject == null || !messageObject.isGiveaway()) {
             return false;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/boosts/cells/msg/GiveawayResultsMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/boosts/cells/msg/GiveawayResultsMessageCell.java
@@ -166,6 +166,52 @@ public class GiveawayResultsMessageCell {
         textDividerPaint.setTextAlign(Paint.Align.CENTER);
     }
 
+
+    /** Everything the card holds, in the order it is drawn. */
+    public CharSequence getAccessibilityText() {
+        final StringBuilder sb = new StringBuilder();
+        appendLayout(sb, titleLayout);
+        appendLayout(sb, topLayout);
+        for (int a = 0; a < userTitles.length; a++) {
+            if (!TextUtils.isEmpty(userTitles[a])) {
+                append(sb, userTitles[a]);
+            }
+        }
+        appendLayout(sb, countriesLayout);
+        appendLayout(sb, bottomLayout);
+        return sb;
+    }
+
+    private static void appendLayout(StringBuilder sb, StaticLayout layout) {
+        if (layout != null) {
+            append(sb, layout.getText());
+        }
+    }
+
+    private static void append(StringBuilder sb, CharSequence text) {
+        if (TextUtils.isEmpty(text)) {
+            return;
+        }
+        if (sb.length() > 0) {
+            sb.append(", ");
+        }
+        // the card is laid out in lines, and a line break is nothing to say
+        sb.append(AndroidUtilities.replaceNewLines(text));
+    }
+
+    /** How many of the winners it names can be opened, and what each of them is called. */
+    public int getUserCount() {
+        return users == null ? 0 : users.length;
+    }
+
+    public CharSequence getUserTitle(int index) {
+        return userTitles != null && index >= 0 && index < userTitles.length ? userTitles[index] : null;
+    }
+
+    public Rect getUserBounds(int index) {
+        return clickRect != null && index >= 0 && index < clickRect.length ? clickRect[index] : null;
+    }
+
     public boolean checkMotionEvent(MotionEvent event) {
         if (messageObject == null || !messageObject.isGiveawayResults()) {
             return false;


### PR DESCRIPTION
## Summary

A giveaway is a card drawn by hand. On it are the prize, the extra prize where there is one, how many will win and for how long, who may take part, the chats it runs in, the countries it is open to and the day the winners are picked. A finished one carries the winners themselves.

None of that is text of the message, so none of it was said, and the message was as good as empty: a screen reader was told a giveaway had been posted and nothing whatever about it.

Have each card give back everything on it in the order it is drawn, and say it after the message.

The chats a giveaway runs in, and the winners it ended with, are drawn as a row of buttons that open them. They are no views of their own, so touch exploration had nothing to land on and nothing to press. Give each of them a place in the tree, named by what is written on it, with the bounds it is drawn at, so a finger finds it as well as a swipe.

Their ids are kept well clear of the ones that stand for a single button each, which run down from the top of the range: a run that reached up into those would answer for every one of them and hide the lot.

## Checking it

With TalkBack on, swipe onto a giveaway message in a channel, and onto a finished one.

Before, all that was said was that a giveaway had been posted. Now the whole card is read in the order it is drawn: the prize, how many will win, who may take part, the chats it runs in, the countries, and the day the winners are picked. A finished one reads its winners, and the chats named on it can be opened.
