### PR TITLE
Say when a picture in the story gallery was taken

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/GalleryListView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/GalleryListView.java
@@ -1005,10 +1005,23 @@ public class GalleryListView extends FrameLayout implements NotificationCenter.N
             setDraft(false);
             if (photoEntry == null) {
                 accessibilityText = null;
-            } else if (photoEntry.isVideo) {
-                accessibilityText = LocaleController.getString(R.string.AttachVideo) + ", " + LocaleController.formatDuration(photoEntry.duration);
             } else {
-                accessibilityText = LocaleController.getString(R.string.AttachPhoto);
+                // the day a picture was taken is written under it in the gallery the chat attaches
+                // from, and said there too. Here it was written and never said, so one picture was
+                // told from the next by nothing at all: a hundred of them all called photo
+                final StringBuilder sb = new StringBuilder();
+                if (photoEntry.isLivePhoto()) {
+                    sb.append(LocaleController.getString(R.string.AttachLivePhoto));
+                } else if (photoEntry.isVideo) {
+                    sb.append(LocaleController.getString(R.string.AttachVideo));
+                    sb.append(", ");
+                    sb.append(LocaleController.formatDuration(photoEntry.duration));
+                } else {
+                    sb.append(LocaleController.getString(R.string.AttachPhoto));
+                }
+                sb.append(". ");
+                sb.append(LocaleController.getInstance().getFormatterStats().format(photoEntry.dateTaken * 1000L));
+                accessibilityText = sb;
             }
             loadBitmap(photoEntry);
             invalidate();


### PR DESCRIPTION
## Summary

The gallery a story is made from draws the day each picture was taken and says nothing of it. The gallery a chat attaches from says it, and this one is the same gallery of the same pictures.

Without it there was nothing to tell one from another: a screen reader went along a wall of pictures hearing the word photo over and over, with no way of knowing which was this morning's and which was last year's, and so no way of finding the one wanted except by opening them one at a time.

It says the same thing the other gallery says now, in the same order and the same words, a live photo among them named for what it is.

## Checking it

With TalkBack on, open the story camera and swipe through the gallery of pictures.

Before, every picture read as the same word with nothing to tell one from another. Now each says the day it was taken, exactly as the gallery a chat attaches from already did, and a live photo is named for what it is.
