### PR TITLE
Say what a press does where the press has no words

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/CachedMediaLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/CachedMediaLayout.java
@@ -1029,6 +1029,7 @@ public class CachedMediaLayout extends FrameLayout implements NestedSizeNotifier
             checkBox.setDrawBackgroundAsArc(14);
             checkBox.setColor(Theme.key_checkbox, Theme.key_radioBackground, Theme.key_checkboxCheck);
             View checkBoxClickableView = new View(getContext());
+            checkBoxClickableView.setContentDescription(LocaleController.getString(R.string.Select));
             checkBoxClickableView.setOnClickListener(v -> {
                 onCheckBoxPressed();
             });

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/CheckBoxCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/CheckBoxCell.java
@@ -263,6 +263,10 @@ public class CheckBoxCell extends FrameLayout {
                 click1Container.setBackground(Theme.createSelectorDrawable(getThemedColor(Theme.key_listSelector), Theme.RIPPLE_MASK_ALL));
                 addView(click1Container, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT, Gravity.FILL));
             }
+            // it lies over the whole row and opens or closes the rest of the sections. A plain
+            // view has no words of its own, so a reader found a button here that said nothing
+            click1Container.setContentDescription(LocaleController.getString(
+                collapsedState != null && collapsedState ? R.string.PollExpand : R.string.PollCollapse));
             click1Container.setOnClickListener(onTextClick);
         }
 
@@ -276,11 +280,18 @@ public class CheckBoxCell extends FrameLayout {
                 click2Container = new View(getContext());
                 addView(click2Container, LayoutHelper.createFrame(56, LayoutHelper.MATCH_PARENT, LocaleController.isRTL ? Gravity.RIGHT : Gravity.LEFT));
             }
+            // and this one lies over the box at the near edge and ticks the row. Same again
+            click2Container.setContentDescription(LocaleController.getString(R.string.Select));
             click2Container.setOnClickListener(onCheckboxClick);
         }
     }
 
