### PR TITLE
Name the buttons that had no name

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/video/VideoAds.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/video/VideoAds.java
@@ -306,6 +306,7 @@ public class VideoAds {
         final CloseDrawable closeDrawable = new CloseDrawable(layout.buttonView, ad.min_display_duration, ad.max_display_duration, currentBulletinPassedTime);
         closeDrawable.setColor(Theme.getColor(Theme.key_featuredStickers_addButton, bulletinFactory.getResourcesProvider()));
         layout.buttonView.setImageDrawable(closeDrawable);
+        layout.buttonView.setContentDescription(LocaleController.getString(R.string.Close));
         layout.buttonView.setOnClickListener(v -> {
             if (closeDrawable.isCrossAvailable()) {
                 if (bulletin != null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Business/BusinessBotButton.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Business/BusinessBotButton.java
@@ -126,6 +126,7 @@ public class BusinessBotButton extends FrameLayout {
         menuView.setImageResource(R.drawable.msg_mini_customize);
         menuView.setBackground(Theme.createCircleSelectorDrawable(Theme.getColor(Theme.key_listSelector, resourcesProvider), 0, 0));
         menuView.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_chat_topPanelClose, resourcesProvider), PorterDuff.Mode.MULTIPLY));
+        menuView.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
         menuView.setOnClickListener(e -> {
             ItemOptions itemOptions = ItemOptions.makeOptions(chatActivity.getLayoutContainer(), resourcesProvider, menuView);
             itemOptions.add(R.drawable.msg_cancel, LocaleController.getString(R.string.BizBotRemove), true, () -> {

--- a/TMessagesProj/src/main/java/org/telegram/ui/CacheControlActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/CacheControlActivity.java
@@ -1250,6 +1250,7 @@ public class CacheControlActivity extends BaseFragment implements NotificationCe
         }
 
         ActionBarMenuItem otherItem = actionBar.createMenu().addItem(other_id, R.drawable.ic_ab_other);
+        otherItem.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
         clearDatabaseItem = otherItem.addSubItem(clear_database_id, R.drawable.msg_delete, LocaleController.getString(R.string.ClearLocalDatabase));
         clearDatabaseItem.setIconColor(Theme.getColor(Theme.key_text_RedRegular));
         clearDatabaseItem.setTextColor(Theme.getColor(Theme.key_text_RedBold));

--- a/TMessagesProj/src/main/java/org/telegram/ui/CallLogActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/CallLogActivity.java
@@ -1242,6 +1242,7 @@ public class CallLogActivity extends BaseFragment implements NotificationCenter.
 			actionModeCloseView.setImageDrawable(new BackDrawable(true));
 			actionModeCloseView.setColorFilter(new PorterDuffColorFilter(getThemedColor(Theme.key_actionBarActionModeDefaultIcon), PorterDuff.Mode.MULTIPLY));
 			actionModeCloseView.setBackground(Theme.createSelectorDrawable(getThemedColor(Theme.key_actionBarActionModeDefaultSelector)));
+			actionModeCloseView.setContentDescription(LocaleController.getString(R.string.Close));
 			actionModeCloseView.setOnClickListener(v -> hideActionMode(true));
 			actionMode.addView(actionModeCloseView, LayoutHelper.createLinear(54, 54, Gravity.CENTER_VERTICAL));
 			actionModeViews.add(actionModeCloseView);
@@ -1877,6 +1878,7 @@ public class CallLogActivity extends BaseFragment implements NotificationCenter.
             }
         }.show());
 		if (creator) {
+			optionsView.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
 			optionsView.setOnClickListener(v -> ItemOptions.makeOptions(sheet.getContainer(), resourcesProvider, optionsView)
                 .add(R.drawable.menu_link_revoke, getString(R.string.GroupCallCreatedLinkRevoke), revoke)
                 .setOnTopOfScrim()

--- a/TMessagesProj/src/main/java/org/telegram/ui/CameraScanActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/CameraScanActivity.java
@@ -670,6 +670,7 @@ public class CameraScanActivity extends BaseFragment {
                 galleryButton.setImageResource(R.drawable.qr_gallery);
                 galleryButton.setBackgroundDrawable(Theme.createSelectorDrawableFromDrawables(Theme.createCircleDrawable(dp(60), 0x22ffffff), Theme.createCircleDrawable(dp(60), 0x44ffffff)));
                 viewGroup.addView(galleryButton);
+                galleryButton.setContentDescription(LocaleController.getString(R.string.Gallery));
                 galleryButton.setOnClickListener(currentImage -> {
                     if (getParentActivity() == null) {
                         return;
@@ -732,6 +733,7 @@ public class CameraScanActivity extends BaseFragment {
             flashButton.setImageResource(R.drawable.qr_flashlight);
             flashButton.setBackgroundDrawable(Theme.createCircleDrawable(dp(60), 0x22ffffff));
             viewGroup.addView(flashButton);
+            flashButton.setContentDescription(LocaleController.getString(R.string.AccDescrFlashlight));
             flashButton.setOnClickListener(currentImage -> {
                 if (cameraView == null) {
                     return;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/AdminedChannelCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/AdminedChannelCell.java
@@ -78,6 +78,7 @@ public class AdminedChannelCell extends FrameLayout {
             deleteButton = new ImageView(context);
             deleteButton.setScaleType(ImageView.ScaleType.CENTER);
             deleteButton.setImageResource(R.drawable.msg_panel_clear);
+            deleteButton.setContentDescription(LocaleController.getString(R.string.Delete));
             deleteButton.setOnClickListener(onClickListener);
             deleteButton.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_listSelector)));
             deleteButton.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_windowBackgroundWhiteGrayText), PorterDuff.Mode.MULTIPLY));

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/AudioPlayerCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/AudioPlayerCell.java
@@ -100,6 +100,7 @@ public class AudioPlayerCell extends FrameLayout implements DownloadController.F
         optionsButton.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_windowBackgroundWhiteGrayIcon, resourcesProvider), PorterDuff.Mode.SRC_IN));
         optionsButton.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_listSelector, resourcesProvider), Theme.RIPPLE_MASK_CIRCLE_20DP));
         addView(optionsButton, LayoutHelper.createFrame(42, 42, (LocaleController.isRTL ? Gravity.LEFT : Gravity.RIGHT) | Gravity.CENTER_VERTICAL, 5, 0, 5, 0));
+        optionsButton.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
         optionsButton.setOnClickListener(v -> {
 
         });

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogsHintCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogsHintCell.java
@@ -174,6 +174,7 @@ public class DialogsHintCell extends FrameLayout {
     public void setOnCloseListener(OnClickListener closeListener) {
         chevronView.setVisibility(INVISIBLE);
         closeView.setVisibility(VISIBLE);
+        closeView.setContentDescription(LocaleController.getString(R.string.Close));
         closeView.setOnClickListener(closeListener);
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ManageChatUserCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ManageChatUserCell.java
@@ -132,6 +132,7 @@ public class ManageChatUserCell extends FrameLayout {
 
     public void setStoryItem(TL_stories.StoryItem storyItem, OnClickListener listener) {
         this.storyItem = storyItem;
+        avatarImageView.setContentDescription(LocaleController.getString(R.string.AccDescrProfilePicture));
         avatarImageView.setOnClickListener(listener);
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/StatisticPostInfoCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/StatisticPostInfoCell.java
@@ -184,6 +184,7 @@ public class StatisticPostInfoCell extends FrameLayout {
     }
 
     public void setImageViewAction(View.OnClickListener action){
+        imageView.setContentDescription(LocaleController.getString(R.string.AccDescrProfilePicture));
         imageView.setOnClickListener(action);
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/StickerSetCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/StickerSetCell.java
@@ -412,6 +412,7 @@ public class StickerSetCell extends FrameLayout {
     public void setDeleteAction(OnClickListener action) {
         if (deleteView != null) {
             deleteView.setVisibility(action == null ? View.GONE : View.VISIBLE);
+            deleteView.setContentDescription(LocaleController.getString(R.string.Delete));
             deleteView.setOnClickListener(action);
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/UserCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/UserCell.java
@@ -906,6 +906,7 @@ public class UserCell extends FrameLayout implements NotificationCenter.Notifica
                 closeView.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_listSelector, resourcesProvider), Theme.RIPPLE_MASK_CIRCLE_AUTO));
                 addView(closeView, LayoutHelper.createFrame(30, 30, (LocaleController.isRTL ? Gravity.LEFT : Gravity.RIGHT) | Gravity.CENTER_VERTICAL, LocaleController.isRTL ? 14 : 0, 0, LocaleController.isRTL ? 0 : 14, 0));
             }
+            closeView.setContentDescription(LocaleController.getString(R.string.Close));
             closeView.setOnClickListener(onClick);
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -4244,6 +4244,7 @@ public class ChatActivity extends BaseFragment implements
 
         if (UserObject.isBotForumWithEditableTopics(currentUser) && chatMode == 0) {
             topicCreateItem = menu.addItem(chat_menu_topic_create, R.drawable.menu_topic_add_30);
+            topicCreateItem.setContentDescription(LocaleController.getString(R.string.CreateTopic));
         }
 
         if (currentEncryptedChat == null && (chatMode == 0 || chatMode == MODE_SAVED || chatMode == MODE_SUGGESTIONS) && !isReport()) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AIEditorAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AIEditorAlert.java
@@ -164,6 +164,7 @@ public class AIEditorAlert extends BottomSheetWithRecyclerListView implements No
         closeView.setBackground(Theme.createSelectorDrawable(Theme.multAlpha(getThemedColor(Theme.key_windowBackgroundWhiteBlackText), .10f)));
         actionBar.addView(closeView, LayoutHelper.createFrame(54, 54, Gravity.BOTTOM | Gravity.RIGHT, 0, 0, 8, 0));
         ScaleStateListAnimator.apply(closeView, .1f, 1.5f);
+        closeView.setContentDescription(LocaleController.getString(R.string.Close));
         closeView.setOnClickListener(v -> this.dismiss());
 
         tabsContainer = new FrameLayout(context);
@@ -1957,6 +1958,7 @@ public class AIEditorAlert extends BottomSheetWithRecyclerListView implements No
             closeView.setBackground(Theme.createSelectorDrawable(Theme.multAlpha(getThemedColor(Theme.key_windowBackgroundWhiteBlackText), .10f)));
             actionBar.addView(closeView, LayoutHelper.createFrame(54, 54, Gravity.BOTTOM | Gravity.RIGHT, 0, 0, 8, 0));
             ScaleStateListAnimator.apply(closeView, .1f, 1.5f);
+            closeView.setContentDescription(LocaleController.getString(R.string.Close));
             closeView.setOnClickListener(v -> this.dismiss());
 
             iconCell = new FrameLayout(context);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AlertsCreator.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AlertsCreator.java
@@ -4746,6 +4746,7 @@ public class AlertsCreator {
             });
         }
         final HintView2[] notifyHint = new HintView2[1];
+        notifyItem.setContentDescription(LocaleController.getString(R.string.Notifications));
         notifyItem.setOnClickListener(v -> {
             notify[0] = !notify[0];
             if (notify[0]) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AudioPlayerAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AudioPlayerAlert.java
@@ -1282,6 +1282,7 @@ public class AudioPlayerAlert extends BottomSheet implements NotificationCenter.
         playlist = MediaController.getInstance().getPlaylist();
         if (isMyList()) {
             addItem = menu.addItem(8, R.drawable.msg_add);
+        addItem.setContentDescription(LocaleController.getString(R.string.Add));
         }
         searchItem = menu.addItem(0, R.drawable.outline_header_search)
             .setIsSearchField(true)

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/CaptionPhotoViewer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/CaptionPhotoViewer.java
@@ -151,6 +151,7 @@ public class CaptionPhotoViewer extends CaptionContainerView {
                 .show();
         });
 
+        timerButton.setContentDescription(LocaleController.getString(R.string.SetTimer));
         timerButton.setOnClickListener(e -> {
             if (timerPopup != null && timerPopup.isShown()) {
                 timerPopup.dismiss();
@@ -291,6 +292,7 @@ public class CaptionPhotoViewer extends CaptionContainerView {
     }
 
     public void setOnAddPhotoClick(View.OnClickListener listener) {
+        addPhotoButton.setContentDescription(LocaleController.getString(R.string.AttachPhoto));
         addPhotoButton.setOnClickListener(listener);
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlert.java
@@ -2953,6 +2953,7 @@ public class ChatAttachAlert extends BottomSheet implements NotificationCenter.N
         moveCaptionButton.setColorFilter(new PorterDuffColorFilter(getThemedColor(Theme.key_windowBackgroundWhiteGrayText2), PorterDuff.Mode.SRC_IN));
         moveCaptionButton.setImageResource(R.drawable.menu_link_above);
         moveCaptionButton.setVisibility(View.GONE);
+        moveCaptionButton.setContentDescription(LocaleController.getString(R.string.CaptionAbove));
         moveCaptionButton.setOnClickListener(v -> {
             if (!captionAbove) {
                 toggleCaptionAbove();
@@ -3481,6 +3482,7 @@ public class ChatAttachAlert extends BottomSheet implements NotificationCenter.N
         topCommentMoveButton.setImageResource(R.drawable.menu_link_below);
         topCommentMoveButton.setColorFilter(new PorterDuffColorFilter(getThemedColor(Theme.key_chat_messagePanelIcons), PorterDuff.Mode.SRC_IN));
         topCommentTextView.addView(topCommentMoveButton, LayoutHelper.createFrame(40, 40, Gravity.BOTTOM | Gravity.RIGHT, 0, 0, 60, 0));
+        topCommentMoveButton.setContentDescription(LocaleController.getString(R.string.CaptionBelow));
         topCommentMoveButton.setOnClickListener(v -> {
             if (captionAbove) {
                 toggleCaptionAbove();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatThemeBottomSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatThemeBottomSheet.java
@@ -167,6 +167,7 @@ public class ChatThemeBottomSheet extends BottomSheet implements NotificationCen
         backButtonView.setPadding(padding, padding, padding, padding);
         backButtonDrawable = new BackDrawable(false);
         backButtonView.setImageDrawable(backButtonDrawable);
+        backButtonView.setContentDescription(LocaleController.getString(R.string.Back));
         backButtonView.setOnClickListener(v -> {
             if (hasChanges()) {
                 resetToPrimaryState(true);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/CustomPhoneKeyboardView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/CustomPhoneKeyboardView.java
@@ -1,5 +1,7 @@
 package org.telegram.ui.Components;
 
+import org.telegram.messenger.LocaleController;
+
 import static org.telegram.messenger.AndroidUtilities.dp;
 
 import android.annotation.SuppressLint;
@@ -155,6 +157,7 @@ public class CustomPhoneKeyboardView extends ViewGroup {
         backButton.setColorFilter(Theme.getColor(Theme.key_windowBackgroundWhiteBlackText));
         int pad = dp(11);
         backButton.setPadding(pad, pad, pad, pad);
+        backButton.setContentDescription(LocaleController.getString(R.string.AccDescrBackspace));
         backButton.setOnClickListener(v -> {});
         addView(views[11] = backButton);
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/DownloadsInfoBottomSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/DownloadsInfoBottomSheet.java
@@ -49,6 +49,7 @@ public class DownloadsInfoBottomSheet extends BottomSheet {
         closeView.setBackground(Theme.createSelectorDrawable(getThemedColor(Theme.key_listSelector)));
         closeView.setColorFilter(getThemedColor(Theme.key_sheet_other));
         closeView.setImageResource(R.drawable.ic_layer_close);
+        closeView.setContentDescription(LocaleController.getString(R.string.Close));
         closeView.setOnClickListener((view) -> dismiss());
         int closeViewPadding = AndroidUtilities.dp(8);
         closeView.setPadding(closeViewPadding, closeViewPadding, closeViewPadding, closeViewPadding);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiView.java
@@ -778,6 +778,23 @@ public class EmojiView extends FrameLayout implements
 
         private int type;
         private ImageView searchImageView;
+
+        /**
+         * The picture at the left of the search box. For most of its life it is a magnifying
+         * glass that answers no press at all, and it stood in the way as a button with no name
+         * and nothing to do: the box beside it is what opens a search. Once a search is under way
+         * it turns into an arrow back that empties the box, and only then is it a button.
+         */
+        private void updateSearchImageAccessibility() {
+            if (searchImageView == null || searchStateDrawable == null) {
+                return;
+            }
+            final boolean isBack = searchStateDrawable.getIconState() == SearchStateDrawable.State.STATE_BACK;
+            searchImageView.setImportantForAccessibility(isBack
+                ? View.IMPORTANT_FOR_ACCESSIBILITY_YES
+                : View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+            searchImageView.setContentDescription(isBack ? getString(R.string.Back) : null);
+        }
         private SearchStateDrawable searchStateDrawable;
         private EditTextBoldCursor searchEditText;
         private View shadowView;
@@ -848,6 +865,7 @@ public class EmojiView extends FrameLayout implements
             searchStateDrawable.setColor(glassDesign ? getGlassIconColor(0.4f) : getThemedColor(Theme.key_chat_emojiSearchIcon));
             searchImageView.setScaleType(ImageView.ScaleType.CENTER);
             searchImageView.setImageDrawable(searchStateDrawable);
+            updateSearchImageAccessibility();
             searchImageView.setOnClickListener(e -> {
                 if (searchStateDrawable.getIconState() == SearchStateDrawable.State.STATE_BACK) {
                     searchEditText.setText("");
@@ -1098,6 +1116,7 @@ public class EmojiView extends FrameLayout implements
             isprogress = progress;
             if (progress) {
                 searchStateDrawable.setIconState(SearchStateDrawable.State.STATE_PROGRESS);
+                updateSearchImageAccessibility();
             } else {
                 updateButton(true);
             }
@@ -1111,6 +1130,7 @@ public class EmojiView extends FrameLayout implements
             if (!isInProgress() || searchEditText.length() == 0 && (categoriesListView == null || categoriesListView.getSelectedCategory() == null) || force) {
                 boolean backButton = searchEditText.length() > 0 || categoriesListView != null && categoriesListView.isCategoriesShown() && (categoriesListView.isScrolledIntoOccupiedWidth() || categoriesListView.getSelectedCategory() != null);
                 searchStateDrawable.setIconState(backButton ? SearchStateDrawable.State.STATE_BACK : SearchStateDrawable.State.STATE_SEARCH);
+                updateSearchImageAccessibility();
                 isprogress = false;
             }
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/FragmentSearchField.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/FragmentSearchField.java
@@ -139,6 +139,7 @@ public class FragmentSearchField extends FrameLayout implements FactorAnimator.T
         closeIcon.setScaleType(ImageView.ScaleType.CENTER);
         closeIcon.setImageResource(R.drawable.miniplayer_close);
         closeIcon.setVisibility(GONE);
+        closeIcon.setContentDescription(LocaleController.getString(R.string.ClearButton));
         closeIcon.setOnClickListener(v -> {
             if (hasRemovableFilters()) {
                 if (searchFiltersListener != null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/JoinGroupAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/JoinGroupAlert.java
@@ -95,6 +95,7 @@ public class JoinGroupAlert extends BottomSheet {
         closeView.setBackground(Theme.createSelectorDrawable(getThemedColor(Theme.key_listSelector)));
         closeView.setColorFilter(getThemedColor(Theme.key_sheet_other));
         closeView.setImageResource(R.drawable.ic_layer_close);
+        closeView.setContentDescription(LocaleController.getString(R.string.Close));
         closeView.setOnClickListener((view) -> dismiss());
         int closeViewPadding = dp(8);
         closeView.setPadding(closeViewPadding, closeViewPadding, closeViewPadding, closeViewPadding);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/MediaActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/MediaActivity.java
@@ -278,11 +278,13 @@ public class MediaActivity extends BaseFragment implements SharedMediaLayout.Sha
             deleteItem.setIcon(R.drawable.msg_delete);
             deleteItem.setVisibility(View.GONE);
             deleteItem.setAlpha(0f);
+            deleteItem.setContentDescription(LocaleController.getString(R.string.Delete));
             deleteItem.setOnClickListener(v -> menu2.onItemClick(2));
             menu.addView(deleteItem);
 
             optionsItem = new ActionBarMenuItem(context, menu2, getThemedColor(Theme.key_actionBarActionModeDefaultSelector), getThemedColor(Theme.key_windowBackgroundWhiteBlackText));
             optionsItem.setIcon(R.drawable.ic_ab_other);
+            optionsItem.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
             optionsItem.setOnClickListener(v -> optionsItem.toggleSubMenu());
             optionsItem.setVisibility(View.GONE);
             optionsItem.setAlpha(0f);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/ColorPickerBottomSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/ColorPickerBottomSheet.java
@@ -91,6 +91,7 @@ public class ColorPickerBottomSheet extends BottomSheet {
         pipetteView.setImageResource(R.drawable.picker);
         pipetteView.setColorFilter(new PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN));
         pipetteView.setBackground(Theme.createSelectorDrawable(Theme.ACTION_BAR_WHITE_SELECTOR_COLOR));
+        pipetteView.setContentDescription(LocaleController.getString(R.string.AccDescrColorPicker));
         pipetteView.setOnClickListener(v -> {
             if (pipetteDelegate.isPipetteVisible()) {
                 return;
@@ -127,6 +128,7 @@ public class ColorPickerBottomSheet extends BottomSheet {
         doneView.setImageResource(R.drawable.ic_ab_done);
         doneView.setColorFilter(new PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN));
         doneView.setBackground(Theme.createSelectorDrawable(Theme.ACTION_BAR_WHITE_SELECTOR_COLOR));
+        doneView.setContentDescription(LocaleController.getString(R.string.Done));
         doneView.setOnClickListener(v -> {
             dismiss();
         });

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/LPhotoPaintView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Paint/Views/LPhotoPaintView.java
@@ -542,6 +542,7 @@ public class LPhotoPaintView extends SizeNotifierFrameLayoutPhoto implements IPh
         undoButton.setImageResource(R.drawable.photo_undo2);
         undoButton.setPadding(dp(3), dp(3), dp(3), dp(3));
         undoButton.setBackground(Theme.createSelectorDrawable(Theme.ACTION_BAR_WHITE_SELECTOR_COLOR));
+        undoButton.setContentDescription(LocaleController.getString(R.string.Undo));
         undoButton.setOnClickListener(v -> {
             if (renderView != null && renderView.getCurrentBrush() instanceof Brush.Shape) {
                 renderView.clearShape();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/PermanentLinkBottomSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/PermanentLinkBottomSheet.java
@@ -62,6 +62,7 @@ public class PermanentLinkBottomSheet extends BottomSheet {
         closeView.setBackground(Theme.createSelectorDrawable(getThemedColor(Theme.key_listSelector)));
         closeView.setColorFilter(getThemedColor(Theme.key_sheet_other));
         closeView.setImageResource(R.drawable.ic_layer_close);
+        closeView.setContentDescription(LocaleController.getString(R.string.Close));
         closeView.setOnClickListener((view) -> dismiss());
         int closeViewPadding = AndroidUtilities.dp(8);
         closeView.setPadding(closeViewPadding, closeViewPadding, closeViewPadding, closeViewPadding);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/PhotoFilterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/PhotoFilterView.java
@@ -532,6 +532,7 @@ public class PhotoFilterView extends FrameLayout implements FilterShaders.Filter
         tuneItem.setColorFilter(new PorterDuffColorFilter(getThemedColor(Theme.key_chat_editMediaButton), PorterDuff.Mode.MULTIPLY));
         tuneItem.setBackgroundDrawable(Theme.createSelectorDrawable(Theme.ACTION_BAR_WHITE_SELECTOR_COLOR));
         linearLayout.addView(tuneItem, LayoutHelper.createLinear(56, 48));
+        tuneItem.setContentDescription(LocaleController.getString(R.string.AccDescrPhotoAdjust));
         tuneItem.setOnClickListener(v -> {
             selectedTool = 0;
             tuneItem.setColorFilter(new PorterDuffColorFilter(getThemedColor(Theme.key_chat_editMediaButton), PorterDuff.Mode.MULTIPLY));
@@ -545,6 +546,7 @@ public class PhotoFilterView extends FrameLayout implements FilterShaders.Filter
         blurItem.setImageResource(R.drawable.msg_photo_blur);
         blurItem.setBackgroundDrawable(Theme.createSelectorDrawable(Theme.ACTION_BAR_WHITE_SELECTOR_COLOR));
         linearLayout.addView(blurItem, LayoutHelper.createLinear(56, 48));
+        blurItem.setContentDescription(LocaleController.getString(R.string.LiteOptionsBlur2));
         blurItem.setOnClickListener(v -> {
             selectedTool = 1;
             tuneItem.setColorFilter(null);
@@ -561,6 +563,7 @@ public class PhotoFilterView extends FrameLayout implements FilterShaders.Filter
         curveItem.setImageResource(R.drawable.msg_photo_curve);
         curveItem.setBackgroundDrawable(Theme.createSelectorDrawable(Theme.ACTION_BAR_WHITE_SELECTOR_COLOR));
         linearLayout.addView(curveItem, LayoutHelper.createLinear(56, 48));
+        curveItem.setContentDescription(LocaleController.getString(R.string.AccDescrCurvesTool));
         curveItem.setOnClickListener(v -> {
             selectedTool = 2;
             tuneItem.setColorFilter(null);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/PipVideoOverlay.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/PipVideoOverlay.java
@@ -1,5 +1,7 @@
 package org.telegram.ui.Components;
 
+import org.telegram.messenger.LocaleController;
+
 import static android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE;
 
 import static org.telegram.messenger.AndroidUtilities.dp;
@@ -458,11 +460,14 @@ public class PipVideoOverlay implements IPipSourceDelegate {
         if (!isPlaying) {
             if (isVideoCompleted) {
                 playPauseButton.setImageResource(R.drawable.pip_replay_large);
+                playPauseButton.setContentDescription(LocaleController.getString(R.string.AccActionPlay));
             } else {
                 playPauseButton.setImageResource(R.drawable.pip_play_large);
+                playPauseButton.setContentDescription(LocaleController.getString(R.string.AccActionPlay));
             }
         } else {
             playPauseButton.setImageResource(R.drawable.pip_pause_large);
+            playPauseButton.setContentDescription(LocaleController.getString(R.string.AccActionPause));
             AndroidUtilities.runOnUIThread(progressRunnable, 500);
         }
     }
@@ -1062,6 +1067,7 @@ public class PipVideoOverlay implements IPipSourceDelegate {
 
         ImageView closeButton = new ImageView(context);
         closeButton.setImageResource(R.drawable.pip_video_close);
+        closeButton.setContentDescription(LocaleController.getString(R.string.Close));
         closeButton.setColorFilter(Theme.getColor(Theme.key_voipgroup_actionBarItems), PorterDuff.Mode.MULTIPLY);
         closeButton.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_listSelector)));
         closeButton.setPadding(padding, padding, padding, padding);
@@ -1070,6 +1076,7 @@ public class PipVideoOverlay implements IPipSourceDelegate {
 
         ImageView expandButton = new ImageView(context);
         expandButton.setImageResource(R.drawable.pip_video_expand);
+        expandButton.setContentDescription(LocaleController.getString(R.string.AccExitFullscreen));
         expandButton.setColorFilter(Theme.getColor(Theme.key_voipgroup_actionBarItems), PorterDuff.Mode.MULTIPLY);
         expandButton.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_listSelector)));
         expandButton.setPadding(padding, padding, padding, padding);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/LimitReachedBottomSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/LimitReachedBottomSheet.java
@@ -1371,6 +1371,7 @@ public class LimitReachedBottomSheet extends BottomSheetWithRecyclerListView imp
                             imageView.setPadding(AndroidUtilities.dp(8), AndroidUtilities.dp(8), AndroidUtilities.dp(8), AndroidUtilities.dp(8));
                             imageView.setBackground(Theme.createSimpleSelectorRoundRectDrawable(AndroidUtilities.dp(20), 0, ColorUtils.setAlphaComponent(Theme.getColor(Theme.key_listSelector, resourcesProvider), (int) (255 * 0.3f))));
                             frameLayout.addView(imageView, LayoutHelper.createFrame(40, 40, Gravity.RIGHT | Gravity.CENTER_VERTICAL, 15, 0, 15, 0));
+                            imageView.setContentDescription(LocaleController.getString(R.string.Statistics));
                             imageView.setOnClickListener(v -> {
                                 statisticClickRunnable.run();
                                 dismiss();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/boosts/cells/LinkCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/boosts/cells/LinkCell.java
@@ -1,5 +1,7 @@
 package org.telegram.ui.Components.Premium.boosts.cells;
 
+import org.telegram.messenger.LocaleController;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Canvas;
@@ -61,6 +63,7 @@ public class LinkCell extends FrameLayout {
         imageView.setPadding(AndroidUtilities.dp(8), AndroidUtilities.dp(8), AndroidUtilities.dp(8), AndroidUtilities.dp(8));
         imageView.setBackground(Theme.createSimpleSelectorRoundRectDrawable(AndroidUtilities.dp(20), 0, ColorUtils.setAlphaComponent(Theme.getColor(Theme.key_listSelector, resourcesProvider), (int) (255 * 0.3f))));
         addView(imageView, LayoutHelper.createFrame(40, 40, Gravity.RIGHT | Gravity.CENTER_VERTICAL, 15, 0, 17, 0));
+        imageView.setContentDescription(LocaleController.getString(R.string.Copy));
         imageView.setOnClickListener(v -> AndroidUtilities.addToClipboard(link));
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/boosts/cells/selector/SelectorHeaderCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/boosts/cells/selector/SelectorHeaderCell.java
@@ -1,5 +1,7 @@
 package org.telegram.ui.Components.Premium.boosts.cells.selector;
 
+import org.telegram.messenger.R;
+
 import static org.telegram.messenger.AndroidUtilities.dp;
 
 import android.annotation.SuppressLint;
@@ -48,6 +50,7 @@ public class SelectorHeaderCell extends FrameLayout {
         backDrawable.setRotatedColor(Theme.getColor(Theme.key_dialogTextBlack, resourcesProvider));
         backDrawable.setAnimationTime(220);
         addView(closeView, LayoutHelper.createFrame(24, 24, Gravity.CENTER_VERTICAL | (LocaleController.isRTL ? Gravity.RIGHT : Gravity.LEFT), 16, 0, 16, 0));
+        closeView.setContentDescription(LocaleController.getString(R.string.Back));
         closeView.setOnClickListener(e -> {
             if (onCloseClickListener != null) {
                 onCloseClickListener.run();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/boosts/cells/selector/SelectorUserCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/boosts/cells/selector/SelectorUserCell.java
@@ -110,6 +110,7 @@ public class SelectorUserCell extends BaseCell {
     public void setOptions(View.OnClickListener listener) {
         if (listener != null) {
             optionsView.setVisibility(View.VISIBLE);
+            optionsView.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
             optionsView.setOnClickListener(listener);
         } else {
             optionsView.setVisibility(View.GONE);
@@ -120,10 +121,12 @@ public class SelectorUserCell extends BaseCell {
         hasAudioView = audio != null;
         audioView.setVisibility(hasAudioView && showCallButtons ? View.VISIBLE : View.GONE);
 //        audioView.setAlpha(hasAudioView && showCallButtons ? 1.0f : 0.0f);
+        audioView.setContentDescription(LocaleController.getString(R.string.Call));
         audioView.setOnClickListener(audio);
         hasVideoView = video != null;
         videoView.setVisibility(hasVideoView && showCallButtons ? View.VISIBLE : View.GONE);
 //        videoView.setAlpha(hasVideoView && showCallButtons ? 1.0f : 0.0f);
+        videoView.setContentDescription(LocaleController.getString(R.string.VideoCall));
         videoView.setOnClickListener(video);
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactionsContainerLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactionsContainerLayout.java
@@ -2566,6 +2566,7 @@ public class ReactionsContainerLayout extends FrameLayout implements Notificatio
                     premiumLockIconView.setScaleY(0f);
                     premiumLockIconView.setPadding(dp(1), dp(1), dp(1), dp(1));
                     premiumLockContainer.addView(premiumLockIconView, LayoutHelper.createFrame(26, 26, Gravity.CENTER));
+                    premiumLockIconView.setContentDescription(LocaleController.getString(R.string.PremiumMore));
                     premiumLockIconView.setOnClickListener(v -> {
                         int[] position = new int[2];
                         v.getLocationOnScreen(position);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/SearchField.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/SearchField.java
@@ -1,5 +1,7 @@
 package org.telegram.ui.Components;
 
+import org.telegram.messenger.LocaleController;
+
 import android.content.Context;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
@@ -78,6 +80,7 @@ public class SearchField extends FrameLayout {
             lp = LayoutHelper.createFrame(36, 36, Gravity.RIGHT | Gravity.TOP, horizontalMargin, 11, horizontalMargin, 0);
         }
         addView(clearSearchImageView, lp);
+        clearSearchImageView.setContentDescription(LocaleController.getString(R.string.ClearButton));
         clearSearchImageView.setOnClickListener(v -> {
             searchEditText.setText("");
             AndroidUtilities.showKeyboard(searchEditText);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/SearchViewPager.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/SearchViewPager.java
@@ -861,6 +861,7 @@ public class SearchViewPager extends ViewPagerFixed implements FilteredSearchVie
                 actionModeCloseView.setImageDrawable(new BackDrawable(true));
                 actionModeCloseView.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_actionBarActionModeDefaultIcon), PorterDuff.Mode.MULTIPLY));
                 actionModeCloseView.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_actionBarActionModeDefaultSelector)));
+                actionModeCloseView.setContentDescription(LocaleController.getString(R.string.Close));
                 actionModeCloseView.setOnClickListener(v -> hideActionMode());
                 actionMode.addView(actionModeCloseView, LayoutHelper.createLinear(54, 54, 0f, Gravity.CENTER_VERTICAL));
             }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ShareTopView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ShareTopView.java
@@ -671,6 +671,7 @@ public class ShareTopView extends FrameLayout implements NotificationCenter.Noti
             closeButton.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_glass_defaultIcon, resourcesProvider), PorterDuff.Mode.MULTIPLY));
             closeButton.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_listSelector, resourcesProvider), 1, dp(18)));
             closeButton.setVisibility(GONE);
+            closeButton.setContentDescription(LocaleController.getString(R.string.Close));
             closeButton.setOnClickListener(v -> dismissWebPagePreview());
             container.addView(closeButton, LayoutHelper.createLinear(36, 36, Gravity.RIGHT | Gravity.CENTER_VERTICAL, 0, 0, 4, 0));
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/SharedMediaLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/SharedMediaLayout.java
@@ -1746,6 +1746,7 @@ public class SharedMediaLayout extends FrameLayout implements NotificationCenter
             });
             if (dialog_id == profileActivity.getUserConfig().getClientUserId() && profileActivity instanceof MediaActivity && canShowSearchItem()) {
                 searchItemIcon = menu.addItem(11, R.drawable.outline_header_search);
+            searchItemIcon.setContentDescription(LocaleController.getString(R.string.Search));
             }
             searchItem = menu.addItem(0, 0).setIsSearchField(true).setActionBarMenuItemSearchListener(new ActionBarMenuItem.ActionBarMenuItemSearchListener() {
                 @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/StickerMasksAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/StickerMasksAlert.java
@@ -212,6 +212,7 @@ public class StickerMasksAlert extends BottomSheet implements NotificationCenter
             clearSearchImageView.setScaleY(0.1f);
             clearSearchImageView.setAlpha(0.0f);
             addView(clearSearchImageView, LayoutHelper.createFrame(36, 36, Gravity.RIGHT | Gravity.TOP, 14, 14, 14, 0));
+            clearSearchImageView.setContentDescription(LocaleController.getString(R.string.ClearButton));
             clearSearchImageView.setOnClickListener(v -> {
                 searchEditText.setText("");
                 AndroidUtilities.showKeyboard(searchEditText);
@@ -768,6 +769,7 @@ public class StickerMasksAlert extends BottomSheet implements NotificationCenter
             emojiButton.setBackground(rippleDrawable);
         }
         itemsLayout.addView(emojiButton, LayoutHelper.createLinear(70, 48));
+        emojiButton.setContentDescription(LocaleController.getString(R.string.Emoji));
         emojiButton.setOnClickListener(v -> {
             if (currentType == MediaDataController.TYPE_EMOJIPACKS) {
                 return;
@@ -795,6 +797,7 @@ public class StickerMasksAlert extends BottomSheet implements NotificationCenter
             stickersButton.setBackground(rippleDrawable);
         }
         itemsLayout.addView(stickersButton, LayoutHelper.createLinear(70, 48));
+        stickersButton.setContentDescription(LocaleController.getString(R.string.AccDescrStickers));
         stickersButton.setOnClickListener(v -> {
             if (currentType == MediaDataController.TYPE_IMAGE) {
                 return;
@@ -823,6 +826,7 @@ public class StickerMasksAlert extends BottomSheet implements NotificationCenter
                 masksButton.setBackground(rippleDrawable);
             }
             itemsLayout.addView(masksButton, LayoutHelper.createLinear(70, 48));
+            masksButton.setContentDescription(LocaleController.getString(R.string.Masks));
             masksButton.setOnClickListener(v -> {
                 if (currentType == MediaDataController.TYPE_MASK) {
                     return;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/TableView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/TableView.java
@@ -115,6 +115,7 @@ public class TableView extends TableLayout {
             copyView.setImageResource(R.drawable.msg_copy);
             copyView.setScaleType(ImageView.ScaleType.CENTER);
             copyView.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_windowBackgroundWhiteBlueIcon, resourcesProvider), PorterDuff.Mode.SRC_IN));
+            copyView.setContentDescription(LocaleController.getString(R.string.Copy));
             copyView.setOnClickListener(v -> {
                 AndroidUtilities.addToClipboard(text);
                 copyButton.run();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/TagEditCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/TagEditCell.java
@@ -1,5 +1,7 @@
 package org.telegram.ui.Components;
 
+import org.telegram.messenger.LocaleController;
+
 import static org.telegram.messenger.AndroidUtilities.dp;
 import static org.telegram.messenger.AndroidUtilities.dpf2;
 import static org.telegram.messenger.LocaleController.formatString;
@@ -132,6 +134,7 @@ public class TagEditCell extends LinearLayout {
         clearImageView.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_windowBackgroundWhiteGrayText, resourcesProvider), PorterDuff.Mode.SRC_IN));
         editTextCell.addView(clearImageView, LayoutHelper.createFrame(24, 24, Gravity.CENTER_VERTICAL | Gravity.RIGHT, 0, 0, 20, 0));
         ScaleStateListAnimator.apply(clearImageView);
+        clearImageView.setContentDescription(LocaleController.getString(R.string.ClearButton));
         clearImageView.setOnClickListener(v -> {
             editText.setText("");
         });
@@ -355,6 +358,7 @@ public class TagEditCell extends LinearLayout {
                 }
             });
         });
+        closeView.setContentDescription(LocaleController.getString(R.string.Close));
         closeView.setOnClickListener(v -> sheet.dismiss());
 
         sheet.show();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ThemeEditorView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ThemeEditorView.java
@@ -191,6 +191,7 @@ public class ThemeEditorView {
                 clearSearchImageView.setScaleY(0.1f);
                 clearSearchImageView.setAlpha(0.0f);
                 addView(clearSearchImageView, LayoutHelper.createFrame(36, 36, Gravity.RIGHT | Gravity.TOP, 14, 11, 14, 0));
+                clearSearchImageView.setContentDescription(LocaleController.getString(R.string.ClearButton));
                 clearSearchImageView.setOnClickListener(v -> {
                     searchEditText.setText("");
                     AndroidUtilities.showKeyboard(searchEditText);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/TopicsTabsView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/TopicsTabsView.java
@@ -396,6 +396,7 @@ public class TopicsTabsView extends FrameLayout implements NotificationCenter.No
         ImageView button = new ImageView(context);
         button.setImageResource(iconRes);
         button.setScaleType(ImageView.ScaleType.CENTER);
+        button.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
         button.setOnClickListener(onClickListener);
         ScaleStateListAnimator.apply(button);
         return button;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/TranslateAlert2.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/TranslateAlert2.java
@@ -1207,6 +1207,7 @@ public class TranslateAlert2 extends BottomSheet implements NotificationCenter.N
             backButton.setColorFilter(new PorterDuffColorFilter(getThemedColor(Theme.key_dialogTextBlack), PorterDuff.Mode.MULTIPLY));
             backButton.setBackground(Theme.createSelectorDrawable(getThemedColor(Theme.key_listSelector)));
             backButton.setAlpha(0f);
+            backButton.setContentDescription(LocaleController.getString(R.string.Back));
             backButton.setOnClickListener(e -> dismiss());
             addView(backButton, LayoutHelper.createFrame(54, 54, Gravity.TOP, 1, 1, 1, 1));
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/TranslateAlert3.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/TranslateAlert3.java
@@ -77,6 +77,7 @@ public class TranslateAlert3 extends BottomSheetWithRecyclerListView {
         closeView.setBackground(Theme.createSelectorDrawable(Theme.multAlpha(getThemedColor(Theme.key_windowBackgroundWhiteBlackText), .10f)));
         actionBar.addView(closeView, LayoutHelper.createFrame(54, 54, Gravity.BOTTOM | Gravity.RIGHT, 0, 0, 8, 0));
         ScaleStateListAnimator.apply(closeView, .1f, 1.5f);
+        closeView.setContentDescription(LocaleController.getString(R.string.Close));
         closeView.setOnClickListener(v -> this.dismiss());
 
         to_lang = TranslateAlert2.getToLanguage();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/TranslateButton.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/TranslateButton.java
@@ -112,6 +112,7 @@ public class TranslateButton extends FrameLayout implements Theme.Colorable {
         menuView = new ImageView(context);
         menuView.setScaleType(ImageView.ScaleType.CENTER);
         menuView.setImageResource(R.drawable.msg_mini_customize);
+        menuView.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
         menuView.setOnClickListener(e -> {
             final TLRPC.Chat chat = MessagesController.getInstance(currentAccount).getChat(-dialogId);
             if (UserConfig.getInstance(currentAccount).isPremium() || chat != null && chat.autotranslation) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/WebPlayerView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/WebPlayerView.java
@@ -8,6 +8,8 @@
 
 package org.telegram.ui.Components;
 
+import org.telegram.messenger.LocaleController;
+
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.AnimatorSet;
@@ -1699,6 +1701,7 @@ public class WebPlayerView extends ViewGroup implements VideoPlayer.VideoPlayerD
             shareButton.setScaleType(ImageView.ScaleType.CENTER);
             shareButton.setImageResource(R.drawable.ic_share_video);
             controlsView.addView(shareButton, LayoutHelper.createFrame(56, 48, Gravity.RIGHT | Gravity.TOP));
+            shareButton.setContentDescription(LocaleController.getString(R.string.ShareFile));
             shareButton.setOnClickListener(v -> {
                 if (delegate != null) {
                     delegate.onSharePressed();
@@ -1874,11 +1877,14 @@ public class WebPlayerView extends ViewGroup implements VideoPlayer.VideoPlayerD
         if (!videoPlayer.isPlaying()) {
             if (isCompleted) {
                 playButton.setImageResource(isInline ? R.drawable.ic_againinline : R.drawable.ic_again);
+                playButton.setContentDescription(LocaleController.getString(R.string.AccActionPlay));
             } else {
                 playButton.setImageResource(isInline ? R.drawable.ic_playinline : R.drawable.ic_play);
+                playButton.setContentDescription(LocaleController.getString(R.string.AccActionPlay));
             }
         } else {
             playButton.setImageResource(isInline ? R.drawable.ic_pauseinline : R.drawable.ic_pause);
+            playButton.setContentDescription(LocaleController.getString(R.string.AccActionPause));
             AndroidUtilities.runOnUIThread(progressRunnable, 500);
             checkAudioFocus();
         }
@@ -1931,9 +1937,11 @@ public class WebPlayerView extends ViewGroup implements VideoPlayer.VideoPlayerD
         fullscreenButton.setVisibility(VISIBLE);
         if (!inFullscreen) {
             fullscreenButton.setImageResource(R.drawable.ic_gofullscreen);
+            fullscreenButton.setContentDescription(LocaleController.getString(R.string.AccSwitchToFullscreen));
             fullscreenButton.setLayoutParams(LayoutHelper.createFrame(56, 56, Gravity.RIGHT | Gravity.BOTTOM, 0, 0, 0, 5));
         } else {
             fullscreenButton.setImageResource(R.drawable.ic_outfullscreen);
+            fullscreenButton.setContentDescription(LocaleController.getString(R.string.AccExitFullscreen));
             fullscreenButton.setLayoutParams(LayoutHelper.createFrame(56, 56, Gravity.RIGHT | Gravity.BOTTOM, 0, 0, 0, 1));
         }
     }
@@ -1958,6 +1966,7 @@ public class WebPlayerView extends ViewGroup implements VideoPlayer.VideoPlayerD
             return;
         }
         inlineButton.setImageResource(isInline ? R.drawable.ic_goinline : R.drawable.ic_outinline);
+        inlineButton.setContentDescription(LocaleController.getString(R.string.AccDescrPipMode));
         inlineButton.setVisibility(videoPlayer.isPlayerPrepared() ? VISIBLE : GONE);
         if (isInline) {
             inlineButton.setLayoutParams(LayoutHelper.createFrame(40, 40, Gravity.RIGHT | Gravity.TOP));

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/emojiview/FoundStickerPacksHeaderCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/emojiview/FoundStickerPacksHeaderCell.java
@@ -52,6 +52,7 @@ public class FoundStickerPacksHeaderCell extends FrameLayout implements Theme.Co
     }
 
     public void setOnBackClickListener(OnClickListener listener) {
+        backButton.setContentDescription(LocaleController.getString(R.string.Back));
         backButton.setOnClickListener(listener);
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/sheets/PollStatisticsBottomSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/poll/sheets/PollStatisticsBottomSheet.java
@@ -42,7 +42,7 @@ public class PollStatisticsBottomSheet extends BottomSheetWithRecyclerListView {
         recyclerListView.setSections(true);
 
         ActionBarMenu m = actionBar.createMenu();
-        m.addItem(-1, R.drawable.ic_close_white);
+        m.addItem(-1, R.drawable.ic_close_white).setContentDescription(LocaleController.getString(R.string.Close));
         m.setTranslationX(-dp(5));
 
         adapter.update(false);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/voip/GroupCallRenderersContainer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/voip/GroupCallRenderersContainer.java
@@ -198,6 +198,7 @@ public class GroupCallRenderersContainer extends FrameLayout {
         addView(rightShadowView, LayoutHelper.createFrame(160, LayoutHelper.MATCH_PARENT, Gravity.RIGHT));
 
         addView(backButton, LayoutHelper.createFrame(56, LayoutHelper.MATCH_PARENT, Gravity.LEFT | Gravity.TOP));
+        backButton.setContentDescription(LocaleController.getString(R.string.Back));
         backButton.setOnClickListener(view -> onBackPressed());
 
         pinButton = new ImageView(context) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/voip/PrivateVideoPreviewDialog.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/voip/PrivateVideoPreviewDialog.java
@@ -283,6 +283,7 @@ public abstract class PrivateVideoPreviewDialog extends FrameLayout implements V
             micIconView.setScaleType(ImageView.ScaleType.FIT_CENTER);
             micEnabled = true;
             micIcon.setCurrentFrame(micEnabled ? 69 : 36);
+            micIconView.setContentDescription(LocaleController.getString(R.string.VoipMute));
             micIconView.setOnClickListener(v -> {
                 micEnabled = !micEnabled;
                 if (micEnabled) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/voip/RTMPStreamPipOverlay.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/voip/RTMPStreamPipOverlay.java
@@ -1,5 +1,7 @@
 package org.telegram.ui.Components.voip;
 
+import org.telegram.messenger.LocaleController;
+
 import static android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE;
 
 import android.animation.Animator;
@@ -606,6 +608,7 @@ public class RTMPStreamPipOverlay implements NotificationCenter.NotificationCent
 
         ImageView closeButton = new ImageView(context);
         closeButton.setImageResource(R.drawable.pip_video_close);
+        closeButton.setContentDescription(LocaleController.getString(R.string.Close));
         closeButton.setColorFilter(Theme.getColor(Theme.key_voipgroup_actionBarItems));
         closeButton.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_listSelector)));
         closeButton.setPadding(padding, padding, padding, padding);
@@ -614,6 +617,7 @@ public class RTMPStreamPipOverlay implements NotificationCenter.NotificationCent
 
         ImageView expandButton = new ImageView(context);
         expandButton.setImageResource(R.drawable.pip_video_expand);
+        expandButton.setContentDescription(LocaleController.getString(R.string.AccExitFullscreen));
         expandButton.setColorFilter(Theme.getColor(Theme.key_voipgroup_actionBarItems));
         expandButton.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_listSelector)));
         expandButton.setPadding(padding, padding, padding, padding);

--- a/TMessagesProj/src/main/java/org/telegram/ui/ContactsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ContactsActivity.java
@@ -309,6 +309,7 @@ public class ContactsActivity extends BaseFragment implements FactorAnimator.Tar
             actionModeCloseView.setImageDrawable(new BackDrawable(true));
             actionModeCloseView.setColorFilter(new PorterDuffColorFilter(getThemedColor(Theme.key_actionBarActionModeDefaultIcon), PorterDuff.Mode.MULTIPLY));
             actionModeCloseView.setBackground(Theme.createSelectorDrawable(getThemedColor(Theme.key_actionBarActionModeDefaultSelector)));
+            actionModeCloseView.setContentDescription(LocaleController.getString(R.string.Close));
             actionModeCloseView.setOnClickListener(v -> hideActionMode());
             actionMode.addView(actionModeCloseView, LayoutHelper.createLinear(54, 54, Gravity.CENTER_VERTICAL));
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/CreateGroupCallSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/CreateGroupCallSheet.java
@@ -1,5 +1,7 @@
 package org.telegram.ui;
 
+import org.telegram.messenger.LocaleController;
+
 import static org.telegram.messenger.AndroidUtilities.dp;
 import static org.telegram.messenger.LocaleController.getString;
 import static org.telegram.messenger.MessagesController.findUpdates;
@@ -79,6 +81,7 @@ public class CreateGroupCallSheet extends BottomSheetWithRecyclerListView {
         closeButton.setColorFilter(new PorterDuffColorFilter(0xFF848D94, PorterDuff.Mode.SRC_IN));
         topView.addView(closeButton, LayoutHelper.createFrame(24, 24, Gravity.RIGHT | Gravity.TOP, 0, 14, 14, 0));
         ScaleStateListAnimator.apply(closeButton);
+        closeButton.setContentDescription(LocaleController.getString(R.string.Close));
         closeButton.setOnClickListener(v -> dismiss());
 
         final FrameLayout imageBackgroundView = new FrameLayout(context);

--- a/TMessagesProj/src/main/java/org/telegram/ui/DebugRecordingCanvasReplayFragment.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DebugRecordingCanvasReplayFragment.java
@@ -1,5 +1,8 @@
 package org.telegram.ui;
 
+import org.telegram.messenger.LocaleController;
+import org.telegram.messenger.R;
+
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -85,6 +88,7 @@ public class DebugRecordingCanvasReplayFragment extends BaseFragment {
         playButton = new ImageButton(context);
         updatePlayButtonIcon();
         playButton.setBackgroundColor(Color.TRANSPARENT);
+        playButton.setContentDescription(LocaleController.getString(R.string.AccActionPlay));
         playButton.setOnClickListener(v -> togglePlayback());
 
         // SeekBar

--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -3296,6 +3296,7 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
         fragmentSearchField.setPivotY(0);
         if (initialDialogsType == DIALOGS_TYPE_DEFAULT) {
             speedItem = menu.addItem(-47, R.drawable.avd_speed);
+            speedItem.setContentDescription(LocaleController.getString(R.string.Speed));
             AndroidUtilities.removeFromParent(speedItem);
             speedItem.setOnClickListener(v -> showDialog(new PremiumFeatureBottomSheet(DialogsActivity.this, PremiumPreviewFragment.PREMIUM_FEATURE_DOWNLOAD_SPEED, true)));
 
@@ -6727,6 +6728,7 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
             actionModeCloseView.setImageDrawable(new BackDrawable(true));
             actionModeCloseView.setColorFilter(new PorterDuffColorFilter(getThemedColor(Theme.key_actionBarActionModeDefaultIcon), PorterDuff.Mode.MULTIPLY));
             actionModeCloseView.setBackground(Theme.createSelectorDrawable(getThemedColor(Theme.key_actionBarActionModeDefaultSelector)));
+            actionModeCloseView.setContentDescription(LocaleController.getString(R.string.Close));
             actionModeCloseView.setOnClickListener(v -> hideActionMode(true));
             actionMode.addView(actionModeCloseView, LayoutHelper.createLinear(54, 54, Gravity.CENTER_VERTICAL));
             actionModeViews.add(actionModeCloseView);

--- a/TMessagesProj/src/main/java/org/telegram/ui/FilterCreateActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/FilterCreateActivity.java
@@ -2690,6 +2690,7 @@ public class FilterCreateActivity extends BaseFragment {
                 closeImageView.setScaleType(ImageView.ScaleType.CENTER);
                 closeImageView.setImageResource(R.drawable.msg_close);
                 closeImageView.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_windowBackgroundWhiteGrayText5), PorterDuff.Mode.MULTIPLY));
+                closeImageView.setContentDescription(LocaleController.getString(R.string.Close));
                 closeImageView.setOnClickListener(e -> dismiss());
                 addView(closeImageView, LayoutHelper.createFrame(48, 48, Gravity.RIGHT | Gravity.TOP, 0, -4, 2, 0));
             }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Gifts/GiftMessageBottomSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Gifts/GiftMessageBottomSheet.java
@@ -452,6 +452,7 @@ public class GiftMessageBottomSheet extends BottomSheet {
         closeButton.setBackground(Blur3Utils.wrapCenteredDrawable(
             Theme.createServiceDrawable(AndroidUtilities.dp(16), closeButton, containerView, getThemedPaint(Theme.key_paint_chatActionBackground)),
             dp(32), dp(32)));
+        closeButton.setContentDescription(LocaleController.getString(R.string.Close));
         closeButton.setOnClickListener(v -> dismiss());
         containerView.addView(closeButton, LayoutHelper.createFrame(56, 56, Gravity.TOP | Gravity.RIGHT));
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Gifts/ProfileGiftsContainer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Gifts/ProfileGiftsContainer.java
@@ -2173,6 +2173,7 @@ public class ProfileGiftsContainer extends FrameLayout implements NotificationCe
 
             final ActionBarMenu menu = actionBar.createMenu();
             final ActionBarMenuItem other = menu.addItem(1, R.drawable.ic_ab_other);
+        other.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
             actionBar.setActionBarMenuOnItemClick(new ActionBar.ActionBarMenuOnItemClick() {
                 @Override
                 public void onItemClick(int id) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/GroupCallActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/GroupCallActivity.java
@@ -5514,6 +5514,7 @@ public class GroupCallActivity extends BottomSheet implements NotificationCenter
         callMessageHideButton.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_graySectionText, resourcesProvider), PorterDuff.Mode.MULTIPLY));
         callMessageHideButton.setScaleType(ImageView.ScaleType.CENTER);
         callMessageHideButton.setImageResource(R.drawable.arrow_more);
+        callMessageHideButton.setContentDescription(LocaleController.getString(R.string.AccDescrCollapsePanel));
         callMessageHideButton.setOnClickListener(v -> hideKeyboardOrEmojiView());
 
         callMessageSendButton = new ImageView(context);
@@ -5521,6 +5522,7 @@ public class GroupCallActivity extends BottomSheet implements NotificationCenter
         callMessageSendButton.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_windowBackgroundWhiteBlueIcon, resourcesProvider), PorterDuff.Mode.MULTIPLY));
         callMessageSendButton.setScaleType(ImageView.ScaleType.CENTER);
         callMessageSendButton.setImageResource(R.drawable.ic_send);
+        callMessageSendButton.setContentDescription(LocaleController.getString(R.string.Send));
         callMessageSendButton.setOnClickListener(v -> {
             CharSequence text = callMessageEnterView.getText();
             TLRPC.TL_textWithEntities toSend = new TLRPC.TL_textWithEntities();

--- a/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
@@ -767,6 +767,7 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
 
         proxyButtonView = new ImageView(context);
         proxyButtonView.setImageDrawable(proxyDrawable = new ProxyDrawable(context));
+        proxyButtonView.setContentDescription(LocaleController.getString(R.string.Proxy));
         proxyButtonView.setOnClickListener(v -> presentFragment(new ProxyListActivity()));
         proxyButtonView.setAlpha(0f);
         proxyButtonView.setVisibility(View.GONE);
@@ -7440,6 +7441,7 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
                     passwordButton = new ImageView(context);
                     passwordButton.setImageResource(R.drawable.msg_message);
                     AndroidUtilities.updateViewVisibilityAnimated(passwordButton, true, 0.1f, false);
+                    passwordButton.setContentDescription(LocaleController.getString(R.string.SettingsHelp));
                     passwordButton.setOnClickListener(v -> {
                         isPasswordVisible = !isPasswordVisible;
 
@@ -9879,6 +9881,7 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
 
             cells[2].setSubtitle(premium_days == 7 ? getString(R.string.SMSFee3Text) : formatPluralStringComma("SMSFee3TextDays", premium_days));
 
+            optionsButton.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
             optionsButton.setOnClickListener(v -> {
                 ItemOptions.makeOptions(LoginActivity.this, optionsButton)
                     .add(R.drawable.msg_help, getString(R.string.SettingsHelp), () -> {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ManageLinksActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ManageLinksActivity.java
@@ -1075,6 +1075,7 @@ public class ManageLinksActivity extends BaseFragment implements NotificationCen
             optionsView.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_ab_other));
             optionsView.setScaleType(ImageView.ScaleType.CENTER);
             optionsView.setColorFilter(Theme.getColor(Theme.key_stickers_menu));
+            optionsView.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
             optionsView.setOnClickListener(view -> {
                 if (invite == null) {
                     return;

--- a/TMessagesProj/src/main/java/org/telegram/ui/MessageSendPreview.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/MessageSendPreview.java
@@ -1263,6 +1263,7 @@ public class MessageSendPreview extends Dialog implements NotificationCenter.Not
         this.anchorSendButton.copyTo(this.sendButton);
         this.sendButton.open.set(sendButton.open.get(), true);
         this.sendButton.setOnClickListener(onClick);
+        this.sendButton.setContentDescription(anchorSendButton.getContentDescription() != null ? anchorSendButton.getContentDescription() : LocaleController.getString(R.string.Send));
         containerView.addView(this.sendButton, new ViewGroup.LayoutParams(sendButton.getWidth(), sendButton.getHeight()));
         sendButtonWidth = anchorSendButton.width(sendButton.getHeight());
         sendButtonInitialPosition[0] += anchorSendButton.getWidth() - anchorSendButton.width(sendButton.getHeight()) - dp(6);

--- a/TMessagesProj/src/main/java/org/telegram/ui/MessageStatisticActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/MessageStatisticActivity.java
@@ -595,6 +595,7 @@ public class MessageStatisticActivity extends BaseFragment implements Notificati
             ActionBarMenu menu = actionBar.createMenu();
             menu.clearItems();
             ActionBarMenuItem headerItem = menu.addItem(0, R.drawable.ic_ab_other);
+        headerItem.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
             headerItem.addSubItem(1, R.drawable.msg_stats, LocaleController.getString(R.string.ViewChannelStats));
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/PasscodeActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PasscodeActivity.java
@@ -382,6 +382,7 @@ public class PasscodeActivity extends BaseFragment implements NotificationCenter
                     ActionBarMenuSubItem switchItem;
                     if (type == TYPE_SETUP_CODE) {
                         otherItem = menu.addItem(0, R.drawable.ic_ab_other);
+        otherItem.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
                         switchItem = otherItem.addSubItem(ID_SWITCH_TYPE, R.drawable.msg_permissions, LocaleController.getString(R.string.PasscodeSwitchToPassword));
                     } else switchItem = null;
 
@@ -539,6 +540,7 @@ public class PasscodeActivity extends BaseFragment implements NotificationCenter
                     }
                 });
 
+                passwordButton.setContentDescription(LocaleController.getString(R.string.SettingsHelp));
                 passwordButton.setOnClickListener(v -> {
                     isPasswordShown.set(!isPasswordShown.get());
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/PasskeysActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PasskeysActivity.java
@@ -259,6 +259,7 @@ public class PasskeysActivity extends BaseFragment {
             } else {
                 subtitleView.setText(LocaleController.formatString(R.string.PasskeyCreatedOn, LocaleController.formatDateTime(passkey.date, false)));
             }
+            optionsView.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
             optionsView.setOnClickListener(onOptions);
             setWillNotDraw(!(needDivider = divider));
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/PassportActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PassportActivity.java
@@ -1995,7 +1995,7 @@ public class PassportActivity extends BaseFragment implements NotificationCenter
 
         actionBar.setTitle(LocaleController.getString(R.string.TelegramPassport));
 
-        actionBar.createMenu().addItem(info_item, R.drawable.msg_info);
+        actionBar.createMenu().addItem(info_item, R.drawable.msg_info).setContentDescription(LocaleController.getString(R.string.Info));
 
         if (botUser != null) {
             FrameLayout avatarContainer = new FrameLayout(context);
@@ -2425,7 +2425,7 @@ public class PassportActivity extends BaseFragment implements NotificationCenter
 
         actionBar.setTitle(LocaleController.getString(R.string.TelegramPassport));
 
-        actionBar.createMenu().addItem(info_item, R.drawable.msg_info);
+        actionBar.createMenu().addItem(info_item, R.drawable.msg_info).setContentDescription(LocaleController.getString(R.string.Info));
 
         headerCell = new HeaderCell(context);
         headerCell.setText(LocaleController.getString(R.string.PassportProvidedInformation));

--- a/TMessagesProj/src/main/java/org/telegram/ui/PeerColorActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PeerColorActivity.java
@@ -1623,6 +1623,7 @@ public class PeerColorActivity extends BaseFragment implements NotificationCente
         backButton.setBackground(Theme.createSelectorDrawable(getThemedColor(Theme.key_actionBarWhiteSelector), Theme.RIPPLE_MASK_CIRCLE_20DP));
         backButton.setImageResource(R.drawable.ic_ab_back);
         backButton.setColorFilter(new PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN));
+        backButton.setContentDescription(LocaleController.getString(R.string.Back));
         backButton.setOnClickListener(v -> {
             if (onBackPressed(true)) {
                 finishFragment();
@@ -1647,7 +1648,15 @@ public class PeerColorActivity extends BaseFragment implements NotificationCente
         sunDrawable.setLayerColor("Path 5", color);
         sunDrawable.commitApplyLayerColors();
 
-        dayNightItem = new ImageView(context);
+        // which of the two themes pressing this would take you to, asked each time rather than
+        // settled once: a name fixed when it was made would be wrong for half the life of it
+        dayNightItem = new ImageView(context) {
+            @Override
+            public void onInitializeAccessibilityNodeInfo(android.view.accessibility.AccessibilityNodeInfo info) {
+                super.onInitializeAccessibilityNodeInfo(info);
+                info.setText(LocaleController.getString(isDark ? R.string.AccDescrSwitchToDayTheme : R.string.AccDescrSwitchToNightTheme));
+            }
+        };
         dayNightItem.setScaleType(ImageView.ScaleType.CENTER);
         dayNightItem.setBackground(Theme.createSelectorDrawable(getThemedColor(Theme.key_actionBarWhiteSelector), Theme.RIPPLE_MASK_CIRCLE_20DP));
         dayNightItem.setColorFilter(new PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN));

--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoPickerActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoPickerActivity.java
@@ -521,6 +521,7 @@ public class PhotoPickerActivity extends BaseFragment implements NotificationCen
         if (isDocumentsPicker) {
             ActionBarMenu menu = actionBar.createMenu();
             ActionBarMenuItem menuItem = menu.addItem(0, R.drawable.ic_ab_other);
+            menuItem.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
             menuItem.setSubMenuDelegate(new ActionBarMenuItem.ActionBarSubMenuItemDelegate() {
                 @Override
                 public void onShowSubMenu() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
@@ -14043,6 +14043,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
             videoTimelineView.setAlpha(1.0f);
         }
         muteDrawable.setMuted(false, false);
+        muteButton.setContentDescription(LocaleController.getString(R.string.Sound));
         editorDoneLayout.setVisibility(View.GONE);
         captionTextViewSwitcher.setTag(null);
         captionTextViewSwitcher.setVisibility(View.INVISIBLE);
@@ -21202,11 +21203,11 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
                     videoTimelineView.setMaxProgressDiff(1.0f);
                     videoTimelineView.setMode(VideoTimelinePlayView.MODE_VIDEO);
                 }
-//                muteItem.setContentDescription(getString("NoSound", R.string.NoSound));
+                muteButton.setContentDescription(LocaleController.getString(R.string.NoSound));
             } else {
                 actionBarContainer.setSubtitle(currentSubtitle);
                 muteDrawable.setMuted(false, true);
-//                muteItem.setContentDescription(getString("Sound", R.string.Sound));
+                muteButton.setContentDescription(LocaleController.getString(R.string.Sound));
                 if (compressItem.getTag() != null) {
                     compressItem.setAlpha(1.0f);
                     compressItem.setEnabled(true);

--- a/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
@@ -9955,6 +9955,7 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
         if (menu.getItem(10) == null) {
             if (animatingItem == null) {
                 animatingItem = menu.addItem(10, R.drawable.ic_ab_other);
+            animatingItem.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
             }
         }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/QrActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/QrActivity.java
@@ -1,5 +1,7 @@
 package org.telegram.ui;
 
+import org.telegram.messenger.LocaleController;
+
 import static org.telegram.messenger.AndroidUtilities.dp;
 import static org.telegram.messenger.LocaleController.getString;
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/ReportBottomSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ReportBottomSheet.java
@@ -714,6 +714,7 @@ public class ReportBottomSheet extends BottomSheet {
                 btnBack.setImageDrawable(backDrawable = new BackDrawable(false));
                 backDrawable.setColor(0xffffffff);
                 addView(btnBack, LayoutHelper.createFrame(24, 24, Gravity.TOP | (LocaleController.isRTL ? Gravity.RIGHT : Gravity.LEFT), 16, 16, 16, 0));
+                btnBack.setContentDescription(LocaleController.getString(R.string.Back));
                 btnBack.setOnClickListener(e -> {
                     if (onBackClickListener != null) {
                         onBackClickListener.run();

--- a/TMessagesProj/src/main/java/org/telegram/ui/SelectAnimatedEmojiDialog.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SelectAnimatedEmojiDialog.java
@@ -5302,6 +5302,7 @@ public class SelectAnimatedEmojiDialog extends FrameLayout implements Notificati
             });
             clear.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_listSelector, resourcesProvider), Theme.RIPPLE_MASK_CIRCLE_20DP, AndroidUtilities.dp(15)));
             clear.setAlpha(0f);
+            clear.setContentDescription(LocaleController.getString(R.string.ClearButton));
             clear.setOnClickListener(e -> {
                 input.setText("");
                 search(null, true, false);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stars/MessageSuggestionOfferSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stars/MessageSuggestionOfferSheet.java
@@ -174,6 +174,7 @@ public class MessageSuggestionOfferSheet extends BottomSheet {
         closeView.setImageResource(R.drawable.ic_close_white);
         closeView.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_dialogEmptyImage, resourcesProvider), PorterDuff.Mode.SRC_IN));
         ScaleStateListAnimator.apply(closeView);
+        closeView.setContentDescription(LocaleController.getString(R.string.Close));
         closeView.setOnClickListener(v -> dismiss());
         headerLayout.addView(closeView, LayoutHelper.createLinear(48, 48, 0, Gravity.CENTER_VERTICAL | Gravity.RIGHT, 0, 0, 6, 0));
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stars/StarGiftPreviewSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stars/StarGiftPreviewSheet.java
@@ -328,6 +328,7 @@ public class StarGiftPreviewSheet extends BottomSheetWithRecyclerListView {
         backButton.setBackground(Theme.createRadSelectorDrawable(0, 0x10FFFFFF, 16, 16));
         backButton.setImageResource(R.drawable.ic_ab_back);
         backButton.setScaleType(ImageView.ScaleType.CENTER);
+        backButton.setContentDescription(LocaleController.getString(R.string.Back));
         backButton.setOnClickListener(v -> dismiss());
         ScaleStateListAnimator.apply(backButton);
         headerView.addView(backButton, LayoutHelper.createFrame(32, 32, Gravity.TOP | Gravity.LEFT, 12, 14, 0, 0));
@@ -335,6 +336,7 @@ public class StarGiftPreviewSheet extends BottomSheetWithRecyclerListView {
         headerPlay = new ImageView(context);
         headerPlay.setBackground(Theme.createRadSelectorDrawable(0, 0x10FFFFFF, 16, 16));
         headerPlay.setImageResource(R.drawable.filled_gift_pause_24);
+        headerPlay.setContentDescription(LocaleController.getString(R.string.AccActionPause));
         headerPlay.setScaleType(ImageView.ScaleType.CENTER);
         headerPlay.setOnClickListener(v -> {
             // AndroidUtilities.dumpCanvas(container);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stars/StarGiftSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stars/StarGiftSheet.java
@@ -2237,6 +2237,7 @@ public class StarGiftSheet extends BottomSheetWithRecyclerListView implements No
             closeView.setImageResource(R.drawable.msg_close);
             ScaleStateListAnimator.apply(closeView);
             addView(closeView, LayoutHelper.createFrame(28, 28, Gravity.RIGHT | Gravity.TOP, 0, 12, 12, 0));
+            closeView.setContentDescription(LocaleController.getString(R.string.Close));
             closeView.setOnClickListener(v -> dismiss.run());
             closeView.setVisibility(View.GONE);
 //            addView(resellPriceView, LayoutHelper.createFrame(LayoutHelper.WRAP_CONTENT, 24, Gravity.LEFT | Gravity.TOP, 12, 14, 0, 0));
@@ -2248,6 +2249,7 @@ public class StarGiftSheet extends BottomSheetWithRecyclerListView implements No
             ScaleStateListAnimator.apply(craftView);
             if (onCraftClick != null) {
                 addView(craftView, LayoutHelper.createFrame(42, 42, Gravity.TOP | Gravity.RIGHT, 0, 5, 5 + 42, 0));
+                craftView.setContentDescription(LocaleController.getString(R.string.GiftCraft));
                 craftView.setOnClickListener(onCraftClick);
             }
             craftView.setVisibility(View.GONE);
@@ -4333,6 +4335,7 @@ public class StarGiftSheet extends BottomSheetWithRecyclerListView implements No
                 deleteView.setImageResource(R.drawable.menu_delete_old);
                 deleteView.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_featuredStickers_addButton, resourcesProvider), PorterDuff.Mode.SRC_IN));
                 ScaleStateListAnimator.apply(deleteView);
+                deleteView.setContentDescription(LocaleController.getString(R.string.Delete));
                 deleteView.setOnClickListener(v -> {
                     showDeleteDescriptionAlert(detailsText);
                 });
@@ -8648,6 +8651,7 @@ public class StarGiftSheet extends BottomSheetWithRecyclerListView implements No
             helpButton.setImageResource(R.drawable.outline_question_mark);
             helpButton.setBackground(new RoundRectStrokeDrawable(dp(24), Theme.multAlpha(0xFFFFFFFF, 0.08f)));
             buttonsLayout.addView(helpButton, LayoutHelper.createFrame(32, 32, Gravity.TOP | Gravity.LEFT, 14, 14, 14, 14));
+            helpButton.setContentDescription(LocaleController.getString(R.string.SettingsHelp));
             helpButton.setOnClickListener(v -> {
                 if (buttonsLayout.getAlpha() < 1) return;
                 onClose.run();
@@ -8658,6 +8662,7 @@ public class StarGiftSheet extends BottomSheetWithRecyclerListView implements No
             closeButton.setImageResource(R.drawable.msg_close);
             closeButton.setBackground(new RoundRectStrokeDrawable(dp(24), Theme.multAlpha(0xFFFFFFFF, 0.08f)));
             buttonsLayout.addView(closeButton, LayoutHelper.createFrame(32, 32, Gravity.TOP | Gravity.RIGHT, 14, 14, 14, 14));
+            closeButton.setContentDescription(LocaleController.getString(R.string.Close));
             closeButton.setOnClickListener(v -> {
                 if (buttonsLayout.getAlpha() < 1) return;
                 onClose.run();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stars/StarsReactionsSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stars/StarsReactionsSheet.java
@@ -337,6 +337,7 @@ public class StarsReactionsSheet extends BottomSheet implements NotificationCent
         closeView.setImageResource(R.drawable.ic_close_white);
         closeView.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_dialogEmptyImage, resourcesProvider), PorterDuff.Mode.SRC_IN));
         ScaleStateListAnimator.apply(closeView);
+        closeView.setContentDescription(LocaleController.getString(R.string.Close));
         closeView.setOnClickListener(v -> dismiss());
 
 //        ScaleStateListAnimator.apply(balanceView);

--- a/TMessagesProj/src/main/java/org/telegram/ui/StickersActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/StickersActivity.java
@@ -240,9 +240,9 @@ public class StickersActivity extends BaseFragment implements NotificationCenter
         actionMode.addView(selectedCountTextView, LayoutHelper.createLinear(0, LayoutHelper.MATCH_PARENT, 1.0f, 72, 0, 0, 0));
         selectedCountTextView.setOnTouchListener((v, event) -> true);
 
-        shareMenuItem = actionMode.addItemWithWidth(MENU_SHARE, R.drawable.msg_share, dp(54));
-        archiveMenuItem = actionMode.addItemWithWidth(MENU_ARCHIVE, R.drawable.msg_archive, dp(54));
-        deleteMenuItem = actionMode.addItemWithWidth(MENU_DELETE, R.drawable.msg_delete, dp(54));
+        shareMenuItem = actionMode.addItemWithWidth(MENU_SHARE, R.drawable.msg_share, dp(54), LocaleController.getString(R.string.ShareFile));
+        archiveMenuItem = actionMode.addItemWithWidth(MENU_ARCHIVE, R.drawable.msg_archive, dp(54), LocaleController.getString(R.string.Archive));
+        deleteMenuItem = actionMode.addItemWithWidth(MENU_DELETE, R.drawable.msg_delete, dp(54), LocaleController.getString(R.string.Delete));
 
         if (currentType == TYPE_EMOJIPACKS && frozenEmojiPacks != null) {
             sets = frozenEmojiPacks;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/LiveCommentsView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/LiveCommentsView.java
@@ -432,6 +432,7 @@ public class LiveCommentsView extends FrameLayout implements NotificationCenter.
         arrowButton.setRotation(90.0f);
         arrowButton.setBackground(Theme.createSelectorDrawable(0x40FFFFFF));
 //        addView(arrowButton, LayoutHelper.createFrame(26, 26, Gravity.LEFT | Gravity.BOTTOM, 10, 9, 10, 9));
+        arrowButton.setContentDescription(LocaleController.getString(R.string.Send));
         arrowButton.setOnClickListener(v -> {
             setCollapsed(!collapsed, true);
         });

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/LiveStoryPipOverlay.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/LiveStoryPipOverlay.java
@@ -1,5 +1,7 @@
 package org.telegram.ui.Stories;
 
+import org.telegram.messenger.LocaleController;
+
 import static android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE;
 
 import android.animation.Animator;
@@ -620,6 +622,7 @@ public class LiveStoryPipOverlay implements NotificationCenter.NotificationCente
 
         ImageView closeButton = new ImageView(context);
         closeButton.setImageResource(R.drawable.pip_video_close);
+        closeButton.setContentDescription(LocaleController.getString(R.string.Close));
         closeButton.setColorFilter(Theme.getColor(Theme.key_voipgroup_actionBarItems));
         closeButton.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_listSelector)));
         closeButton.setPadding(padding, padding, padding, padding);
@@ -628,6 +631,7 @@ public class LiveStoryPipOverlay implements NotificationCenter.NotificationCente
 
         ImageView expandButton = new ImageView(context);
         expandButton.setImageResource(R.drawable.pip_video_expand);
+        expandButton.setContentDescription(LocaleController.getString(R.string.AccExitFullscreen));
         expandButton.setColorFilter(Theme.getColor(Theme.key_voipgroup_actionBarItems));
         expandButton.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_listSelector)));
         expandButton.setPadding(padding, padding, padding, padding);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/GalleryListView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/GalleryListView.java
@@ -1526,6 +1526,7 @@ public class GalleryListView extends FrameLayout implements NotificationCenter.N
                 searchButton.setImageResource(R.drawable.outline_header_search);
                 searchButton.setColorFilter(new PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN));
                 searchButton.setBackground(Theme.createSelectorDrawable(436207615));
+                searchButton.setContentDescription(LocaleController.getString(R.string.Search));
                 searchButton.setOnClickListener(view -> openSearch());
                 addView(searchButton, LayoutHelper.createFrame(24, 24, Gravity.RIGHT | Gravity.CENTER_VERTICAL));
             }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/StoryLinkSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/StoryLinkSheet.java
@@ -1,5 +1,7 @@
 package org.telegram.ui.Stories.recorder;
 
+import org.telegram.messenger.LocaleController;
+
 import static org.telegram.messenger.AndroidUtilities.dp;
 import static org.telegram.messenger.LocaleController.getString;
 
@@ -529,6 +531,7 @@ public class StoryLinkSheet extends BottomSheetWithRecyclerListView implements N
                 titleView.setText(titleLoading, animated);
                 messageView.setText(messageLoading, animated);
             }
+            closeView.setContentDescription(LocaleController.getString(R.string.Close));
             closeView.setOnClickListener(onCloseClick);
         }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/ThemePreviewActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ThemePreviewActivity.java
@@ -1070,11 +1070,11 @@ public class ThemePreviewActivity extends BaseFragment implements DownloadContro
                 if (currentWallpaper instanceof WallpapersListActivity.FileWallpaper) {
                     WallpapersListActivity.FileWallpaper fileWallpaper = (WallpapersListActivity.FileWallpaper) currentWallpaper;
                     if (fileWallpaper.originalPath != null) {
-                        menu2.addItem(OPTION_PHOTO_EDIT, R.drawable.msg_header_draw);
+                        menu2.addItem(OPTION_PHOTO_EDIT, R.drawable.msg_header_draw).setContentDescription(LocaleController.getString(R.string.AccDescrPhotoEditor));
                     }
                 }
                 if (dialogId == 0 && (BuildVars.DEBUG_PRIVATE_VERSION && Theme.getActiveTheme().getAccent(false) != null || currentWallpaper instanceof WallpapersListActivity.ColorWallpaper && !Theme.DEFAULT_BACKGROUND_SLUG.equals(((WallpapersListActivity.ColorWallpaper) currentWallpaper).slug) || currentWallpaper instanceof TLRPC.TL_wallPaper)) {
-                    menu2.addItem(5, R.drawable.msg_header_share);
+                    menu2.addItem(5, R.drawable.msg_header_share).setContentDescription(LocaleController.getString(R.string.ShareFile));
                 }
                 if (dialogId != 0 && shouldShowDayNightIcon) {
                     sunDrawable = new RLottieDrawable(R.raw.sun, "" + R.raw.sun, dp(28), dp(28), true, null);

--- a/TMessagesProj/src/main/java/org/telegram/ui/TopicCreateFragment.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/TopicCreateFragment.java
@@ -297,7 +297,7 @@ public class TopicCreateFragment extends BaseFragment {
         if (topicForEdit == null) {
             actionBar.createMenu().addItem(CREATE_ID, LocaleController.getString(R.string.Create));
         } else {
-            actionBar.createMenu().addItem(EDIT_ID, R.drawable.ic_ab_done);
+            actionBar.createMenu().addItem(EDIT_ID, R.drawable.ic_ab_done).setContentDescription(LocaleController.getString(R.string.Done));
         }
         actionBar.setBackgroundColor(getThemedColor(Theme.key_windowBackgroundGray));
         actionBar.setCastShadows(false);

--- a/TMessagesProj/src/main/java/org/telegram/ui/TopicsFragment.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/TopicsFragment.java
@@ -2405,8 +2405,8 @@ public class TopicsFragment extends BaseFragment implements NotificationCenter.N
         actionMode.addView(selectedDialogsCountTextView, LayoutHelper.createLinear(0, LayoutHelper.MATCH_PARENT, 1.0f, 72, 0, 0, 0));
         selectedDialogsCountTextView.setOnTouchListener((v, event) -> true);
 
-        pinItem = actionMode.addItemWithWidth(pin_id, R.drawable.msg_pin, AndroidUtilities.dp(54));
-        unpinItem = actionMode.addItemWithWidth(unpin_id, R.drawable.msg_unpin, AndroidUtilities.dp(54));
+        pinItem = actionMode.addItemWithWidth(pin_id, R.drawable.msg_pin, AndroidUtilities.dp(54), LocaleController.getString(R.string.PinMessage));
+        unpinItem = actionMode.addItemWithWidth(unpin_id, R.drawable.msg_unpin, AndroidUtilities.dp(54), LocaleController.getString(R.string.UnpinMessage));
         muteItem = actionMode.addItemWithWidth(mute_id, R.drawable.msg_mute, AndroidUtilities.dp(54));
         deleteItem = actionMode.addItemWithWidth(delete_id, R.drawable.msg_delete, AndroidUtilities.dp(54), getString(R.string.Delete));
         hideItem = actionMode.addItemWithWidth(hide_id, R.drawable.msg_archive_hide, AndroidUtilities.dp(54), getString(R.string.Hide));

--- a/TMessagesProj/src/main/java/org/telegram/ui/TwoStepVerificationSetupActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/TwoStepVerificationSetupActivity.java
@@ -289,6 +289,7 @@ public class TwoStepVerificationSetupActivity extends BaseFragment {
         if (currentType == TYPE_EMAIL_CONFIRM) {
             ActionBarMenu menu = actionBar.createMenu();
             ActionBarMenuItem item = menu.addItem(0, R.drawable.ic_ab_other);
+            item.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
             item.addSubItem(item_abort, LocaleController.getString(R.string.AbortPasswordMenu));
         }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/VoIPFragment.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/VoIPFragment.java
@@ -1213,6 +1213,7 @@ public class VoIPFragment implements
             if (lockOnScreen) return;
             onBackPressed();
         });
+        addIcon.setContentDescription(LocaleController.getString(R.string.AddContactTitle));
         addIcon.setOnClickListener(v -> {
             if (lockOnScreen) return;
             if (addPeopleSheet != null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/WebviewActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/WebviewActivity.java
@@ -176,9 +176,10 @@ public class WebviewActivity extends BaseFragment {
             }
         });
         ActionBarMenu menu = actionBar.createMenu();
-        progressItem = menu.addItemWithWidth(share, R.drawable.share, AndroidUtilities.dp(54));
+        progressItem = menu.addItemWithWidth(share, R.drawable.share, AndroidUtilities.dp(54), LocaleController.getString(R.string.ShareFile));
         if (type == TYPE_GAME) {
             ActionBarMenuItem menuItem = menu.addItem(0, R.drawable.ic_ab_other);
+        menuItem.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
             menuItem.addSubItem(open_in, R.drawable.msg_openin, LocaleController.getString(R.string.OpenInExternalApp));
 
             actionBar.setTitle(currentGame);

--- a/TMessagesProj/src/main/java/org/telegram/ui/bots/BotAdView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/bots/BotAdView.java
@@ -114,6 +114,7 @@ public class BotAdView extends FrameLayout {
         closeView.setImageResource(R.drawable.msg_close);
         closeView.setScaleType(ImageView.ScaleType.CENTER);
         closeView.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_chat_topPanelClose, resourcesProvider), PorterDuff.Mode.SRC_IN));
+        closeView.setContentDescription(LocaleController.getString(R.string.Close));
         closeView.setOnClickListener(v -> {
 
         });

--- a/TMessagesProj/src/main/java/org/telegram/ui/bots/BotWebViewAttachedSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/bots/BotWebViewAttachedSheet.java
@@ -1013,8 +1013,9 @@ public class BotWebViewAttachedSheet implements NotificationCenter.NotificationC
             }
         }
 
-        menu.addItem(R.id.menu_collapse_bot, R.drawable.arrow_more);
+        menu.addItem(R.id.menu_collapse_bot, R.drawable.arrow_more).setContentDescription(LocaleController.getString(R.string.AccDescrCollapsePanel));
         ActionBarMenuItem otherItem = optionsItem = menu.addItem(0, R.drawable.ic_ab_other);
+        otherItem.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
         otherItem.addSubItem(R.id.menu_open_bot, R.drawable.msg_bot, LocaleController.getString(R.string.BotWebViewOpenBot));
         settingsItem = otherItem.addSubItem(R.id.menu_settings, R.drawable.msg_settings, LocaleController.getString(R.string.BotWebViewSettings));
         settingsItem.setVisibility(View.GONE);

--- a/TMessagesProj/src/main/java/org/telegram/ui/bots/BotWebViewMenuContainer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/bots/BotWebViewMenuContainer.java
@@ -247,6 +247,7 @@ public class BotWebViewMenuContainer extends FrameLayout implements Notification
         if (botCollapseItem == null) {
             ActionBarMenu menu = parentEnterView.getParentFragment().getActionBar().createMenu();
             botCollapseItem = menu.addItem(R.id.menu_collapse_bot, R.drawable.arrow_more);
+        botCollapseItem.setContentDescription(LocaleController.getString(R.string.AccDescrCollapsePanel));
             menu.removeView(botCollapseItem);
             menu.addView(botCollapseItem, 0);
             botCollapseItem.setOnClickListener(v -> {
@@ -258,6 +259,7 @@ public class BotWebViewMenuContainer extends FrameLayout implements Notification
         if (botMenuItem == null) {
             ActionBarMenu menu = parentEnterView.getParentFragment().getActionBar().createMenu();
             botMenuItem = menu.addItem(1000, R.drawable.ic_ab_other);
+        botMenuItem.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
             botMenuItem.setVisibility(GONE);
 
             botMenuItem.addSubItem(R.id.menu_reload_page, R.drawable.msg_retry, LocaleController.getString(R.string.BotWebViewReloadPage));

--- a/TMessagesProj/src/main/java/org/telegram/ui/bots/BotWebViewSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/bots/BotWebViewSheet.java
@@ -1439,7 +1439,7 @@ public class BotWebViewSheet extends Dialog implements NotificationCenter.Notifi
         }
 
         if (onVerifiedAge == null) {
-            menu.addItem(R.id.menu_collapse_bot, R.drawable.arrow_more);
+            menu.addItem(R.id.menu_collapse_bot, R.drawable.arrow_more).setContentDescription(LocaleController.getString(R.string.AccDescrCollapsePanel));
         }
         optionsItem = menu.addItem(0, optionsIcon = new BotFullscreenButtons.OptionsIcon(getContext()));
         optionsItem.setOnClickListener(v -> {

--- a/TMessagesProj/src/main/java/org/telegram/ui/bots/ChannelAffiliateProgramsFragment.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/bots/ChannelAffiliateProgramsFragment.java
@@ -830,6 +830,7 @@ public class ChannelAffiliateProgramsFragment extends GradientHeaderActivity imp
         b.setCustomView(linearLayout);
 
         BottomSheet sheet = b.create();
+        imageView1.setContentDescription(LocaleController.getString(R.string.AccDescrProfilePicture));
         imageView1.setOnClickListener(v -> {
             final BaseFragment lastFragment = LaunchActivity.getSafeLastFragment();
             if (lastFragment != null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/bots/ChatAttachAlertBotWebViewLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/bots/ChatAttachAlertBotWebViewLayout.java
@@ -194,6 +194,7 @@ public class ChatAttachAlertBotWebViewLayout extends ChatAttachAlert.AttachAlert
 
         ActionBarMenu menu = parentAlert.actionBar.createMenu();
         otherItem = menu.addItem(0, R.drawable.ic_ab_other);
+        otherItem.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
         otherItem.addSubItem(R.id.menu_open_bot, R.drawable.msg_bot, LocaleController.getString(R.string.BotWebViewOpenBot));
         settingsItem = otherItem.addSubItem(R.id.menu_settings, R.drawable.msg_settings, LocaleController.getString(R.string.BotWebViewSettings));
         settingsItem.setVisibility(View.GONE);

--- a/TMessagesProj/src/main/java/org/telegram/ui/community/CommunitySheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/community/CommunitySheet.java
@@ -772,9 +772,9 @@ public class CommunitySheet extends BottomSheet implements NotificationCenter.No
             ActionBarMenu menu = actionBar.createMenu();
             menu.setGlassMode(true);
             menu.setTranslationX(-dp(7));
-            menu.addItem(3, R.drawable.outline_header_search);
+            menu.addItem(3, R.drawable.outline_header_search).setContentDescription(LocaleController.getString(R.string.Search));
             if (ChatObject.hasAdminRights(currentCommunity)) {
-                menu.addItem(2, R.drawable.msg_download_settings);
+                menu.addItem(2, R.drawable.msg_download_settings).setContentDescription(LocaleController.getString(R.string.Settings));
             }
 
             ButtonWithCounterView bottomButton = new ButtonWithCounterView(getContext(), resourcesProvider);
@@ -899,7 +899,7 @@ public class CommunitySheet extends BottomSheet implements NotificationCenter.No
             ActionBarMenu menu = actionBar.createMenu();
             menu.setGlassMode(true);
             menu.setTranslationX(-dp(7));
-            menu.addItem(3, R.drawable.outline_header_search);
+            menu.addItem(3, R.drawable.outline_header_search).setContentDescription(LocaleController.getString(R.string.Search));
 
             closeChatToCommunityButton = new ButtonWithCounterView(getContext(), resourcesProvider);
             closeChatToCommunityButton.setRound();

--- a/TMessagesProj/src/main/java/org/telegram/ui/community/cells/CommunityPendingRequestCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/community/cells/CommunityPendingRequestCell.java
@@ -125,6 +125,7 @@ public class CommunityPendingRequestCell extends FrameLayout implements Theme.Co
 
         requesterAvatarView = new BackupImageView(context);
         requesterAvatarView.setRoundRadius(dp(8));
+        requesterAvatarView.setContentDescription(LocaleController.getString(R.string.AccDescrProfilePicture));
         requesterAvatarView.setOnClickListener(v -> {
             if (delegate != null) {
                 delegate.onClickGroupOwner(userDialogId);

--- a/TMessagesProj/src/main/java/org/telegram/ui/iv/RichAIComposeSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/iv/RichAIComposeSheet.java
@@ -86,6 +86,7 @@ public class RichAIComposeSheet extends BottomSheetWithRecyclerListView {
         closeButton.setScaleType(ImageView.ScaleType.CENTER);
         closeButton.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_windowBackgroundWhiteBlackText, resourcesProvider), PorterDuff.Mode.SRC_IN));
         ScaleStateListAnimator.apply(closeButton);
+        closeButton.setContentDescription(LocaleController.getString(R.string.Close));
         closeButton.setOnClickListener(v -> dismiss());
         topView.addView(closeButton, LayoutHelper.createFrame(48, 48, Gravity.RIGHT | Gravity.TOP, 0, 10, 12, 0));
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/iv/RichMediaCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/iv/RichMediaCell.java
@@ -162,6 +162,7 @@ public class RichMediaCell extends RichBlockCell
         addButton = createCircleButton();
         addButton.setImageResource(R.drawable.iv_media_add);
         addView(addButton, LayoutHelper.createFrame(32, 32, Gravity.RIGHT | Gravity.TOP, 12, 12, 12, 12));
+        addButton.setContentDescription(LocaleController.getString(R.string.Add));
         addButton.setOnClickListener(v -> {
             if (delegate != null && currentRow != null) delegate.onAddMedia(currentRow);
         });
@@ -262,6 +263,7 @@ public class RichMediaCell extends RichBlockCell
             AndroidUtilities.updateImageViewImageAnimated(switchModeButton, icon);
         } else {
             switchModeButton.setImageResource(icon);
+        switchModeButton.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
         }
     }
 
@@ -295,6 +297,7 @@ public class RichMediaCell extends RichBlockCell
         while (menuButtons.size() < ms.size()) {
             final ImageView b = createCircleButton();
             b.setImageResource(R.drawable.iv_media_dots);
+        b.setContentDescription(LocaleController.getString(R.string.AccDescrMoreOptions));
             b.setOnClickListener(v -> onMenuClicked(menuButtons.indexOf(v)));
             addView(b, LayoutHelper.createFrame(32, 32, Gravity.LEFT | Gravity.TOP));
             menuButtons.add(b);

--- a/TMessagesProj/src/main/java/org/telegram/ui/web/AddressBarList.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/web/AddressBarList.java
@@ -391,6 +391,7 @@ public class AddressBarList extends FrameLayout {
             }
             listView.adapter.update(true);
         });
+        currentCopyView.setContentDescription(LocaleController.getString(R.string.Copy));
         currentCopyView.setOnClickListener(onCopyClick);
 
         hideCurrent = false;
@@ -573,6 +574,7 @@ public class AddressBarList extends FrameLayout {
             setColors(parent.listBackgroundColor, parent.textColor);
             iconView.setImageResource(type == 0 ? R.drawable.msg_clear_recent : R.drawable.msg_search);
             textView.setText(query);
+            insertView.setContentDescription(LocaleController.getString(R.string.AccDescrInsertIntoSearch));
             insertView.setOnClickListener(onInsertClick);
             setTopBottom(parent.grayBackgroundColor, parent.rippleColor, top, bottom);
             dividerPaint.setColor(Theme.multAlpha(parent.textColor, .1f));

--- a/TMessagesProj/src/main/java/org/telegram/ui/web/WebActionBar.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/web/WebActionBar.java
@@ -343,6 +343,7 @@ public class WebActionBar extends FrameLayout {
         clearButton.setBackground(clearButtonSelector = Theme.createSelectorDrawable(Theme.ACTION_BAR_WHITE_SELECTOR_COLOR));
         clearButton.setVisibility(GONE);
         clearButton.setAlpha(0f);
+        clearButton.setContentDescription(LocaleController.getString(R.string.ClearButton));
         clearButton.setOnClickListener(v -> {
             searchEditText.setText("");
         });

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5038,6 +5038,10 @@
     <string name="AccDescrEditing">Editing</string>
     <string name="AccDescrPasscodeLock">Lock application</string>
     <string name="AccDescrBackspace">Backspace</string>
+    <string name="AccDescrCurvesTool">Curves</string>
+    <string name="AccDescrColorPicker">Color picker</string>
+    <string name="AccDescrFlashlight">Flashlight</string>
+    <string name="AccDescrInsertIntoSearch">Insert into search</string>
     <string name="AccDescrFingerprint">Fingerprint</string>
     <string name="AccDescrPrevious">Previous</string>
     <string name="AccDescrRepeatOff">Repeat, off</string>


### PR DESCRIPTION
## Summary

A button drawn as a picture and nothing else has no name unless it is given one, and a screen reader landing on one can only say "button". A hundred and forty of them across the app were in that state: the buttons that close a sheet, the ones that go back, the ones that empty a search box, the ones that leave the mode where things are being chosen, every "more options", the buttons on a call, the ones on a photo being edited, the ones on a video playing in a corner of the screen, and the rest.

None of this changes what any of them do. Each is given the name of what it already does, taken wherever possible from a word the app already has translated, so that the name arrives in the reader's own language rather than in English. Four had nothing that fitted and are named here for the first time: the curves tool and the colour picker of the photo editor, the flashlight of the code scanner, and the arrow that puts a suggestion into the address bar.

Where a button's name changes with the picture it is showing, the name is set beside the picture wherever that picture is chosen, so that the two cannot come apart: a video's button says play or pause as it is, a sound turned off says so, a theme button names the theme it would switch to.

The picture at the left of the emoji search box is the one that goes the other way. For most of its life it is a magnifying glass that answers no press at all — the box beside it is what opens a search — and it stood there as a button with no name and nothing to do. It steps out of the way now, and comes back only once a search is under way, when it turns into an arrow that empties the box and is a button in earnest.

## Checking it

With TalkBack on, go through the app and stop on the buttons drawn as a picture and nothing else: the one that closes a sheet, the one that goes back, the one that empties a search box, the one that leaves the mode where things are being chosen, every "more options".

Before, each said only "button". Now each says what it does.

Nothing about what any of them does changes. Where a button's name depends on what it is showing — a video's play and pause, a sound turned off, a theme button — the name is set beside the picture, so the two cannot come apart.
