### PR TITLE
fix(photos): raise compressed JPEG quality to q92

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/DownloadController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/DownloadController.java
@@ -49,6 +49,8 @@ public class DownloadController extends BaseController implements NotificationCe
     public static final int AUTODOWNLOAD_TYPE_AUDIO = 2;
     public static final int AUTODOWNLOAD_TYPE_VIDEO = 4;
     public static final int AUTODOWNLOAD_TYPE_DOCUMENT = 8;
+    public static final int AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO = 16;
+    public static final int AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO = 32;
 
     public static final int PRESET_NUM_CONTACT = 0;
     public static final int PRESET_NUM_PM = 1;
@@ -59,6 +61,8 @@ public class DownloadController extends BaseController implements NotificationCe
     public static final int PRESET_SIZE_NUM_VIDEO = 1;
     public static final int PRESET_SIZE_NUM_DOCUMENT = 2;
     public static final int PRESET_SIZE_NUM_AUDIO = 3;
+    public static final int PRESET_SIZE_NUM_UNCOMPRESSED_PHOTO = 4;
+    public static final int PRESET_SIZE_NUM_UNCOMPRESSED_VIDEO = 5;
 
     private int lastCheckMask = 0;
     private ArrayList<DownloadObject> photoDownloadQueue = new ArrayList<>();
@@ -86,7 +90,7 @@ public class DownloadController extends BaseController implements NotificationCe
 
     public static class Preset {
         public int[] mask = new int[4];
-        public long[] sizes = new long[4];
+        public long[] sizes = new long[6];
         public boolean preloadVideo;
         public boolean preloadMusic;
         public boolean preloadStories;
@@ -100,6 +104,8 @@ public class DownloadController extends BaseController implements NotificationCe
             sizes[PRESET_SIZE_NUM_VIDEO] = v;
             sizes[PRESET_SIZE_NUM_DOCUMENT] = f;
             sizes[PRESET_SIZE_NUM_AUDIO] = 512 * 1024;
+            sizes[PRESET_SIZE_NUM_UNCOMPRESSED_PHOTO] = f;
+            sizes[PRESET_SIZE_NUM_UNCOMPRESSED_VIDEO] = v;
             preloadVideo = pv;
             preloadMusic = pm;
             lessCallData = l;
@@ -146,6 +152,14 @@ public class DownloadController extends BaseController implements NotificationCe
                         defaultArgs = deafultValue.split("_");
                     }
                     preloadStories = Utilities.parseInt(defaultArgs[13]) == 1;
+                }
+
+                if (args.length >= 16) {
+                    sizes[PRESET_SIZE_NUM_UNCOMPRESSED_PHOTO] = Utilities.parseInt(args[14]);
+                    sizes[PRESET_SIZE_NUM_UNCOMPRESSED_VIDEO] = Utilities.parseInt(args[15]);
+                } else {
+                    sizes[PRESET_SIZE_NUM_UNCOMPRESSED_PHOTO] = sizes[PRESET_SIZE_NUM_DOCUMENT];
+                    sizes[PRESET_SIZE_NUM_UNCOMPRESSED_VIDEO] = sizes[PRESET_SIZE_NUM_VIDEO];
                 }
             }
         }
@@ -202,7 +216,9 @@ public class DownloadController extends BaseController implements NotificationCe
                     "_" + (enabled ? 1 : 0) +
                     "_" + (lessCallData ? 1 : 0) +
                     "_" + maxVideoBitrate +
