### PR TITLE
Let the rest of a long message be asked for

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/RichMessageLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/RichMessageLayout.java
@@ -1596,6 +1596,18 @@ public class RichMessageLayout {
         }
     }
 
+    /**
+     * Whether the button that opens the rest of a message cut short is on the screen, and where it
+     * is. Its place is worked out while it is drawn, the same way the blocks above it are.
+     */
+    public boolean hasShowMoreButton() {
+        return isPart && !showMoreRect.isEmpty();
+    }
+
+    public void getShowMoreBounds(Rect out) {
+        showMoreRect.round(out);
+    }
+
     private void drawShowMoreButton(Canvas canvas, int contentBottom) {
         final int color = getThemedColor(isOut() ? Theme.key_chat_outPreviewInstantText : Theme.key_chat_inPreviewInstantText);
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -6008,6 +6008,11 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         }
     }
 
+    private boolean hasShowMoreButton() {
+        return currentMessageObject != null && currentMessageObject.richLayout != null
+            && currentMessageObject.richLayout.hasShowMoreButton();
+    }
+
     private void didClickedImage() {
         if (currentMessageObject.hasMediaSpoilers() && !currentMessageObject.needDrawBluredPreview() && !currentMessageObject.isMediaSpoilersRevealed) {
             if (delegate != null && currentMessageObject.isSensitive()) {
@@ -27025,6 +27030,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         public static final int CONTACT_VIEW = 491;
         public static final int CONTACT_ADD = 490;
         public static final int CONTACT_MESSAGE = 489;
+        public static final int SHOW_MORE = 487;
         private Path linkPath = new Path();
         private RectF rectF = new RectF();
         private Rect rect = new Rect();
@@ -27424,6 +27430,12 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     info.addChild(ChatMessageCell.this, POLL_BUTTONS_START + i);
                     i++;
                 }
+                // the button that opens the rest of a message cut short. It is drawn by hand
+                // under the text and is no view of its own, so nothing said the message went on,
+                // and there was no way to ask for the rest of it
+                if (hasShowMoreButton()) {
+                    info.addChild(ChatMessageCell.this, SHOW_MORE);
+                }
                 if (drawInstantView && !instantButtonRect.isEmpty()) {
                     info.addChild(ChatMessageCell.this, INSTANT_VIEW);
                 }
@@ -27677,6 +27689,25 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     rect.offset(pos[0], pos[1]);
                     info.setBoundsInScreen(rect);
                     info.setClickable(true);
+                } else if (virtualViewId == SHOW_MORE) {
+                    if (!hasShowMoreButton()) {
+                        return null;
+                    }
+                    info.setClassName("android.widget.Button");
+                    info.setEnabled(true);
+                    info.setText(getString(R.string.ShowMore));
+                    info.addAction(AccessibilityNodeInfo.ACTION_CLICK);
+                    currentMessageObject.richLayout.getShowMoreBounds(rect);
+                    rect.offset(textX, textY);
+                    info.setBoundsInParent(rect);
+                    // the bounds go into the map the cell hit tests against, so a finger on the
+                    // screen finds it as well as a swipe
+                    if (accessibilityVirtualViewBounds.get(virtualViewId) == null || !accessibilityVirtualViewBounds.get(virtualViewId).equals(rect)) {
+                        accessibilityVirtualViewBounds.put(virtualViewId, new Rect(rect));
+                    }
+                    rect.offset(pos[0], pos[1]);
+                    info.setBoundsInScreen(rect);
+                    info.setClickable(true);
                 } else if (virtualViewId == INSTANT_VIEW) {
                     info.setClassName("android.widget.Button");
                     info.setEnabled(true);
@@ -27907,6 +27938,11 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         sendAccessibilityEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_CLICKED);
                     } else if (virtualViewId == POLL_HINT) {
                         didPressVoteHint();
+                    } else if (virtualViewId == SHOW_MORE) {
+                        if (delegate != null && hasShowMoreButton()) {
+                            delegate.didPressShowMore(ChatMessageCell.this);
+                        }
+                        sendAccessibilityEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_CLICKED);
                     } else if (virtualViewId == INSTANT_VIEW) {
                         if (delegate != null) {
                             delegate.didPressInstantButton(ChatMessageCell.this, drawInstantViewType);


### PR DESCRIPTION
## Summary

A message too long to show at once is cut short and given a button under it for opening the rest. The button is drawn by hand and is no view of its own, so nothing said the message went on past what was read, and there was no way to ask for the rest of it: the end of a long message simply was the end of it.

Give the button a place in the tree, named by the words on it, and have a press on it do what a press on the button does. Its bounds go into the map the cell hit tests against, so a finger moving over the screen finds it as well as a swipe.

Where the button is drawn is worked out while it is drawn, which is where the blocks above it get theirs from too.

## Checking it

With TalkBack on, find a message long enough to be cut short and swipe through it.

Before, nothing said the message went on past what was read, and the rest could not be asked for. Now the button is in the tree, named by the words on it, and pressing it opens the rest.
