### PR TITLE
Open the options of a sender on an option

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/AvatarPreviewer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/AvatarPreviewer.java
@@ -21,6 +21,8 @@ import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.animation.Interpolator;
@@ -407,6 +409,11 @@ public class AvatarPreviewer {
             iBlur3Factory.setSourceRootView(new ViewPositionWatcher(this), this);
 
             blurView = new View(context);
+            // a sheet of glass over the whole screen that closes the preview when pressed. It
+            // has no words, and being added first it is the first thing a screen reader comes
+            // to: it found nothing to say there, named the window by the app it belongs to, and
+            // stayed. It does close the preview, so it is told what it does rather than hidden
+            blurView.setContentDescription(LocaleController.getString(R.string.Close));
             blurView.setOnClickListener(v -> setShowing(false));
             addView(blurView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT));
 
@@ -591,6 +598,34 @@ public class AvatarPreviewer {
             }
 
             setShowing(true);
+            focusFirstMenuItem();
+        }
+
+        /**
+         * Put a screen reader on the first option once the preview has finished appearing, the
+         * way the menu that opens on a message does. Taking the input focus is what brings a
+         * reader out of the state a new window leaves it in, asking for the reading focus is what
+         * moves it onto the option, and saying so is what gets the option read. Waiting is what
+         * makes it hold: a reader announcing the window of its own accord would otherwise take
+         * the focus back afterwards.
+         */
+        private void focusFirstMenuItem() {
+            if (menu == null || menu.getItemsCount() <= 0) {
+                return;
+            }
+            final View first = menu.getItemAt(0);
+            if (first == null) {
+                return;
+            }
+            first.setFocusableInTouchMode(true);
+            AndroidUtilities.runOnUIThread(() -> {
+                if (!showing) {
+                    return;
+                }
+                first.requestFocus();
+                first.performAccessibilityAction(AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS, null);
+                first.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+            }, 420);
         }
 
         private void setShowing(boolean showing) {


### PR DESCRIPTION
## Summary

Holding the picture of whoever sent a message opens their picture large with a short menu under it. It opens in a window of its own, and the first thing in that window is a sheet of glass laid over the whole screen, there to close the preview when it is pressed. It has no words on it, and it comes before everything else.

So a screen reader arriving at the new window landed on the glass, found nothing written there, named the window by the app it belongs to, and stayed sitting on it. Every option in the menu had to be gone looking for by hand, and what was read out first was meaningless.

The menu that opens on a message has neither problem: it dims what is behind it by painting over it rather than by laying a view on top, so there is no wordless thing in the way, and once it has appeared it puts the reader on its first option.

Both are done here. The glass is told what it does, since pressing it does close the preview and that is worth being able to reach. And the first option takes the focus once the preview has finished appearing, so holding a sender's picture lands on opening their profile, the way holding a message lands on replying.

## Checking it

With TalkBack on, hold the picture of whoever sent a message in a group.

Before, the reader landed on a sheet of glass laid over the whole screen, said the name of the app, and stayed there; the options had to be gone looking for by hand. Now it says what the glass does — it closes the preview — and the focus goes to the first option, so holding a sender's picture lands on opening their profile, the way holding a message lands on replying.
