### PR TITLE
Say the effect a message was sent with

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -27158,6 +27158,13 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         }
                         sb.append(messageText);
                     }
+                    // an effect is chosen when a message is sent and drawn on it ever after: it is
+                    // as much a part of what was sent as the words are, and it was never said
+                    final TLRPC.TL_availableEffect effect = getEffect();
+                    if (effect != null && !TextUtils.isEmpty(effect.emoticon)) {
+                        sb.append(", ");
+                        sb.append(formatString(R.string.AccDescrMessageEffect, effect.emoticon));
+                    }
                     if (documentAttach != null && (documentAttachType == DOCUMENT_ATTACH_TYPE_DOCUMENT || documentAttachType == DOCUMENT_ATTACH_TYPE_GIF || documentAttachType == DOCUMENT_ATTACH_TYPE_VIDEO)) {
                         if (buttonState == 1 && loadingProgressLayout != null) {
                             sb.append("\n");

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5145,6 +5145,7 @@
     <string name="AccDescrQuizCorrectAnswer">Correct answer</string>
     <string name="AccDescrQuizIncorrectAnswer">Incorrect answer</string>
     <string name="AccDescrQuizExplanation">Explanation</string>
+    <string name="AccDescrMessageEffect">sent with %s</string>
     <string name="AccDescrPipMode">Picture-in-Picture mode</string>
     <string name="AccDescrVoipMicOn">Microphone is on</string>
     <string name="AccDescrVoipMicOff">Microphone is off</string>


### PR DESCRIPTION
## Summary

A message can be sent with an effect, and the emoji it was chosen from is drawn on the message beside the time from then on.

It never reached a screen reader. The effect is not part of the text of the message, so nothing said a message had been sent with one or which one it was.

Say it with the message, where it belongs: it is as much a part of what was sent as the words are. The effect itself is something to watch, so what there is to give is the knowing of it, not the playing of it again.

## Checking it

With TalkBack on, send a message with an effect, then swipe onto it.

Before, nothing said the message had been sent with one, nor which. Now the effect is said as part of the message, beside the time, as it is drawn.
