### PR TITLE
Name the search button before it has been pressed

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBarMenuItem.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBarMenuItem.java
@@ -1278,11 +1278,15 @@ public class ActionBarMenuItem extends FrameLayout {
 
     public void setSearchFieldHint(CharSequence hint) {
         searchFieldHint = hint;
+        // the button is called by the hint of the field it opens, and it can be called that from
+        // the moment the hint is given. The field is not built until the search is opened, and
+        // naming the button was left waiting on the field — so until it had been pressed, which
+        // is the one thing that cannot be done without knowing what it is, it had no name at all
+        setContentDescription(hint);
         if (searchFieldCaption == null) {
             return;
         }
         searchField.setHint(hint);
-        setContentDescription(hint);
     }
 
     public void setSearchFieldText(CharSequence text, boolean animated) {


### PR DESCRIPTION
## Summary

The button that opens a search is called by the hint of the field it opens, and that is set when the screen is built. But the field itself is not built until the search is actually opened, and the naming was left waiting on the field: the hint was remembered, and everything else in the method, the name included, was skipped until there was a field to put a hint on.

So the button had no name until it had been pressed, which is the one thing that cannot be done without knowing what it is. A screen reader found a button at the top of the screen and could say nothing about it.

The name does not depend on the field, so it is given straight away and the rest goes on waiting as before.

Thirty one screens ask for that hint, so thirty one search buttons were silent: settings, contacts, the sticker and language lists, the chats themselves, a channel's log, wallpapers, and the rest.

## Checking it

With TalkBack on, open Settings and swipe onto the search button at the top of the screen.

Before, it had no name. Open the search once and come back, and it had one — which is the whole of the bug: the name was waiting on a field that is not built until the search is opened, so the button was nameless until it had been pressed.

Now it is named from the start. Thirty one screens ask for that hint, so check a few others: contacts, the sticker and language lists, wallpapers.
