### PR TITLE
Answer a press on a poll, a quiz and a checklist

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -26573,12 +26573,33 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         return layoutHeight;
     }
 
+    // a message that holds nothing to open answers a press with nothing at all: a text message,
+    // and a poll or a checklist, whose answers are pressed on their own and whose card is not.
+    // What a press on the screen does to such a message is hold it, and what holding it opens is
+    // the menu of the message, so that is what a press asks for here. The menu keeps the one
+    // place it is offered by name, which is where a reader looks for it.
+    private boolean pressOpensMessageOptions() {
+        if (currentMessageObject == null || drawVideoImageButton) {
+            return false;
+        }
+        if (currentMessageObject.type != MessageObject.TYPE_TEXT && currentMessageObject.type != MessageObject.TYPE_POLL) {
+            return false;
+        }
+        return getIconForCurrentState() == MediaActionDrawable.ICON_NONE;
+    }
+
     @Override
     public boolean performAccessibilityAction(int action, Bundle arguments) {
         if (delegate != null && delegate.onAccessibilityAction(action, arguments)) {
             return false;
         }
         if (action == AccessibilityNodeInfo.ACTION_CLICK) {
+            if (pressOpensMessageOptions()) {
+                if (delegate != null) {
+                    delegate.didPressOther(this, otherX, otherY);
+                }
+                return true;
+            }
             int icon = getIconForCurrentState();
             if (icon != MediaActionDrawable.ICON_NONE && icon != MediaActionDrawable.ICON_FILE) {
                 didPressButton(true, false);


### PR DESCRIPTION
## Summary

The answers of a poll, a quiz and a checklist are pressed on their own, and the card around them carries nothing to open, so it answered a press with nothing at all: a screen reader is told it can press, presses, and nothing happens. A text message already comes to its menu that way.

What a press on the screen does to such a card is hold it, and what holding opens is the menu of the message. So a press asks for that menu here as well, by the one path, and the menu goes on being offered by name in the place a reader looks for it.

Messages that open something of their own on a press are left as they were.

## Checking it

With TalkBack on, reach the card of a poll, a quiz or a checklist — the message itself, not one of its answers — and press it. Before, the press did nothing at all. Now it opens the menu of the message, which is what holding it on the screen does, and which a text message has always opened this way.

Go through the actions the message offers: the menu is there once, under its own name, as it was before this.

The answers of the poll go on being pressed on their own.

Reach a photo, a video or a voice message: they open and play on a press as they did before.