-                    "_" + (preloadStories ? 1 : 0);
+                    "_" + (preloadStories ? 1 : 0) +
+                    "_" + sizes[PRESET_SIZE_NUM_UNCOMPRESSED_PHOTO] +
+                    "_" + sizes[PRESET_SIZE_NUM_UNCOMPRESSED_VIDEO];
         }
 
         public boolean equals(Preset obj) {
@@ -214,6 +230,8 @@ public class DownloadController extends BaseController implements NotificationCe
                     sizes[1] == obj.sizes[1] &&
                     sizes[2] == obj.sizes[2] &&
                     sizes[3] == obj.sizes[3] &&
+                    sizes[4] == obj.sizes[4] &&
+                    sizes[5] == obj.sizes[5] &&
                     preloadVideo == obj.preloadVideo &&
                     preloadMusic == obj.preloadMusic &&
                     maxVideoBitrate == obj.maxVideoBitrate &&
@@ -444,8 +462,25 @@ public class DownloadController extends BaseController implements NotificationCe
             return PRESET_SIZE_NUM_VIDEO;
         } else if (type == AUTODOWNLOAD_TYPE_DOCUMENT) {
             return PRESET_SIZE_NUM_DOCUMENT;
+        } else if (type == AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO) {
+            return PRESET_SIZE_NUM_UNCOMPRESSED_PHOTO;
+        } else if (type == AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO) {
+            return PRESET_SIZE_NUM_UNCOMPRESSED_VIDEO;
         }
         return PRESET_SIZE_NUM_PHOTO;
+    }
+
+    public static int getDocumentAutoDownloadType(TLRPC.Document document) {
+        if (document == null) {
+            return AUTODOWNLOAD_TYPE_DOCUMENT;
+        }
+        if (document.isUncompressedAutoDownloadPhoto()) {
+            return AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO;
+        }
+        if (document.isUncompressedAutoDownloadVideo()) {
+            return AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO;
+        }
+        return AUTODOWNLOAD_TYPE_DOCUMENT;
     }
 
     public void cleanup() {
@@ -503,6 +538,12 @@ public class DownloadController extends BaseController implements NotificationCe
             if ((masksArray[a] & AUTODOWNLOAD_TYPE_DOCUMENT) != 0) {
                 mask |= AUTODOWNLOAD_TYPE_DOCUMENT;
             }
+            if ((masksArray[a] & AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO) != 0) {
+                mask |= AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO;
+            }
+            if ((masksArray[a] & AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO) != 0) {
+                mask |= AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO;
+            }
             result |= mask << (a * 8);
         }
         return result;
@@ -525,6 +566,12 @@ public class DownloadController extends BaseController implements NotificationCe
             }
             if ((getCurrentMobilePreset().mask[a] & AUTODOWNLOAD_TYPE_DOCUMENT) != 0 || (getCurrentWiFiPreset().mask[a] & AUTODOWNLOAD_TYPE_DOCUMENT) != 0 || (getCurrentRoamingPreset().mask[a] & AUTODOWNLOAD_TYPE_DOCUMENT) != 0) {
                 mask |= AUTODOWNLOAD_TYPE_DOCUMENT;
+            }
+            if ((getCurrentMobilePreset().mask[a] & AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO) != 0 || (getCurrentWiFiPreset().mask[a] & AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO) != 0 || (getCurrentRoamingPreset().mask[a] & AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO) != 0) {
+                mask |= AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO;
+            }
+            if ((getCurrentMobilePreset().mask[a] & AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO) != 0 || (getCurrentWiFiPreset().mask[a] & AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO) != 0 || (getCurrentRoamingPreset().mask[a] & AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO) != 0) {
+                mask |= AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO;
             }
         }
         return mask;
@@ -564,9 +611,10 @@ public class DownloadController extends BaseController implements NotificationCe
             }
             audioDownloadQueue.clear();
         }
-        if ((currentMask & AUTODOWNLOAD_TYPE_DOCUMENT) != 0) {
+        int documentTypes = AUTODOWNLOAD_TYPE_DOCUMENT | AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO | AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO;
+        if ((currentMask & documentTypes) != 0) {
             if (documentDownloadQueue.isEmpty()) {
-                newDownloadObjectsAvailable(AUTODOWNLOAD_TYPE_DOCUMENT);
+                newDownloadObjectsAvailable(currentMask & documentTypes);
             }
         } else {
             for (int a = 0; a < documentDownloadQueue.size(); a++) {
@@ -602,6 +650,12 @@ public class DownloadController extends BaseController implements NotificationCe
             }
             if ((mask & AUTODOWNLOAD_TYPE_DOCUMENT) == 0) {
                 getMessagesStorage().clearDownloadQueue(AUTODOWNLOAD_TYPE_DOCUMENT);
+            }
+            if ((mask & AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO) == 0) {
+                getMessagesStorage().clearDownloadQueue(AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO);
+            }
+            if ((mask & AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO) == 0) {
+                getMessagesStorage().clearDownloadQueue(AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO);
             }
         }
     }
