### PR TITLE
Say whether a country has been chosen

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/boosts/cells/selector/SelectorCountryCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Premium/boosts/cells/selector/SelectorCountryCell.java
@@ -12,6 +12,7 @@ import android.text.TextUtils;
 import android.text.style.ReplacementSpan;
 import android.view.Gravity;
 import android.view.View;
+import android.view.accessibility.AccessibilityNodeInfo;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -120,6 +121,19 @@ public class SelectorCountryCell extends BaseCell {
         } else {
             checkBox.animate().cancel();
             checkBox.setAlpha(alpha);
+        }
+    }
+
+    // the tick beside a country is the whole of what says it is one of the countries chosen, and
+    // it was only drawn: the country read the same whether it had been taken or left, and a press
+    // on it said nothing of which of the two it had just done
+    @Override
+    public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
+        super.onInitializeAccessibilityNodeInfo(info);
+        if (checkBox.getVisibility() == View.VISIBLE) {
+            info.setClassName("android.widget.CheckBox");
+            info.setCheckable(true);
+            info.setChecked(checkBox.isChecked());
         }
     }
 


### PR DESCRIPTION
## Summary

A poll can be held open only to certain countries, and the countries are picked from a list where each one is drawn with a tick beside it. The tick is the whole of what says whether that country is among the ones taken.

None of it reached a screen reader. A country read the same whether it had been taken or left, and a press on one said nothing of which of the two it had just done, so what the poll would end up open to could not be known at all.

Give a country the kind of a check box and the state of one, so the tick is spoken as state in the words of the screen reader and a press on a country is answered.

## Checking it

With TalkBack on, start a poll, turn on holding it open to certain countries, and open the list of them. Swipe through the countries and press some of them.

Before, every country read the same whether it had been taken or left, and a press said nothing at all, so there was no way of knowing what the poll was open to. Now each country reads as a check box with its state, and a press is answered by the state being said again.

The same list is used for choosing the countries of a giveaway, which reads the same way now.
