### PR TITLE
Say whether a message is here, and say what happens to it

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -1258,6 +1258,10 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     CharSequence accessibilityText;
     private boolean accessibilityTextUnread, accessibilityTextContentUnread;
     private long accessibilityTextFileSize;
+    private boolean accessibilityTextMediaDownloaded;
+    private int accessibilityStateMessageId = Integer.MIN_VALUE;
+    private boolean accessibilityStateDownloaded, accessibilityStateContentUnread, accessibilityStateUnread;
+    private CharSequence accessibilityStateReactions;
     private boolean wasTranscriptionOpen;
     private Path instantLinkArrowPath;
     private Paint instantLinkArrowPaint;
@@ -18063,6 +18067,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
 
     @Override
     public void onSuccessDownload(String fileName) {
+        checkAccessibilityStateChanges();
         if (documentAttachType == DOCUMENT_ATTACH_TYPE_STICKER && currentMessageObject.isDice()) {
             DownloadController.getInstance(currentAccount).removeLoadingFileObserver(this);
             setCurrentDiceValue(true);
@@ -20121,10 +20126,133 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     protected void onDraw(Canvas canvas) {
         drawInternal(canvas);
     }
+    // what a message keeps as a file of its own: a picture, a voice, a video, a round video, a
+    // gif, a piece of music or a file. Everything else it holds is words, and words are here as
+    // soon as the message is
+    private boolean hasAccessibilityDownloadState() {
+        if (currentMessageObject == null || currentMessageObject.isSending() || currentMessageObject.isSendError() || currentMessageObject.isEditing()) {
+            return false;
+        }
+        switch (currentMessageObject.type) {
+            case MessageObject.TYPE_PHOTO:
+            case MessageObject.TYPE_VOICE:
+            case MessageObject.TYPE_VIDEO:
+            case MessageObject.TYPE_ROUND_VIDEO:
+            case MessageObject.TYPE_GIF:
+            case MessageObject.TYPE_FILE:
+            case MessageObject.TYPE_MUSIC:
+                return true;
+        }
+        return false;
+    }
+
+    private boolean isMediaDownloadedForAccessibility() {
+        return currentMessageObject != null && (currentMessageObject.mediaExists || currentMessageObject.attachPathExists);
+    }
+
+    // only the message a screen reader is sitting on is spoken to: anything else would talk over
+    // whatever is being read somewhere else in the chat
+    private boolean isReadOutByAccessibility() {
+        if (!isAccessibilityFocused()) {
+            return false;
+        }
+        final AccessibilityManager am = (AccessibilityManager) getContext().getSystemService(Context.ACCESSIBILITY_SERVICE);
+        return am != null && am.isEnabled() && am.isTouchExplorationEnabled();
+    }
+
+    // a message changes under the reader: the file arrives, a voice is played, a message is seen.
+    // All of it is drawn, and the words a reader is given are only built again the next time the
+    // message is reached, so someone sitting on a message heard none of it and had to leave and
+    // come back to find out. Say the piece that changed, and nothing else.
+    private void checkAccessibilityStateChanges() {
+        if (currentMessageObject == null) {
+            return;
+        }
+        final boolean downloaded = hasAccessibilityDownloadState() && isMediaDownloadedForAccessibility();
+        final boolean contentUnread = currentMessageObject.isContentUnread();
+        final boolean unread = currentMessageObject.isOut() && !currentMessageObject.scheduled && currentMessageObject.isUnread();
+        final CharSequence reactions = saysReactionChanges() ? getReactionsAccessibilityState() : null;
+        final int id = currentMessageObject.getId();
+        // a cell is used again for another message, and what the last one was doing is nothing to
+        // say about this one
+        if (accessibilityStateMessageId != id) {
+            accessibilityStateMessageId = id;
+        } else if (isReadOutByAccessibility()) {
+            final StringBuilder changed = new StringBuilder();
+            if (downloaded && !accessibilityStateDownloaded) {
+                appendAccessibilityStateChange(changed, getString(R.string.AccDescrMediaDownloaded));
+            }
+            if (!contentUnread && accessibilityStateContentUnread) {
+                appendAccessibilityStateChange(changed, getString(R.string.AccDescrMsgPlayed));
+            }
+            if (!unread && accessibilityStateUnread) {
+                appendAccessibilityStateChange(changed, getString(R.string.AccDescrMsgRead));
+            }
+            if (!TextUtils.isEmpty(reactions) && !TextUtils.equals(reactions, accessibilityStateReactions)) {
+                appendAccessibilityStateChange(changed, reactions);
+            }
+            if (changed.length() > 0) {
+                announceForAccessibility(changed);
+            }
+        }
+        accessibilityStateDownloaded = downloaded;
+        accessibilityStateContentUnread = contentUnread;
+        accessibilityStateUnread = unread;
+        accessibilityStateReactions = reactions;
+    }
+
+    private void appendAccessibilityStateChange(StringBuilder sb, CharSequence text) {
+        if (TextUtils.isEmpty(text)) {
+            return;
+        }
+        if (sb.length() > 0) {
+            sb.append(", ");
+        }
+        sb.append(text);
+    }
+
+    // a reaction arriving is something that happens to a message while it sits there, and it is
+    // drawn under it without a word said. In a channel they arrive by the hundred and would talk
+    // over everything else, so this is for the chats where a reaction is one person answering
+    private boolean saysReactionChanges() {
+        if (currentMessageObject == null) {
+            return false;
+        }
+        final long did = currentMessageObject.getDialogId();
+        if (did >= 0) {
+            return true;
+        }
+        return !ChatObject.isChannelAndNotMegaGroup(MessagesController.getInstance(currentAccount).getChat(-did));
+    }
+
+    // the reactions as they now stand, in the form the message itself reads them out in: what is
+    // under the message and how many gave each of them
+    private CharSequence getReactionsAccessibilityState() {
+        if (currentMessageObject == null || currentMessageObject.messageOwner.reactions == null || currentMessageObject.messageOwner.reactions.results == null) {
+            return null;
+        }
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < currentMessageObject.messageOwner.reactions.results.size(); ++i) {
+            final TLRPC.ReactionCount reactionCount = currentMessageObject.messageOwner.reactions.results.get(i);
+            if (reactionCount == null || reactionCount.count <= 0) {
+                continue;
+            }
+            final String emoticon = reactionCount.reaction instanceof TLRPC.TL_reactionEmoji
+                ? ((TLRPC.TL_reactionEmoji) reactionCount.reaction).emoticon
+                : getString(R.string.AccDescrCustomEmoji);
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append(emoticon).append(" ").append(reactionCount.count);
+        }
+        return sb.length() > 0 ? sb : null;
+    }
+
     public void drawInternal(Canvas canvas) {
         if (currentMessageObject == null) {
             return;
         }
+        checkAccessibilityStateChanges();
         if (!wasLayout) {
             onLayout(false, getLeft(), getTop(), getRight(), getBottom());
         }
@@ -27079,7 +27207,8 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 final boolean unread = currentMessageObject != null && currentMessageObject.isOut() && !currentMessageObject.scheduled && currentMessageObject.isUnread();
                 final boolean contentUnread = currentMessageObject != null && currentMessageObject.isContentUnread();
                 final long fileSize = currentMessageObject != null ? currentMessageObject.loadedFileSize : 0;
-                if (accessibilityText == null || accessibilityTextUnread != unread || accessibilityTextContentUnread != contentUnread || accessibilityTextFileSize != fileSize) {
+                final boolean mediaDownloaded = isMediaDownloadedForAccessibility();
+                if (accessibilityText == null || accessibilityTextUnread != unread || accessibilityTextContentUnread != contentUnread || accessibilityTextFileSize != fileSize || accessibilityTextMediaDownloaded != mediaDownloaded) {
                     SpannableStringBuilder sb = new SpannableStringBuilder();
                     if (isChat && currentUser != null && !currentMessageObject.isOut()) {
                         sb.append(UserObject.getUserName(currentUser));
@@ -27214,6 +27343,14 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                             sb.append(AndroidUtilities.formatFileSize(documentAttach.size));
                         }
                     }
+                    // whether what the message holds is already on the phone is drawn as the
+                    // button over it and was never said, though it is what decides what pressing
+                    // the message does. It comes after the length and the size, where the button
+                    // is drawn
+                    if (hasAccessibilityDownloadState()) {
+                        sb.append(", ");
+                        sb.append(getString(isMediaDownloadedForAccessibility() ? R.string.AccDescrMediaDownloaded : R.string.AccDescrMediaNotDownloaded));
+                    }
                     if (currentMessageObject.isVoiceTranscriptionOpen()) {
                         sb.append("\n");
                         sb.append(currentMessageObject.getVoiceTranscription());
@@ -27324,6 +27461,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     accessibilityTextUnread = unread;
                     accessibilityTextContentUnread = contentUnread;
                     accessibilityTextFileSize = fileSize;
+                    accessibilityTextMediaDownloaded = mediaDownloaded;
                 }
 
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5110,6 +5110,8 @@
     <string name="AccDescrMsgSending">Sending</string>
     <string name="AccDescrMsgSendingError">Sending error</string>
     <string name="AccDescrMsgPlayed">Played</string>
+    <string name="AccDescrMediaDownloaded">Downloaded</string>
+    <string name="AccDescrMediaNotDownloaded">Not downloaded</string>
     <string name="AccDescrMsgNotPlayed">Not played</string>
     <string name="AccDescrSearchNext">Next search result</string>
     <string name="AccDescrSearchPrev">Previous search result</string>


### PR DESCRIPTION
## Summary

A message that holds a picture, a voice, a video, a round video, a gif, a piece of music or a file either has that file on the phone or has yet to fetch it. Which of the two it is decides what pressing the message does, and it was drawn as the button over it and said nowhere. So a message read out gave its length and its size and left out the one thing that would have told what pressing it would do. It is said now, after the length and the size, where the button is drawn.

The other half of this is that a message changes while it is being read. The file arrives, a voice is played, a message of ours is seen, someone answers it with a reaction. All of it is drawn, and the words a reader is given are built again only the next time the message is reached, so someone sitting on a message heard none of it: they had to leave and come back to find out that the file they were waiting for had arrived.

Say the pieces that changed, and only those pieces, and only while the message is the one being read: a message the reader is not on says nothing, and a cell that has been given another message to draw says nothing about what the last one was doing.

Reactions are said where a reaction is one person answering, which is to say in a chat with someone and in a group. In a channel they arrive by the hundred and would talk over everything else, so there they are left to the message itself to report when it is next read.

## Checking it

With TalkBack on, reach a video or a file that has not been fetched yet. After its length and its size it now says that it has not been downloaded; before, the one thing that decides what a press does was drawn as the button over it and said nowhere.

Stay on that message and fetch the file. When it arrives, the message says so by itself. Before, the only way to find out was to leave the message and come back to it.

Stay on a message of your own until the other side sees it, and on a voice message of theirs while it is played: each says the piece that changed and nothing more.

In a chat with someone or in a group, stay on a message while somebody answers it with a reaction: the reactions are said as they now stand.

Move to another message and let the first one change: it says nothing, because it is not the message being read.
