### PR TITLE
Let messages be chosen, and say which ones are

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -785,6 +785,15 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             return false;
         }
 
+        // whether this message is among the ones chosen, and choosing or letting go of it. Both
+        // are the chat's to answer: the cell draws a tick but is never told what it stands for
+        default boolean isMessageSelected(MessageObject message) {
+            return false;
+        }
+
+        default void didPressSelect(ChatMessageCell cell) {
+        }
+
         default void videoTimerReached() {
         }
 
@@ -6006,6 +6015,83 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         if (delegate != null) {
             delegate.didPressPollMedia(cell, imageReceiver, answer, media, x, y, unshuffledIndex);
         }
+    }
+
+    /**
+     * What a press does to the media a message carries, named for the state that media is in:
+     * fetch it, stop fetching it, fetch it again where fetching was stopped, play it, pause it,
+     * or open it. Null where the message carries nothing a press would do anything to.
+     */
+    private CharSequence mediaAccessibilityActionLabel() {
+        if (currentMessageObject == null) {
+            return null;
+        }
+        switch (getIconForCurrentState()) {
+            case MediaActionDrawable.ICON_PLAY:
+                return getString(R.string.AccActionPlay);
+            case MediaActionDrawable.ICON_PAUSE:
+                return getString(R.string.AccActionPause);
+            case MediaActionDrawable.ICON_FILE:
+                return getString(R.string.AccActionOpenFile);
+            case MediaActionDrawable.ICON_DOWNLOAD:
+                return getString(R.string.AccActionDownload);
+            case MediaActionDrawable.ICON_CANCEL:
+                return getString(R.string.AccActionCancelDownload);
+        }
+        if (currentMessageObject.type == MessageObject.TYPE_PHONE_CALL) {
+            return getString(R.string.CallAgain);
+        }
+        // a picture or a video already here opens rather than plays, and by then the button
+        // drawn over it is gone, so there is no icon left to go by
+        return hasMediaToOpen() ? getString(R.string.Open) : null;
+    }
+
+    private boolean hasMediaToOpen() {
+        final MessageObject message = currentMessageObject;
+        if (message == null) {
+            return false;
+        }
+        return message.type == MessageObject.TYPE_PHOTO
+            || message.type == MessageObject.TYPE_VIDEO
+            || message.type == MessageObject.TYPE_GIF
+            || message.type == MessageObject.TYPE_ROUND_VIDEO
+            || message.type == MessageObject.TYPE_EXTENDED_MEDIA_PREVIEW;
+    }
+
+    // the very path a press takes, so that asking for it by name reaches the same place
+    private void performMediaAccessibilityClick() {
+        if (currentMessageObject == null) {
+            return;
+        }
+        final int icon = getIconForCurrentState();
+        if (icon != MediaActionDrawable.ICON_NONE && icon != MediaActionDrawable.ICON_FILE) {
+            didPressButton(true, false);
+        } else if (currentMessageObject.type == MessageObject.TYPE_PHONE_CALL) {
+            if (delegate != null) {
+                delegate.didPressOther(this, otherX, otherY);
+            }
+        } else {
+            didClickedImage();
+        }
+    }
+
+    /**
+     * Choosing a message, or letting go of one. A tick is drawn beside every message that can be
+     * chosen while the chat is choosing them, and that is what says the chat is in that state and
+     * that this message is one of the ones it will take.
+     */
+    private boolean performSelectionAccessibilityAction(int action) {
+        if (delegate == null || currentMessageObject == null) {
+            return false;
+        }
+        // while messages are being chosen, a tap chooses, the way a tap on the screen does. Out
+        // of that, only a press held down starts choosing, again as it does by hand
+        if (!checkBoxVisible && action != AccessibilityNodeInfo.ACTION_LONG_CLICK) {
+            return false;
+        }
+        delegate.didPressSelect(this);
+        sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_CLICKED);
+        return true;
     }
 
     private void didClickedImage() {
@@ -26575,18 +26661,18 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
 
     @Override
     public boolean performAccessibilityAction(int action, Bundle arguments) {
+        if ((action == AccessibilityNodeInfo.ACTION_CLICK || action == AccessibilityNodeInfo.ACTION_LONG_CLICK)
+                && performSelectionAccessibilityAction(action)) {
+            return true;
+        }
         if (delegate != null && delegate.onAccessibilityAction(action, arguments)) {
             return false;
         }
         if (action == AccessibilityNodeInfo.ACTION_CLICK) {
-            int icon = getIconForCurrentState();
-            if (icon != MediaActionDrawable.ICON_NONE && icon != MediaActionDrawable.ICON_FILE) {
-                didPressButton(true, false);
-            } else if (currentMessageObject.type == MessageObject.TYPE_PHONE_CALL) {
-                delegate.didPressOther(this, otherX, otherY);
-            } else {
-                didClickedImage();
-            }
+            performMediaAccessibilityClick();
+            return true;
+        } else if (action == R.id.acc_action_media) {
+            performMediaAccessibilityClick();
             return true;
         } else if (action == R.id.acc_action_small_button) {
             didPressMiniButton(true);
@@ -27338,31 +27424,27 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     info.setCollectionItemInfo(AccessibilityNodeInfo.CollectionItemInfo.obtain(itemInfo.getRowIndex(), 1, 0, 1, false));
                 }
                 info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_msg_options, getString("AccActionMessageOptions", R.string.AccActionMessageOptions)));
