### PR TITLE
Say which one of them has been chosen

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactionsContainerLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactionsContainerLayout.java
@@ -1844,6 +1844,12 @@ public class ReactionsContainerLayout extends FrameLayout implements Notificatio
                     info.setText(LocaleController.getString(R.string.AccDescrCustomEmoji));
                     info.setEnabled(true);
                 }
+                // the one that has been picked - the effect a message is to be sent with, or the
+                // reaction already left on it - is drawn smaller and on a circle of its own, and
+                // that drawing was the whole of what said so. What had been picked read exactly
+                // as what had not, and a press said nothing of what it had just done
+                info.setCheckable(true);
+                info.setChecked(selected);
             }
         }
 


### PR DESCRIPTION
## Summary

The row that offers the effect a message is to be sent with, and the row that offers reactions, both draw the one that has been chosen smaller and on a circle of its own. That drawing was the whole of what said so.

A screen reader read the chosen one exactly as it read every other, and a press said nothing of what it had just done, so an effect could be put on a message with no way of telling which one was on it, or whether one was on it at all.

Give each of them the state of a check box, so which one is chosen is spoken in the words of the screen reader wherever it is come to.

## Checking it

With TalkBack on, write a message, hold the send button, and go along the row of effects. Choose one and come back to it.

Before, the chosen effect read exactly as every other, and a press said nothing, so there was no telling which effect the message would be sent with. Now the chosen one says so, and a press is answered.

The row of reactions on a message reads the same way: the reaction already given is the one that says it is chosen.