@@ -700,7 +754,7 @@ public class DownloadController extends BaseController implements NotificationCe
         } else if (MessageObject.isPhoto(msg) || MessageObject.isStickerMessage(msg) || MessageObject.isAnimatedStickerMessage(msg)) {
             type = AUTODOWNLOAD_TYPE_PHOTO;
         } else if (MessageObject.getDocument(msg) != null) {
-            type = AUTODOWNLOAD_TYPE_DOCUMENT;
+            type = getDocumentAutoDownloadType(MessageObject.getDocument(msg));
         } else {
             return 0;
         }
@@ -790,7 +844,7 @@ public class DownloadController extends BaseController implements NotificationCe
         } else if (MessageObject.isPhoto(msg) || MessageObject.isStickerMessage(msg) || MessageObject.isAnimatedStickerMessage(msg)) {
             type = AUTODOWNLOAD_TYPE_PHOTO;
         } else if (MessageObject.getDocument(msg) != null) {
-            type = AUTODOWNLOAD_TYPE_DOCUMENT;
+            type = getDocumentAutoDownloadType(MessageObject.getDocument(msg));
         } else {
             return 0;
         }
@@ -871,7 +925,7 @@ public class DownloadController extends BaseController implements NotificationCe
         } else if (MessageObject.isPhoto(message) || MessageObject.isStickerMessage(message) || MessageObject.isAnimatedStickerMessage(message)) {
             type = AUTODOWNLOAD_TYPE_PHOTO;
         } else if (MessageObject.getDocument(message) != null) {
-            type = AUTODOWNLOAD_TYPE_DOCUMENT;
+            type = getDocumentAutoDownloadType(MessageObject.getDocument(message));
         } else {
             return 0;
         }
@@ -953,7 +1007,7 @@ public class DownloadController extends BaseController implements NotificationCe
         } else if (media instanceof TLRPC.TL_messageMediaPhoto) {
             type = AUTODOWNLOAD_TYPE_PHOTO;
         } else if (media.document != null) {
-            type = AUTODOWNLOAD_TYPE_DOCUMENT;
+            type = getDocumentAutoDownloadType(media.document);
         } else {
             return 0;
         }
@@ -1197,8 +1251,16 @@ public class DownloadController extends BaseController implements NotificationCe
         if ((mask & AUTODOWNLOAD_TYPE_VIDEO) != 0 && (downloadMask & AUTODOWNLOAD_TYPE_VIDEO) != 0 && videoDownloadQueue.isEmpty()) {
             getMessagesStorage().getDownloadQueue(AUTODOWNLOAD_TYPE_VIDEO);
         }
-        if ((mask & AUTODOWNLOAD_TYPE_DOCUMENT) != 0 && (downloadMask & AUTODOWNLOAD_TYPE_DOCUMENT) != 0 && documentDownloadQueue.isEmpty()) {
-            getMessagesStorage().getDownloadQueue(AUTODOWNLOAD_TYPE_DOCUMENT);
+        if (documentDownloadQueue.isEmpty()) {
+            if ((mask & AUTODOWNLOAD_TYPE_DOCUMENT) != 0 && (downloadMask & AUTODOWNLOAD_TYPE_DOCUMENT) != 0) {
+                getMessagesStorage().getDownloadQueue(AUTODOWNLOAD_TYPE_DOCUMENT);
+            }
+            if ((mask & AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO) != 0 && (downloadMask & AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO) != 0) {
+                getMessagesStorage().getDownloadQueue(AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO);
+            }
+            if ((mask & AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO) != 0 && (downloadMask & AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO) != 0) {
+                getMessagesStorage().getDownloadQueue(AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO);
+            }
         }
     }
 
@@ -1225,10 +1287,12 @@ public class DownloadController extends BaseController implements NotificationCe
                 if (videoDownloadQueue.isEmpty()) {
                     newDownloadObjectsAvailable(AUTODOWNLOAD_TYPE_VIDEO);
                 }