-                int icon = getIconForCurrentState();
-                CharSequence actionLabel = null;
-                switch (icon) {
-                    case MediaActionDrawable.ICON_PLAY:
-                        actionLabel = getString("AccActionPlay", R.string.AccActionPlay);
-                        break;
-                    case MediaActionDrawable.ICON_PAUSE:
-                        actionLabel = getString("AccActionPause", R.string.AccActionPause);
-                        break;
-                    case MediaActionDrawable.ICON_FILE:
-                        actionLabel = getString("AccActionOpenFile", R.string.AccActionOpenFile);
-                        break;
-                    case MediaActionDrawable.ICON_DOWNLOAD:
-                        actionLabel = getString("AccActionDownload", R.string.AccActionDownload);
-                        break;
-                    case MediaActionDrawable.ICON_CANCEL:
-                        actionLabel = getString("AccActionCancelDownload", R.string.AccActionCancelDownload);
-                        break;
-                    default:
-                        if (currentMessageObject.type == MessageObject.TYPE_PHONE_CALL) {
-                            actionLabel = getString("CallAgain", R.string.CallAgain);
-                        }
+                final CharSequence mediaActionLabel = mediaAccessibilityActionLabel();
+                if (checkBoxVisible) {
+                    // a tick is drawn beside this message, so the chat is choosing messages and
+                    // this is one it can take. Whether it has been taken was drawn and never said,
+                    // so going back over them told nothing of which had been chosen
+                    final boolean selected = delegate != null && delegate.isMessageSelected(currentMessageObject);
+                    info.setCheckable(true);
+                    info.setChecked(selected);
+                    final CharSequence selectLabel = getString(selected ? R.string.Deselect : R.string.Select);
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(AccessibilityNodeInfo.ACTION_CLICK, selectLabel));
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(AccessibilityNodeInfo.ACTION_LONG_CLICK, selectLabel));
+                    // what a press would have done to the media is not lost while messages are
+                    // being chosen: it can be asked for by name, and only where a message carries
+                    // something to play, open or fetch
+                    if (mediaActionLabel != null) {
+                        info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_media, mediaActionLabel));
+                    }
+                } else {
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(AccessibilityNodeInfo.ACTION_CLICK, mediaActionLabel));
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(AccessibilityNodeInfo.ACTION_LONG_CLICK, getString("AccActionEnterSelectionMode", R.string.AccActionEnterSelectionMode)));
                 }
-                info.addAction(new AccessibilityNodeInfo.AccessibilityAction(AccessibilityNodeInfo.ACTION_CLICK, actionLabel));
-                info.addAction(new AccessibilityNodeInfo.AccessibilityAction(AccessibilityNodeInfo.ACTION_LONG_CLICK, getString("AccActionEnterSelectionMode", R.string.AccActionEnterSelectionMode)));
                 int smallIcon = getMiniIconForCurrentState();
                 if (smallIcon == MediaActionDrawable.ICON_DOWNLOAD) {
                     info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_small_button, getString("AccActionDownload", R.string.AccActionDownload)));
@@ -27470,9 +27552,10 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 if (forwardedNameLayout[0] != null && forwardedNameLayout[1] != null) {
                     info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_open_forwarded_origin, getString("AccActionOpenForwardedOrigin", R.string.AccActionOpenForwardedOrigin)));
                 }
