### PR TITLE
Call the button that offers a post by what it does

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -3780,7 +3780,10 @@ public class ChatActivityEnterView extends FrameLayout implements
             }
             delegate.didPressSuggestionButton();
         });
-        suggestButton.setContentDescription(getString(R.string.AccDescrAttachButton));
+        // this button offers the message as a post rather than sending it, and it was called
+        // what the button beside it is called: a reader was told it attaches media, which is what
+        // the other one does and this one does not
+        suggestButton.setContentDescription(getString(R.string.PostSuggestionsOfferTitle));
     }
 
     private boolean suggestButtonVisible;


### PR DESCRIPTION
## Summary

Writing to a channel that takes suggestions puts a second button beside the box, and pressing it opens what a post is offered with: a price, and when it should be published.

It carried the words of the button next to it, so a screen reader called it attaching media, which is what that other button does and this one never does. Someone going by what is read out would press it to attach a photo and be asked for a price instead.

Call it by the name of what it opens.

## Checking it

With TalkBack on, open the chat for writing to a channel that takes suggested posts, and reach the two buttons beside the box.

Before, both said the same thing, and pressing the second one to attach a photo opened a sheet asking for a price and a time instead. Now the second one is called by the name of what it opens.
