### PR TITLE
Reach the person a channel signs its posts with

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -26573,6 +26573,84 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         return layoutHeight;
     }
 
+    // a channel that signs its posts with the person behind them draws that person's picture
+    // beside every post, and a tap on the picture opens them. The picture is drawn by the cell and
+    // is no view of its own, so touch exploration had nothing to tap: the person was named over
+    // every post and could not be reached from any of them.
+    //
+    // in a group the same picture is held down rather than tapped, and what that opens is a menu
+    // the chat builds. A channel opens no such menu, so what is offered here is the tap itself.
+    private boolean hasSignedPostAuthorAction() {
+        if (!isAvatarVisible || currentMessageObject == null || delegate == null) {
+            return false;
+        }
+        if (currentMessageObject.isSponsored() || currentMessageObject.getDialogId() >= 0) {
+            return false;
+        }
+        final TLRPC.Chat chat = MessagesController.getInstance(currentAccount).getChat(-currentMessageObject.getDialogId());
+        if (!ChatObject.isChannelAndNotMegaGroup(chat) || !chat.signature_profiles) {
+            return false;
+        }
+        // a picture standing for a forward whose sender is hidden opens no one
+        return currentUser != null && currentUser.id != 0 || currentChat != null;
+    }
+
+    // the chat a tap on the picture is answered with. A post forwarded into the channel opens
+    // where it came from; anything else stays with the channel the post was made in
+    private TLRPC.Chat signedPostAuthorTargetChat() {
+        TLRPC.Chat chat = currentChat;
+        if (currentMessageObject != null && currentMessageObject.messageOwner.fwd_from != null
+            && (currentMessageObject.messageOwner.fwd_from.flags & 16) == 0 && currentForwardChannel != null) {
+            chat = currentForwardChannel;
+        }
+        return chat != null ? chat : currentChat;
+    }
+
+    private int signedPostAuthorTargetPostId() {
+        if (currentMessageObject == null || currentMessageObject.messageOwner.fwd_from == null) {
+            return 0;
+        }
+        if ((currentMessageObject.messageOwner.fwd_from.flags & 16) != 0) {
+            return currentMessageObject.messageOwner.fwd_from.saved_from_msg_id;
+        }
+        return currentMessageObject.messageOwner.fwd_from.channel_post;
+    }
+
+    // named by what the tap opens and not by what the picture is drawn in. A channel that signs
+    // its posts keeps itself as the chat of every cell and names the person only in the message,
+    // so a name taken from the cell called opening a person opening a channel.
+    private CharSequence getSignedPostAuthorActionLabel() {
+        if (currentUser != null) {
+            return getString(R.string.OpenProfile);
+        }
+        final TLRPC.Chat target = signedPostAuthorTargetChat();
+        if (target != null && target.signature_profiles && currentMessageObject != null) {
+            final long did = DialogObject.getPeerDialogId(currentMessageObject.messageOwner.from_id);
+            // the channel signing in its own name opens its own page, which is a profile as much
+            // as a person's is
+            if (did > 0 || did == currentMessageObject.getDialogId()) {
+                return getString(R.string.OpenProfile);
+            }
+            if (did < 0) {
+                final TLRPC.Chat signer = MessagesController.getInstance(currentAccount).getChat(-did);
+                return getString(ChatObject.isChannelAndNotMegaGroup(signer) ? R.string.OpenChannel2 : R.string.OpenGroup2);
+            }
+        }
+        return getString(ChatObject.isChannelAndNotMegaGroup(target) ? R.string.OpenChannel2 : R.string.OpenGroup2);
+    }
+
+    // tapped the way the picture is tapped, so that a reader comes to whatever a tap comes to
+    private void performSignedPostAuthorAction() {
+        if (!hasSignedPostAuthorAction()) {
+            return;
+        }
+        if (currentUser != null) {
+            delegate.didPressUserAvatar(this, currentUser, lastTouchX, lastTouchY, false);
+            return;
+        }
+        delegate.didPressChannelAvatar(this, signedPostAuthorTargetChat(), signedPostAuthorTargetPostId(), lastTouchX, lastTouchY, false);
+    }
+
     @Override
     public boolean performAccessibilityAction(int action, Bundle arguments) {
         if (delegate != null && delegate.onAccessibilityAction(action, arguments)) {
@@ -26621,6 +26699,8 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     }
                 }
             }
+        } else if (action == R.id.acc_action_sender_profile) {
+            performSignedPostAuthorAction();
         }
         if (currentMessageObject.isVoice() || currentMessageObject.isRoundVideo() || currentMessageObject.isMusic() && MediaController.getInstance().isPlayingMessage(currentMessageObject)) {
             if (seekBarAccessibilityDelegate.performAccessibilityActionInternal(action, arguments)) {
@@ -27369,6 +27449,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
                 if (drawSummarizeButton || drawSummaryReply) {
                     info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_summarize, getString("SummaryTitle", R.string.SummaryTitle)));
+                }
+                if (hasSignedPostAuthorAction()) {
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(R.id.acc_action_sender_profile, getSignedPostAuthorActionLabel()));
                 }
                 if (currentMessageObject.textLayoutBlocks != null) {
                     for (MessageObject.TextLayoutBlock block : currentMessageObject.textLayoutBlocks) {

--- a/TMessagesProj/src/main/res/values/ids.xml
+++ b/TMessagesProj/src/main/res/values/ids.xml
@@ -31,6 +31,7 @@
     <item name="acc_action_open_forwarded_origin" type="id"/>
     <item name="acc_action_copy_code" type="id"/>
     <item name="acc_action_summarize" type="id"/>
+    <item name="acc_action_sender_profile" type="id"/>
     <item name="shake_animation" type="id"/>
 
     <item name="timeout_callback" type="id"/>


### PR DESCRIPTION
## Summary

A channel can sign each post with the person who wrote it. Their picture is then drawn beside the post and their name over it, and a tap on the picture opens them.

The picture is drawn by the cell and is no view of its own, so touch exploration has nothing there to tap. Where a group draws the same picture it is held down instead, and the menu that opens under it is offered as an action on the message; a channel opens no such menu, because holding a picture opens nothing in a channel at all. So the person was named over every post and there was no way of coming to them. The name is a view of its own below Android 7 and nowhere else, so what is running today had nothing.

Offer the tap as an action on the message, and open by it whatever a tap opens: the profile of the person who signed the post, or the channel that signed it, named as the menu in a group names them.

What the action is called is taken from what the tap opens rather than from the cell it is drawn in. A channel that signs its posts stays the chat of every one of its cells and names the person only inside the message, so a name read off the cell offered to open a channel while what it opened was a person. The post forwarded into such a channel is the one case where the tap really does open a channel, and it says so.

## Checking it

With TalkBack on, open a channel that has "Show authors' profiles" turned on, and reach a post signed by a person.

Before, the person was named over the post and there was no way of coming to them: the picture beside the post cannot be tapped by touch exploration, and holding a picture opens nothing in a channel. Now the message offers opening their profile, and it opens the same profile a tap on the picture opens.

Reach a post that was forwarded into such a channel: the action says it opens a channel, which is what a tap on the picture does there.