-            } else if (downloadObject.type == AUTODOWNLOAD_TYPE_DOCUMENT) {
+            } else if (downloadObject.type == AUTODOWNLOAD_TYPE_DOCUMENT
+                    || downloadObject.type == AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO
+                    || downloadObject.type == AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO) {
                 documentDownloadQueue.remove(downloadObject);
                 if (documentDownloadQueue.isEmpty()) {
-                    newDownloadObjectsAvailable(AUTODOWNLOAD_TYPE_DOCUMENT);
+                    newDownloadObjectsAvailable(downloadObject.type);
                 }
             }
         }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
@@ -803,7 +803,7 @@ public class ImageLoader {
                     }
                 }
                 FileOutputStream stream = new FileOutputStream(thumbFile);
-                originalBitmap.compress(Bitmap.CompressFormat.JPEG, info.big ? 83 : 60, stream);
+                originalBitmap.compress(Bitmap.CompressFormat.JPEG, PhotoCompressPolicy.cacheJpegQuality(info.big), stream);
                 try {
                     stream.close();
                 } catch (Exception e) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -805,7 +805,7 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 }
             }
             if (fullPaintPath == null) {
-                TLRPC.PhotoSize size = ImageLoader.scaleAndSaveImage(b, compressFormat, AndroidUtilities.getPhotoSize(highQuality), AndroidUtilities.getPhotoSize(highQuality), highQuality ? 99 : 87, false, 101, 101);
+                TLRPC.PhotoSize size = ImageLoader.scaleAndSaveImage(b, compressFormat, AndroidUtilities.getPhotoSize(highQuality), AndroidUtilities.getPhotoSize(highQuality), PhotoCompressPolicy.chatJpegQuality(highQuality), false, 101, 101);
                 imagePath = FileLoader.getInstance(UserConfig.selectedAccount).getPathToAttach(size, true).toString();
             } else {
                 Bitmap paintBitmap;
@@ -826,7 +826,7 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                     canvas.drawBitmap(paintBitmap, 0, 0, bitmapPaint);
 
                     imagePath = getTempFileAbsolutePath();
-                    resultBitmap.compress(Bitmap.CompressFormat.JPEG, highQuality ? 99 : 87, new FileOutputStream(imagePath));
+                    resultBitmap.compress(Bitmap.CompressFormat.JPEG, PhotoCompressPolicy.chatJpegQuality(highQuality), new FileOutputStream(imagePath));
                 } catch (Exception e) {
                     FileLog.e(e);
                 }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
@@ -4354,7 +4354,7 @@ public class MessagesStorage extends BaseController {
                 return false;
             }
             id = document.id;