+    // whether the rest of the sections are hidden, kept so the view lying over the row can say
+    // which way pressing it would go
+    private Boolean collapsedState;
+
     public void setCollapsed(Boolean collapsed) {
+        collapsedState = collapsed;
         if (collapsed == null) {
             if (collapsedArrow != null) {
                 removeView(collapsedArrow);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/GroupCallUserCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/GroupCallUserCell.java
@@ -393,6 +393,7 @@ public class GroupCallUserCell extends FrameLayout {
         }
         muteButton.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
         addView(muteButton, LayoutHelper.createFrame(48, LayoutHelper.MATCH_PARENT, (LocaleController.isRTL ? Gravity.LEFT : Gravity.RIGHT) | Gravity.CENTER_VERTICAL, 6, 0, 6, 0));
+        muteButton.setContentDescription(LocaleController.getString(R.string.VoipMute));
         muteButton.setOnClickListener(v -> onMuteClick(GroupCallUserCell.this));
 
         avatarWavesDrawable = new AvatarWavesDrawable(AndroidUtilities.dp(26), AndroidUtilities.dp(29));

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/PhotoAttachPhotoCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/PhotoAttachPhotoCell.java
@@ -644,6 +644,7 @@ public class PhotoAttachPhotoCell extends FrameLayout {
     }
 
     public void setOnCheckClickListener(OnClickListener onCheckClickListener) {
+        checkFrame.setContentDescription(LocaleController.getString(R.string.Select));
         checkFrame.setOnClickListener(onCheckClickListener);
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChannelAdminLogActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChannelAdminLogActivity.java
@@ -1582,6 +1582,7 @@ public class ChannelAdminLogActivity extends BaseFragment implements Notificatio
         searchCalendarButton.setImageResource(R.drawable.msg_calendar);
         searchCalendarButton.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_chat_searchPanelIcons), PorterDuff.Mode.MULTIPLY));
         searchContainer.addView(searchCalendarButton, LayoutHelper.createFrame(48, 48, Gravity.RIGHT | Gravity.TOP));
+        searchCalendarButton.setContentDescription(LocaleController.getString(R.string.Calendar));
         searchCalendarButton.setOnClickListener(view -> {
             if (getParentActivity() == null) {
                 return;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ClearHistoryAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ClearHistoryAlert.java
@@ -103,6 +103,9 @@ public class ClearHistoryAlert extends BottomSheet {
         }
 
         public void setText(CharSequence text) {
+            // the words of this button live in a view beside the one that takes the press,
+            // and that one is kept out of a reader's way, so the press had nothing to say
+            background.setContentDescription(text);
             textView.setText(text);
         }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/GigagroupConvertAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/GigagroupConvertAlert.java
@@ -61,6 +61,9 @@ public class GigagroupConvertAlert extends BottomSheet {
         }
 
         public void setText(CharSequence text) {
+            // the words of this button live in a view beside the one that takes the press,
+            // and that one is kept out of a reader's way, so the press had nothing to say
+            background.setContentDescription(text);
             textView.setText(text);
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ImportingAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ImportingAlert.java
@@ -101,6 +101,9 @@ public class ImportingAlert extends BottomSheet implements NotificationCenter.No
         }
 
         public void setText(CharSequence text) {
+            // the words of this button live in a view beside the one that takes the press,
+            // and that one is kept out of a reader's way, so the press had nothing to say
+            background.setContentDescription(text);
             textView.setText(text);
         }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/JoinCallAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/JoinCallAlert.java
@@ -161,6 +161,9 @@ public class JoinCallAlert extends BottomSheet {
         public void setText(CharSequence text, boolean animated) {
             this.text = text;
             if (!animated) {
+                // the words of this button live in a view beside the one that takes the press,
+                // and that one is kept out of a reader's way, so the press had nothing to say
+                background.setContentDescription(text);
                 textView[0].setText(text);
             } else {
                 textView[1].setText(text);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/JoinCallByUrlAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/JoinCallByUrlAlert.java
@@ -61,6 +61,9 @@ public class JoinCallByUrlAlert extends BottomSheet {
         }
 
         public void setText(CharSequence text) {
+            // the words of this button live in a view beside the one that takes the press,
+            // and that one is kept out of a reader's way, so the press had nothing to say
+            background.setContentDescription(text);
             textView.setText(text);
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ReportAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ReportAlert.java
@@ -62,6 +62,9 @@ public class ReportAlert extends BottomSheet {
         }
 
         public void setText(CharSequence text) {
+            // the words of this button live in a view beside the one that takes the press,
+            // and that one is kept out of a reader's way, so the press had nothing to say
+            background.setContentDescription(text);
             textView.setText(text);
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/NotificationPermissionDialog.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/NotificationPermissionDialog.java
@@ -62,6 +62,8 @@ public class NotificationPermissionDialog extends BottomSheet implements Notific
         block.addView(rLottieImageView, LayoutHelper.createFrame(72, 72, Gravity.CENTER));
         block.addView(counterView = new CounterView(context), LayoutHelper.createFrame(64, 32, Gravity.CENTER_HORIZONTAL | Gravity.TOP, 29, 16, 0, 0));
         counterView.setCount(0);
+        // // nothing but a picture turning: there is no answer here for a reader, and it stood in the way as a button that said nothing
+        block.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
         block.setOnClickListener(e -> {
             if (!rLottieImageView.isPlaying()) {
                 rLottieImageView.setProgress(0);

--- a/TMessagesProj/src/main/java/org/telegram/ui/OAuthSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/OAuthSheet.java
@@ -1,5 +1,7 @@
 package org.telegram.ui;
 
+import org.telegram.messenger.LocaleController;
+
 import static org.telegram.messenger.AndroidUtilities.dp;
 import static org.telegram.messenger.AndroidUtilities.replaceSingleLink;
 import static org.telegram.messenger.AndroidUtilities.replaceSingleLinkBold;
@@ -354,6 +356,7 @@ public class OAuthSheet {
                 }
             }
         }
+        accountSelectorLayout.setContentDescription(LocaleController.getString(R.string.Account));
         accountSelectorLayout.setOnClickListener(v -> {
             ItemOptions i = ItemOptions.makeOptions(sheet.container, sheet.getResourcesProvider(), accountSelectorInnerLayout);
             for (int account : accountNumbers) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoAlbumPickerActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoAlbumPickerActivity.java
@@ -420,6 +420,7 @@ public class PhotoAlbumPickerActivity extends BaseFragment implements Notificati
             });
         }
         writeButtonContainer.addView(writeButton, LayoutHelper.createFrame(Build.VERSION.SDK_INT >= 21 ? 56 : 60, Build.VERSION.SDK_INT >= 21 ? 56 : 60, Gravity.LEFT | Gravity.TOP, Build.VERSION.SDK_INT >= 21 ? 2 : 0, 0, 0, 0));
+        writeButton.setContentDescription(LocaleController.getString(R.string.Send));
         writeButton.setOnClickListener(v -> {
             if (chatActivity != null && chatActivity.isInScheduleMode()) {
                 AlertsCreator.createScheduleDatePickerDialog(getParentActivity(), chatActivity.getDialogId(), (notify, scheduleDate, scheduleRepeatPeriod) -> {

--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoPickerActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoPickerActivity.java
@@ -1065,6 +1065,7 @@ public class PhotoPickerActivity extends BaseFragment implements NotificationCen
                 });
             }
             writeButtonContainer.addView(writeButton, LayoutHelper.createFrame(Build.VERSION.SDK_INT >= 21 ? 56 : 60, Build.VERSION.SDK_INT >= 21 ? 56 : 60, Gravity.LEFT | Gravity.TOP, Build.VERSION.SDK_INT >= 21 ? 2 : 0, 0, 0, 0));
+            writeButton.setContentDescription(LocaleController.getString(R.string.Send));
             writeButton.setOnClickListener(v -> {
                 if (chatActivity != null && chatActivity.isInScheduleMode()) {
                     AlertsCreator.createScheduleDatePickerDialog(getParentActivity(), chatActivity.getDialogId(), (notify, scheduleDate, scheduleRepeatPeriod) -> sendSelectedPhotos(notify, scheduleDate, 0));

--- a/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
@@ -395,6 +395,7 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
 
         avatarContainer = new FrameLayout(context);
         topView.addView(avatarContainer, LayoutHelper.createFrame(120, 120, Gravity.CENTER_HORIZONTAL | Gravity.TOP, 0, 23 - 12, 0, 0));
+        avatarContainer.setContentDescription(LocaleController.getString(R.string.AccDescrChangeProfilePicture));
         avatarContainer.setOnClickListener(v -> {
             TLRPC.User user = MessagesController.getInstance(currentAccount).getUser(UserConfig.getInstance(currentAccount).getClientUserId());
             if (user == null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ThemePreviewActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ThemePreviewActivity.java
@@ -1608,7 +1608,9 @@ public class ThemePreviewActivity extends BaseFragment implements DownloadContro
                     backgroundPlayAnimationView.setAlpha(backgroundGradientColor1 != 0 ? 1.0f : 0.0f);
                     backgroundPlayAnimationView.setTag(backgroundGradientColor1 != 0 ? 1 : null);
                     backgroundButtonsContainer.addView(backgroundPlayAnimationView, LayoutHelper.createFrame(48, 48, Gravity.CENTER));
-                    backgroundPlayAnimationView.setOnClickListener(new View.OnClickListener() {
+                    // // nothing but a picture turning: there is no answer here for a reader, and it stood in the way as a button that said nothing
+        backgroundPlayAnimationView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+        backgroundPlayAnimationView.setOnClickListener(new View.OnClickListener() {
 
                         int rotation = 0;
 
@@ -1773,7 +1775,8 @@ public class ThemePreviewActivity extends BaseFragment implements DownloadContro
                     messagesPlayAnimationView.setScaleY(accent.myMessagesGradientAccentColor1 != 0 ? 1.0f : 0.1f);
                     messagesPlayAnimationView.setAlpha(accent.myMessagesGradientAccentColor1 != 0 ? 1.0f : 0.0f);
                     messagesButtonsContainer.addView(messagesPlayAnimationView, LayoutHelper.createFrame(48, 48, Gravity.CENTER));
-                    messagesPlayAnimationView.setOnClickListener(new View.OnClickListener() {
+                    messagesPlayAnimationView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+        messagesPlayAnimationView.setOnClickListener(new View.OnClickListener() {
 
                         int rotation = 0;
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/WearAuthSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/WearAuthSheet.java
@@ -1,5 +1,7 @@
 package org.telegram.ui;
 
+import org.telegram.messenger.LocaleController;
+
 import static org.telegram.messenger.AndroidUtilities.dp;
 import static org.telegram.messenger.LocaleController.getString;
 
@@ -275,6 +277,7 @@ public class WearAuthSheet {
         sheet.setBackgroundColor(Theme.getColor(Theme.key_windowBackgroundGray, resourcesProvider));
         sheet.fixNavigationBar(Theme.getColor(Theme.key_windowBackgroundGray, resourcesProvider));
 
+        accountSelectorLayout.setContentDescription(LocaleController.getString(R.string.Account));
         accountSelectorLayout.setOnClickListener(v -> {
             ItemOptions i = ItemOptions.makeOptions(sheet.container, sheet.getResourcesProvider(), accountSelectorInnerLayout);
             for (int account : accountNumbers) {


### PR DESCRIPTION
## Summary

Some of the buttons in the app are built with the words in one view and the press in another. A plain view is laid over the place and given the press and the ripple, and the words sit beside it, often taken out of a reader's way on purpose so that the two are not read as one. A screen reader lands on the thing that can be pressed, finds nothing written on it, and says only "button".

The one that joins a voice chat is the clearest of them: the words live in a text view beside the pressable layer, and that text view is told not to be focusable. Five other sheets are built from a copy of the same class, so the same button is silent in all six. Each says what is written on it now, set where the words are set, so the two can never disagree.

The two views lying over a row in the list of what is filling the phone do different things: one opens and closes the rest of the sections, the other takes or leaves everything gathered under "Other". Both are plain views, and both were found and pressed with nothing said about either. They are named now, and the one that opens says which way it would go.

Nine more of the same shape are named for what they do: changing the picture at the top of settings, the calendar in a channel's log, sending what has been picked in both photo pickers, choosing the account on the two sign-in sheets, choosing a row in the list of cached media, ticking a photo in the attach panel, and muting someone in a group call.

Three others do nothing a reader can use: two of them turn a picture by a fraction, and one replays an animation. They step out of the way rather than take a name for something that is not there.

## Checking it

With TalkBack on, open a group with a voice chat already running and press to join it. The sheet asking which account to join as has a button under it.

Before, that button said only "button": its words live in a text view beside the pressable layer, and that text view is told not to be focusable. Now it says what is written on it. Five other sheets built from a copy of the same class behave the same.

In Data and Storage, under Storage Usage, swipe past the "Other" row: the two views lying over it now say which is which — one opens and closes the rest of the sections, the other takes or leaves everything gathered under Other.

The picture at the top of the theme preview and the one in the notification permission sheet no longer stop a reader: pressing them only turns or replays a picture, so there is nothing to name.
