### PR TITLE
Keep tablet split layout in wide multi-window mode

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -940,7 +940,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
                     final int height = MeasureSpec.getSize(heightMeasureSpec);
                     setMeasuredDimension(width, height);
 
-                    if (!AndroidUtilities.isInMultiwindow && (!AndroidUtilities.isSmallTablet() || getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE)) {
+                    if ((!AndroidUtilities.isInMultiwindow || getResources().getConfiguration().screenWidthDp >= 840) && (!AndroidUtilities.isSmallTablet() || getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE)) {
                         tabletFullSize = false;
                         final int leftWidth = AndroidUtilities.getTabletLeftFragmentSize(width, insets.left, insets.right);
                         actionBarLayout.getView().measure(MeasureSpec.makeMeasureSpec(leftWidth, MeasureSpec.EXACTLY), MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY));
@@ -963,7 +963,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
                 protected void onLayout(boolean changed, int l, int t, int r, int b) {
                     final int width = getMeasuredWidth();
                     final int height = getMeasuredHeight();
-                    if (!AndroidUtilities.isInMultiwindow && (!AndroidUtilities.isSmallTablet() || getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE)) {
+                    if ((!AndroidUtilities.isInMultiwindow || getResources().getConfiguration().screenWidthDp >= 840) && (!AndroidUtilities.isSmallTablet() || getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE)) {
                         final int leftWidth = AndroidUtilities.getTabletLeftFragmentSize(width, insets.left, insets.right);
                         actionBarLayout.getView().layout(0, 0, actionBarLayout.getView().getMeasuredWidth(), actionBarLayout.getView().getMeasuredHeight());
                         rightActionBarLayout.getView().layout(leftWidth, 0, leftWidth + rightActionBarLayout.getView().getMeasuredWidth(), rightActionBarLayout.getView().getMeasuredHeight());
@@ -1322,7 +1322,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
             return;
         }
 
-        if (!AndroidUtilities.isInMultiwindow && (!AndroidUtilities.isSmallTablet() || getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE)) {
+        if ((!AndroidUtilities.isInMultiwindow || getResources().getConfiguration().screenWidthDp >= 840) && (!AndroidUtilities.isSmallTablet() || getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE)) {
             tabletFullSize = false;
             List<BaseFragment> fragmentStack = actionBarLayout.getFragmentStack();
             if (fragmentStack.size() >= 2) {


### PR DESCRIPTION
### Summary

Fix tablet split layout in wide multi-window environments such as Samsung DeX.

### Problem

On Samsung tablets using the new DeX mode (Android 16 / One UI 8), Telegram detects the app as running in multi-window mode even when its window is maximized.

`LaunchActivity` currently disables the tablet split layout whenever `AndroidUtilities.isInMultiwindow` is true. As a result, Telegram falls back to a single-pane layout despite having enough screen width for the normal tablet UI.

### Fix

Allow the existing tablet split layout in multi-window mode when `screenWidthDp >= 840`.

Narrow multi-window/floating windows keep the existing single-pane behavior.

### Tested

Tested on:
- Samsung Galaxy Tab S11 Ultra
- Android 16 / One UI 8
- Samsung DeX
- Maximized DeX window

Before the change, Telegram used the single-pane phone layout in DeX.

After the change, the normal two-pane tablet layout works correctly (chat list on the left and content on the right).

The regular tablet layout outside DeX continues to work normally.