-            type = DownloadController.AUTODOWNLOAD_TYPE_DOCUMENT;
+            type = DownloadController.getDocumentAutoDownloadType(document);
         } else if (photo != null) {
             TLRPC.PhotoSize photoSize = FileLoader.getClosestPhotoSizeWithSize(photo.sizes, AndroidUtilities.getPhotoSize());
             if (photoSize != null) {
@@ -12847,7 +12847,7 @@ public class MessagesStorage extends BaseController {
                                 object.flags |= 1;
                             } else if (document != null) {
                                 id = document.id;
-                                type = DownloadController.AUTODOWNLOAD_TYPE_DOCUMENT;
+                                type = DownloadController.getDocumentAutoDownloadType(document);
                                 object = new TLRPC.TL_messageMediaDocument();
                                 object.document = document;
                                 object.flags |= 1;

--- a/TMessagesProj/src/main/java/org/telegram/messenger/PhotoCompressPolicy.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/PhotoCompressPolicy.java
@@ -1,0 +1,23 @@
+package org.telegram.messenger;
+
+/**
+ * JPEG quality / max-side for compressed chat photos.
+ * Isolated so it can be unit-tested without the Android SDK.
+ */
+public final class PhotoCompressPolicy {
+    private PhotoCompressPolicy() {}
+
+    /** Default compressed chat send (MediaController rebuildPhoto / scaleAndSaveImage). */
+    public static int chatJpegQuality(boolean highQuality) {
+        return highQuality ? 99 : 92;
+    }
+
+    /** ImageLoader disk cache of decoded bitmaps. */
+    public static int cacheJpegQuality(boolean big) {
+        return big ? 90 : 60;
+    }
+
+    public static int photoMaxSide(boolean highQuality) {
+        return highQuality ? 2560 : 1280;
+    }
+}

--- a/TMessagesProj/src/main/java/org/telegram/tgnet/TLRPC.java
+++ b/TMessagesProj/src/main/java/org/telegram/tgnet/TLRPC.java
@@ -28441,6 +28441,111 @@ public class TLRPC {
             }
             return result;
         }
+
+        public boolean isUncompressedAutoDownloadPhoto() {
+            return getUncompressedAutoDownloadKind() == 1;
+        }
+
+        public boolean isUncompressedAutoDownloadVideo() {
+            return getUncompressedAutoDownloadKind() == 2;
+        }
+
+        // 0 = none, 1 = photo, 2 = video. Send-as-file only; never stickers/emoji/voice/round/music.
+        public int getUncompressedAutoDownloadKind() {
+            if (attributes != null) {
+                for (int a = 0, N = attributes.size(); a < N; a++) {
+                    DocumentAttribute attribute = attributes.get(a);
+                    if (attribute instanceof TL_documentAttributeSticker
+                            || attribute instanceof TL_documentAttributeCustomEmoji
+                            || attribute instanceof TL_documentAttributeAudio) {
+                        return 0;
+                    }
+                    if (attribute instanceof TL_documentAttributeVideo && attribute.round_message) {
+                        return 0;
+                    }
+                }
+            }
+            String name = file_name_fixed;
+            if (name == null || name.length() == 0) {
+                name = file_name;
+            }
+            if ((name == null || name.length() == 0) && attributes != null) {
+                for (int a = 0, N = attributes.size(); a < N; a++) {
+                    DocumentAttribute attribute = attributes.get(a);
+                    if (attribute instanceof TL_documentAttributeFilename && attribute.file_name != null) {
+                        name = attribute.file_name;
+                        break;
+                    }
+                }
+            }
+            if (name != null) {
+                int dot = name.lastIndexOf('.');
+                if (dot >= 0 && dot < name.length() - 1) {
+                    String ext = name.substring(dot + 1).toLowerCase();
+                    if (isUncompressedImageExtension(ext)) {
+                        return 1;
+                    }
+                    if (isUncompressedVideoExtension(ext)) {
+                        return 2;
+                    }
+                }
+            }
+            if (mime_type != null) {
+                String mime = mime_type.toLowerCase();
+                if (mime.startsWith("image/")) {
+                    return 1;
+                }
+                if (mime.startsWith("video/")) {
+                    return 2;
+                }
+            }
+            return 0;
+        }
+
+        private static boolean isUncompressedImageExtension(String ext) {
+            switch (ext) {
+                case "jpg":
+                case "jpeg":
+                case "jpe":
+                case "png":
+                case "webp":
+                case "heic":
+                case "heif":
+                case "bmp":
+                case "tif":
+                case "tiff":
+                case "gif":
+                case "dng":
+                case "raw":
+                case "jxl":
+                case "avif":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static boolean isUncompressedVideoExtension(String ext) {
+            switch (ext) {
+                case "mp4":
+                case "m4v":
+                case "mov":
+                case "mkv":
+                case "webm":
+                case "avi":
+                case "3gp":
+                case "3gpp":
+                case "mpeg":
+                case "mpg":
+                case "wmv":
+                case "flv":
+                case "ts":
+                case "mts":
+                    return true;
+                default:
+                    return false;
+            }
+        }
     }
 
     public static class TL_document_layer92 extends TL_document {

--- a/TMessagesProj/src/main/java/org/telegram/ui/DataAutoDownloadActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DataAutoDownloadActivity.java
@@ -83,6 +83,10 @@ public class DataAutoDownloadActivity extends BaseFragment {
     @Keep
     private int filesRow;
     @Keep
+    private int uncompressedPhotosRow;
+    @Keep
+    private int uncompressedVideosRow;
+    @Keep
     private int storiesRow;
     private int typeSectionRow;
 
@@ -197,9 +201,9 @@ public class DataAutoDownloadActivity extends BaseFragment {
                 cell.setBackgroundColorAnimated(!checked, Theme.getColor(typePreset.enabled ? Theme.key_windowBackgroundChecked : Theme.key_windowBackgroundUnchecked));
                 updateRows();
                 if (typePreset.enabled) {
-                    listAdapter.notifyItemRangeInserted(autoDownloadSectionRow + 1, 9);
+                    listAdapter.notifyItemRangeInserted(autoDownloadSectionRow + 1, 11);
                 } else {
-                    listAdapter.notifyItemRangeRemoved(autoDownloadSectionRow + 1, 9);
+                    listAdapter.notifyItemRangeRemoved(autoDownloadSectionRow + 1, 11);
                 }
                 listAdapter.notifyItemChanged(autoDownloadSectionRow);
                 SharedPreferences.Editor editor = MessagesController.getMainSettings(currentAccount).edit();
@@ -217,7 +221,7 @@ public class DataAutoDownloadActivity extends BaseFragment {
                 cell.setChecked(!checked);
                 DownloadController.getInstance(currentAccount).checkAutodownloadSettings();
                 wereAnyChanges = true;
-            } else if (position == photosRow || position == videosRow || position == filesRow || position == storiesRow) {
+            } else if (position == photosRow || position == videosRow || position == filesRow || position == uncompressedPhotosRow || position == uncompressedVideosRow || position == storiesRow) {
                 if (!view.isEnabled()) {
                     return;
                 }
@@ -228,6 +232,10 @@ public class DataAutoDownloadActivity extends BaseFragment {
                     type = DownloadController.AUTODOWNLOAD_TYPE_VIDEO;
                 } else if (position == storiesRow) {
                     type = -1;
+                } else if (position == uncompressedPhotosRow) {
+                    type = DownloadController.AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO;
+                } else if (position == uncompressedVideosRow) {
+                    type = DownloadController.AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO;
                 } else {
                     type = DownloadController.AUTODOWNLOAD_TYPE_DOCUMENT;
                 }
@@ -319,6 +327,10 @@ public class DataAutoDownloadActivity extends BaseFragment {
                         headerCell.setText(LocaleController.getString(R.string.AutoDownloadPhotosTitle));
                     } else if (position == videosRow) {
                         headerCell.setText(LocaleController.getString(R.string.AutoDownloadVideosTitle));
+                    } else if (position == uncompressedPhotosRow) {
+                        headerCell.setText(LocaleController.getString(R.string.AutoDownloadUncompressedPhotosTitle));
+                    } else if (position == uncompressedVideosRow) {
+                        headerCell.setText(LocaleController.getString(R.string.AutoDownloadUncompressedVideosTitle));
                     } else {
                         headerCell.setText(LocaleController.getString(R.string.AutoDownloadFilesTitle));
                     }
@@ -381,7 +393,9 @@ public class DataAutoDownloadActivity extends BaseFragment {
                         linearLayout.addView(cells[a], LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 50));
                     }
 
-                    if (position != photosRow) {
+                    boolean showSize = position != photosRow;
+                    boolean showPreload = position == videosRow || position == filesRow;
+                    if (showSize) {
                         TextInfoPrivacyCell infoCell = new TextInfoPrivacyCell(getParentActivity());
 
                         sizeCell[0] = new MaxFileSizeCell(getParentActivity()) {
@@ -417,9 +431,13 @@ public class DataAutoDownloadActivity extends BaseFragment {
                         sizeCell[0].setSize(currentPreset.sizes[index]);
                         linearLayout.addView(sizeCell[0], LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 50));
 
-                        checkCell[0] = new TextCheckCell(getParentActivity(), 21, true);
-                        linearLayout.addView(checkCell[0], LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 48));
-                        checkCell[0].setOnClickListener(v -> checkCell[0].setChecked(!checkCell[0].isChecked()));
+                        if (showPreload) {
+                            checkCell[0] = new TextCheckCell(getParentActivity(), 21, true);
+                            linearLayout.addView(checkCell[0], LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 48));
+                            checkCell[0].setOnClickListener(v -> checkCell[0].setChecked(!checkCell[0].isChecked()));
+                        } else {
+                            checkCell[0] = null;
+                        }
 
                         infoCell.setBackgroundColor(Theme.getColor(Theme.key_windowBackgroundGray));
                         linearLayout.addView(infoCell, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT));
@@ -428,10 +446,13 @@ public class DataAutoDownloadActivity extends BaseFragment {
                             sizeCell[0].setText(LocaleController.getString(R.string.AutoDownloadMaxVideoSize));
                             checkCell[0].setTextAndCheck(LocaleController.getString(R.string.AutoDownloadPreloadVideo), currentPreset.preloadVideo, false);
                             infoCell.setText(LocaleController.formatString("AutoDownloadPreloadVideoInfo", R.string.AutoDownloadPreloadVideoInfo, AndroidUtilities.formatFileSize(currentPreset.sizes[index])));
-                        } else {
+                        } else if (position == filesRow) {
                             sizeCell[0].setText(LocaleController.getString(R.string.AutoDownloadMaxFileSize));
                             checkCell[0].setTextAndCheck(LocaleController.getString(R.string.AutoDownloadPreloadMusic), currentPreset.preloadMusic, false);
                             infoCell.setText(LocaleController.getString(R.string.AutoDownloadPreloadMusicInfo));
+                        } else {
+                            sizeCell[0].setText(LocaleController.getString(R.string.AutoDownloadMaxFileSize));
+                            infoCell.setText(null);
                         }
                     } else {
                         sizeCell[0] = null;
@@ -634,6 +655,8 @@ public class DataAutoDownloadActivity extends BaseFragment {
             photosRow = rowCount++;
             videosRow = rowCount++;
             filesRow = rowCount++;
+            uncompressedPhotosRow = rowCount++;
+            uncompressedVideosRow = rowCount++;
             storiesRow = rowCount++;
             typeSectionRow = rowCount++;
         } else {
@@ -644,6 +667,8 @@ public class DataAutoDownloadActivity extends BaseFragment {
             photosRow = -1;
             videosRow = -1;
             filesRow = -1;
+            uncompressedPhotosRow = -1;
+            uncompressedVideosRow = -1;
             storiesRow = -1;
             typeSectionRow = -1;
         }
@@ -701,6 +726,12 @@ public class DataAutoDownloadActivity extends BaseFragment {
                     } else if (position == videosRow) {
                         text = LocaleController.getString(R.string.AutoDownloadVideos);
                         type = DownloadController.AUTODOWNLOAD_TYPE_VIDEO;
+                    } else if (position == uncompressedPhotosRow) {
+                        text = LocaleController.getString(R.string.AutoDownloadUncompressedPhotos);
+                        type = DownloadController.AUTODOWNLOAD_TYPE_UNCOMPRESSED_PHOTO;
+                    } else if (position == uncompressedVideosRow) {
+                        text = LocaleController.getString(R.string.AutoDownloadUncompressedVideos);
+                        type = DownloadController.AUTODOWNLOAD_TYPE_UNCOMPRESSED_VIDEO;
                     } else if (position == storiesRow) {
                         text = LocaleController.getString(R.string.AutoDownloadStories);
                         type = -1;
@@ -808,7 +839,7 @@ public class DataAutoDownloadActivity extends BaseFragment {
         @Override
         public boolean isEnabled(RecyclerView.ViewHolder holder) {
             int position = holder.getAdapterPosition();
-            return position == photosRow || position == videosRow || position == filesRow || position == storiesRow;
+            return position == photosRow || position == videosRow || position == filesRow || position == uncompressedPhotosRow || position == uncompressedVideosRow || position == storiesRow;
         }
 
         @Override
@@ -856,7 +887,7 @@ public class DataAutoDownloadActivity extends BaseFragment {
                         editor.putInt(key2, currentPresetNum);
                         editor.commit();
                         DownloadController.getInstance(currentAccount).checkAutodownloadSettings();
-                        for (int a = 0; a < 4; a++) {
+                        for (int a = 0; a < 6; a++) {
                             RecyclerView.ViewHolder holder = listView.findViewHolderForAdapterPosition(photosRow + a);
                             if (holder != null) {
                                 listAdapter.onBindViewHolder(holder, photosRow + a);
@@ -889,7 +920,7 @@ public class DataAutoDownloadActivity extends BaseFragment {
                 return 2;
             } else if (position == usageProgressRow) {
                 return 3;
-            } else if (position == photosRow || position == videosRow || position == filesRow || position == storiesRow) {
+            } else if (position == photosRow || position == videosRow || position == filesRow || position == uncompressedPhotosRow || position == uncompressedVideosRow || position == storiesRow) {
                 return 4;
             } else {
                 return 5;

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -2532,10 +2532,14 @@
     <string name="AutoDownloadPhotos">Photos</string>
     <string name="AutoDownloadVideos">Videos</string>
     <string name="AutoDownloadFiles">Files</string>
+    <string name="AutoDownloadUncompressedPhotos">Uncompressed images</string>
+    <string name="AutoDownloadUncompressedVideos">Uncompressed videos</string>
     <string name="AutoDownloadPhotosOn">Photos</string>
     <string name="AutoDownloadVideosOn">Videos</string>
     <string name="AutoDownloadFilesOn">Files</string>
     <string name="AutoDownloadFilesTitle">Auto-download files and music</string>
+    <string name="AutoDownloadUncompressedPhotosTitle">Auto-download uncompressed images sent as files</string>
+    <string name="AutoDownloadUncompressedVideosTitle">Auto-download uncompressed videos sent as files</string>
     <string name="AutoDownloadPhotosTitle">Auto-download photos</string>
     <string name="AutoDownloadVideosTitle">Auto-download videos and GIFs</string>
     <string name="AutoDownloadMaxVideoSize">Maximum video size</string>

--- a/TMessagesProj/src/test/java/org/telegram/messenger/PhotoCompressPolicyTest.java
+++ b/TMessagesProj/src/test/java/org/telegram/messenger/PhotoCompressPolicyTest.java
@@ -1,0 +1,36 @@
+package org.telegram.messenger;
+
+/**
+ * Pure-JVM checks for chat photo JPEG quality. No Android SDK.
+ * Run: javac -d /tmp/pcp ... && java -cp /tmp/pcp org.telegram.messenger.PhotoCompressPolicyTest
+ */
+public final class PhotoCompressPolicyTest {
+    private static int failures;
+
+    public static void main(String[] args) {
+        expectEq("chat jpeg default matches Photos-class JPEG (~q85+), not Bitmap q80/87",
+                92, PhotoCompressPolicy.chatJpegQuality(false));
+        expectEq("high-quality send stays near-lossless",
+                99, PhotoCompressPolicy.chatJpegQuality(true));
+        expectEq("cached big preview is not q83 mush",
+                90, PhotoCompressPolicy.cacheJpegQuality(true));
+        expectEq("tiny thumbs stay cheap",
+                60, PhotoCompressPolicy.cacheJpegQuality(false));
+        expectEq("default photo box is still 1280 (no bigger mush without better encode)",
+                1280, PhotoCompressPolicy.photoMaxSide(false));
+        expectEq("HQ photo box is 2560",
+                2560, PhotoCompressPolicy.photoMaxSide(true));
+        if (failures != 0) {
+            System.err.println(failures + " failed");
+            System.exit(1);
+        }
+        System.out.println("ok");
+    }
+
+    private static void expectEq(String name, int want, int got) {
+        if (want != got) {
+            failures++;
+            System.err.println("FAIL " + name + ": want " + want + " got " + got);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Compressed Telegram Android photos look worse than Google Photos: stock `Bitmap.compress` JPEG q87 (cache q83) plus a 1280px box, then bicubic on a dense panel.

Encode-path only:
- `PhotoCompressPolicy`: chat JPEG **q92**, big cache **q90**, thumbs **q60**, max side still 1280/2560
- `MediaController.rebuildPhoto` and `ImageLoader` cache write use the policy
- JVM test `PhotoCompressPolicyTest` (no Android SDK): failed on 87/83, passed on 92/90

Not in this PR: on-device SR, AVIF, Jpegli, send-as-file.

## Test plan
- [x] `PhotoCompressPolicyTest` in eclipse-temurin:17
- [ ] 100% crop vs Google Photos on a 1440p device
