### PR TITLE
Give the button under a link preview a place in the tree

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -1252,6 +1252,12 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     private final MaskDrawable[] selectorMaskDrawable = new MaskDrawable[2];
     private int[] selectorDrawableMaskType = new int[2];
     private RectF instantButtonRect = new RectF();
+    // where the button under a link preview is, for the tree to point at. The rect the touch code
+    // hit tests against is only filled in for the older style that draws the button on its own
+    // below the preview; the style that draws it inside the preview leaves it empty, and touches
+    // on it are taken by the preview as a whole. Keeping a rect of our own means the button can be
+    // named and reached without giving the touch code a region it never had.
+    private final RectF instantButtonAccessibilityRect = new RectF();
     private LoadingDrawable instantButtonLoading;
     private final int[] pressedState = new int[]{android.R.attr.state_enabled, android.R.attr.state_pressed};
     private float animatingLoadingProgressProgress;
@@ -16088,6 +16094,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     SpoilerEffect.layoutDrawMaybe(instantViewLayout, canvas);
                     canvas.restore();
                 }
+                // the whole row under the divider is the button, from the line above it down to
+                // the bottom of the preview
+                instantButtonAccessibilityRect.set(linkX, startY + linkPreviewHeight + dp(2), linkX + width, startY + linkPreviewHeight + dp(42));
             } else {
                 int instantY = startY + linkPreviewHeight + dp(currentMessageObject.isUnsupported() ? -5 : 10);
                 if (instantButtonLoading != null && !loading && !instantButtonLoading.isDisappeared() && !instantButtonLoading.isDisappearing()) {
@@ -16102,6 +16111,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     instantButtonLoading.resetDisappear();
                 }
                 instantButtonRect.set(linkX, instantY, linkX + instantWidth, instantY + dp(36));
+                instantButtonAccessibilityRect.set(instantButtonRect);
                 float scale = instantButtonBounce.getScale(.02f);
                 boolean scaleRestore = scale != 1;
                 if (scaleRestore) {
@@ -25979,6 +25989,11 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
 
                 instantButtonRect.set(textX, instantY, textX + instantWidth, instantY + dp(44));
+                // a poll draws its button here rather than under a link preview, and the place
+                // kept for the tree was only ever filled over there: the button that opens who
+                // voted, or sends the answers of a poll that takes more than one, stood in the
+                // message with nothing in the tree to reach it by
+                instantButtonAccessibilityRect.set(instantButtonRect);
                 if (selectorDrawable[0] != null && selectorDrawableMaskType[0] == 2) {
                     selectorDrawable[0].setBounds(textX - dp(pollInstantViewTouchesBottom ? 6 : 0), instantY, textX + instantWidth, instantY + dp(44));
                     selectorDrawable[0].draw(canvas);
@@ -27424,7 +27439,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     info.addChild(ChatMessageCell.this, POLL_BUTTONS_START + i);
                     i++;
                 }
-                if (drawInstantView && !instantButtonRect.isEmpty()) {
+                if (drawInstantView && !instantButtonAccessibilityRect.isEmpty()) {
                     info.addChild(ChatMessageCell.this, INSTANT_VIEW);
                 }
                 if (drawContact && contactRect != null && !contactRect.isEmpty()) {
@@ -27684,7 +27699,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         info.setText(instantViewLayout.getText());
                     }
                     info.addAction(AccessibilityNodeInfo.ACTION_CLICK);
-                    instantButtonRect.round(rect);
+                    instantButtonAccessibilityRect.round(rect);
                     info.setBoundsInParent(rect);
                     if (accessibilityVirtualViewBounds.get(virtualViewId) == null || !accessibilityVirtualViewBounds.get(virtualViewId).equals(rect)) {
                         accessibilityVirtualViewBounds.put(virtualViewId, new Rect(rect));


### PR DESCRIPTION
## Summary

A link preview carries a button under it: instant view for a page that has one, and open channel, open bot, send message and the rest for what else a link can lead to. It is named on the screen and a press on it goes straight there.

It was in the tree only for the older style that draws the button on its own below the preview. The style used for almost everything now draws it inside the preview, under a divider, and takes touches on it through the preview as a whole, so the rect the button is looked up by is never filled in. The tree asks for that rect before it offers the button, so the button was never offered: nothing said there was one, or what it said, or where it went.

Keep a rect of the button for the tree to point at, filled in by both styles. The rect the touch code hit tests against is left alone, so nothing gains a touch region it did not have.

## Checking it

With TalkBack on, send a link to a page with an instant view, and swipe through the message.

Before, the button under the preview was in no part of the tree for the style used for almost everything now, so it could not be reached or pressed. Now it has a place, named by the words on it, and a press goes where a press on the button goes.

The same holds for open channel, open bot and send message under other kinds of link.
