### PR TITLE
Take the picture at the top of a screen out of the way

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/TopViewCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/TopViewCell.java
@@ -39,6 +39,10 @@ public class TopViewCell extends LinearLayout implements Theme.Colorable {
         imageView.setOnClickListener(v -> {
             imageView.getImageReceiver().startAnimation();
         });
+        // the picture at the top of the screen plays its animation again when pressed, and that
+        // is the whole of what pressing it does. It has no words and nothing to say, so a screen
+        // reader stopped on it and said nothing; there is no name to give it that would be true
+        imageView.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
         addView(imageView, LayoutHelper.createLinear(90, 90, Gravity.CENTER, 0, 9, 0, 9));
 
         titleView = new LinkSpanDrawable.LinksTextView(context);


### PR DESCRIPTION
## Summary

Several screens open with a large picture that plays a short animation, and pressing it plays the animation again. That is the whole of what pressing it does.

It carries no words, so a screen reader stopped on it and said nothing at all: a button, and no way to know what for. There is no name that would be true of it either, since playing an animation again is nothing a reader can use.

It steps out of the way instead. What is drawn does not change, and the press still works for anyone who can see it.

The cell is the one the generic list builder uses, so this is the picture at the top of the business screens — chat bots, links, opening hours, quick replies, greetings, away messages — and of the settings screens built the same way.

## Checking it

With TalkBack on, open Settings, then Telegram Business, then Chatbots, and swipe from the top of the screen.

Before, the first thing reached was the large picture at the top, which said nothing: pressing it only plays its animation again. Now it steps out of the way and the first thing reached is the heading under it.

The same picture is at the top of the other business screens — links, opening hours, quick replies, greetings, away messages — and of the settings screens built the same way.