-                if (drawSelectionBackground || getBackground() != null) {
-                    info.setSelected(true);
-                }
+                // whether a message has been chosen is said once, by the tick it now carries.
+                // It was said twice: this called it chosen as well, going by the background drawn
+                // behind it rather than by what has actually been chosen, and a cell with any
+                // background at all was called chosen whether it was or not
                 return info;
             } else {
                 AccessibilityNodeInfo info = AccessibilityNodeInfo.obtain();

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -42073,6 +42073,32 @@ public class ChatActivity extends BaseFragment implements
         }
 
         @Override
+        public boolean isMessageSelected(MessageObject message) {
+            if (message == null) {
+                return false;
+            }
+            final int index = message.getDialogId() == dialog_id ? 0 : 1;
+            return selectedMessagesIds[index].indexOfKey(message.getId()) >= 0;
+        }
+
+        @Override
+        public void didPressSelect(ChatMessageCell cell) {
+            if (cell == null || isInsideContainer || inPreviewMode) {
+                return;
+            }
+            // the two halves of what holding a message down does: it starts the chat choosing
+            // messages where it was not, and where it already is, it takes this one or puts it
+            // back. Both are the paths a hand takes, so nothing new can be chosen a new way
+            final float x = cell.getMeasuredWidth() / 2f;
+            final float y = cell.getMeasuredHeight() / 2f;
+            if (actionBar.isActionModeShowed() || isReport()) {
+                processRowSelect(cell, false, x, y);
+            } else {
+                createMenu(cell, false, true, x, y, true);
+            }
+        }
+
+        @Override
         public boolean onAccessibilityAction(int action, Bundle arguments) {
             if (action == AccessibilityNodeInfo.ACTION_CLICK || action == R.id.acc_action_small_button || action == R.id.acc_action_msg_options) {
                 if (inPreviewMode && allowExpandPreviewByClick) {

--- a/TMessagesProj/src/main/res/values/ids.xml
+++ b/TMessagesProj/src/main/res/values/ids.xml
@@ -26,6 +26,7 @@
     <item name="current_animation" type="id"/>
     <item name="acc_action_small_button" type="id"/>
     <item name="acc_action_msg_options" type="id"/>
+    <item name="acc_action_media" type="id"/>
     <item name="acc_action_open_photo" type="id"/>
     <item name="acc_action_chat_preview" type="id"/>
     <item name="acc_action_open_forwarded_origin" type="id"/>


### PR DESCRIPTION
## Summary

A chat can be put into choosing messages, and then every message carries a tick and a tap takes it or puts it back. Nothing of that was there to be heard or done.

The message said it could be held down to start choosing, and holding it down did nothing at all: the action was offered and answered by no one, so it fell through to a press the cell has no listener for. And once choosing had been started by other means, a tap was turned away, because the chat turns presses away while it is choosing — which is the one moment the tap was wanted for. So there was no way in and no way to take a second message once in.

Nothing said which messages had been taken, either. The tick is drawn and the cell is never told what it stands for, so going back over the chat gave no answer about any of them; the only sign was the count along the top.

Both now do what they say. While messages are being chosen a message says whether it is one of the ones taken, and a tap takes it or puts it back, the way a tap on the screen does; out of that, holding it down starts the chat choosing, with this message the first taken. Both go the way a hand goes, so nothing can be chosen by a path of its own.

That is now said once and no longer twice: a message also called itself chosen by way of the background drawn behind it, which is a different question from whether it has been chosen — a cell with any background at all answered yes — and the tick it now carries is the truer answer.

What a press would have done to the media is not lost in the meantime. It is offered by name instead, and named for the state the media is in: fetch it, stop fetching it, fetch it again where fetching was stopped, play it, pause it, or open it. It is offered only while messages are being chosen, and only where a message carries something a press would do anything to. A picture or a video already here has no button drawn over it by then and no icon to be named from, and is called what it does: open.

## Checking it

With TalkBack on, hold a message down in a chat.

Before, the action offered for it said it would start choosing messages and did nothing at all. Now it starts choosing, with that message taken.

Swipe onto other messages: each says whether it is one of the chosen, and a double tap takes it or puts it back, the way a tap on the screen does. Before, a tap was turned away while the chat was choosing, so a second message could not be taken.

On a message carrying a picture, a file or a voice message, an action appears for a moment while choosing is on, named for what a press would have done: fetch it, stop fetching, play it, or open it.
